### PR TITLE
Add 60 fC offset to energies readout from ToT

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -14,6 +14,7 @@ void configureIt(const edm::ParameterSet& conf,
   constexpr char adcSaturation[]    = "adcSaturation";
   constexpr char tdcNbits[]         = "tdcNbits";
   constexpr char tdcSaturation[]    = "tdcSaturation";
+  constexpr char tdcOnset[]         = "tdcOnset";
   constexpr char toaLSB_ns[]        = "toaLSB_ns";
   
   if( conf.exists(isSiFE) ) {
@@ -34,10 +35,13 @@ void configureIt(const edm::ParameterSet& conf,
   if( conf.exists(tdcNbits) ) {
     uint32_t nBits    = conf.getParameter<uint32_t>(tdcNbits);
     double saturation = conf.getParameter<double>(tdcSaturation);
+    double onset      = conf.getParameter<double>(tdcOnset); // in fC
     float tdcLSB      = saturation/pow(2.,nBits); 
     maker.set_TDCLSB(tdcLSB);
+    maker.set_tdcOnsetfC(onset);
   } else {
     maker.set_TDCLSB(-1.);
+    maker.set_tdcOnsetfC(-1.);
   } 
     
   if( conf.exists(toaLSB_ns) ) {

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -20,6 +20,7 @@ HGCalUncalibRecHit = cms.EDProducer(
         #tdc information
         tdcNbits      = hgceeDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgceeDigitizer.digiCfg.feCfg.tdcSaturation_fC,
+        tdcOnset      = hgceeDigitizer.digiCfg.feCfg.tdcOnset_fC,
         toaLSB_ns     = hgceeDigitizer.digiCfg.feCfg.toaLSB_ns
         ),
     
@@ -31,6 +32,7 @@ HGCalUncalibRecHit = cms.EDProducer(
         #tdc information
         tdcNbits      = hgchefrontDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgchefrontDigitizer.digiCfg.feCfg.tdcSaturation_fC,
+        tdcOnset      = hgchefrontDigitizer.digiCfg.feCfg.tdcOnset_fC,
         toaLSB_ns     = hgchefrontDigitizer.digiCfg.feCfg.toaLSB_ns
         ),
 


### PR DESCRIPTION
This adds the appropriate offset to energies that are read out in ToT mode.

Removes discontinuity in rechit energy spectra.
