### PR TITLE
Implementation of trigger front-end best-choice codec

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
+++ b/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
@@ -51,7 +51,7 @@ namespace l1t {
     template<typename IDTYPE>
     IDTYPE getDetId() const { return IDTYPE(detid_); }
     template<typename IDTYPE>
-    void   setDetId(const IDTYPE& id) { detid_ = id.uint32_t(); }
+    void   setDetId(const IDTYPE& id) { detid_ = id(); }
 
     // encoding and decoding
     unsigned char getWhichCodec() const { return codec_; }

--- a/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
+++ b/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
@@ -51,7 +51,7 @@ namespace l1t {
     template<typename IDTYPE>
     IDTYPE getDetId() const { return IDTYPE(detid_); }
     template<typename IDTYPE>
-    void   setDetId(const IDTYPE& id) { detid_ = id(); }
+    void   setDetId(const IDTYPE& id) { detid_ = id.rawId(); }
 
     // encoding and decoding
     unsigned char getWhichCodec() const { return codec_; }

--- a/DataFormats/L1THGCal/interface/HGCalCluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalCluster.h
@@ -8,6 +8,7 @@ namespace l1t {
   
   class HGCalCluster : public L1Candidate {
     public:
+        // FIXME: remnants of Stage-2 calo trigger to be removed
       enum ClusterFlag{
         INCLUDE_SEED        = 0,
         INCLUDE_NW          = 1,

--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -4,5 +4,6 @@
 <export>
   <lib   name="1"/>
 </export>
+<flags ADD_SUBDIR="1"/>
 
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
@@ -40,6 +40,7 @@ class HGCalTriggerFECodecBase {
   // give the FECodec a module + input digis and it sets itself
   // with the approprate data
   virtual void setDataPayload(const Module& cell, 
+                              const HGCalTriggerGeometryBase& geom,
                               const HGCEEDigiCollection&,
                               const HGCHEDigiCollection&,
                               const HGCHEDigiCollection& ) = 0;
@@ -91,6 +92,7 @@ namespace HGCalTriggerFE {
     }  
     
     virtual void setDataPayload(const Module& mod, 
+                                const HGCalTriggerGeometryBase& geom, 
                                 const HGCEEDigiCollection& ee, 
                                 const HGCHEDigiCollection& fh,
                                 const HGCHEDigiCollection& bh ) override final {
@@ -99,7 +101,7 @@ namespace HGCalTriggerFE {
           << "Data payload was already set for HGCTriggerFECodec: "
           << this->name() << " overwriting current data!";
       }
-      static_cast<Impl&>(*this).setDataPayloadImpl(mod,ee,fh,bh);
+      static_cast<Impl&>(*this).setDataPayloadImpl(mod,geom,ee,fh,bh);
       dataIsSet_ = true;
     }
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
@@ -40,7 +40,6 @@ class HGCalTriggerFECodecBase {
   // give the FECodec a module + input digis and it sets itself
   // with the approprate data
   virtual void setDataPayload(const Module& cell, 
-                              const HGCalTriggerGeometryBase& geom,
                               const HGCEEDigiCollection&,
                               const HGCHEDigiCollection&,
                               const HGCHEDigiCollection& ) = 0;
@@ -92,7 +91,6 @@ namespace HGCalTriggerFE {
     }  
     
     virtual void setDataPayload(const Module& mod, 
-                                const HGCalTriggerGeometryBase& geom, 
                                 const HGCEEDigiCollection& ee, 
                                 const HGCHEDigiCollection& fh,
                                 const HGCHEDigiCollection& bh ) override final {
@@ -101,7 +99,7 @@ namespace HGCalTriggerFE {
           << "Data payload was already set for HGCTriggerFECodec: "
           << this->name() << " overwriting current data!";
       }
-      static_cast<Impl&>(*this).setDataPayloadImpl(mod,geom,ee,fh,bh);
+      static_cast<Impl&>(*this).setDataPayloadImpl(mod,ee,fh,bh);
       dataIsSet_ = true;
     }
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -77,32 +77,45 @@ namespace HGCalTriggerGeometry {
   class Module {
   public:
     typedef std::unordered_set<unsigned> list_type;
+    typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
     
     Module(unsigned mod_id, const GlobalPoint& pos,
-           const list_type& neighbs, const list_type& comps):
+           const list_type& neighbs, const list_type& comps,
+           const tc_map_type& tc_comps):
       module_id_(mod_id),
       position_(pos),
       neighbours_(neighbs),
-      components_(comps)
+      components_(comps),
+      tc_components_(tc_comps)  
       {}
     ~Module() {}
     
     unsigned moduleId()      const { return module_id_; }
 
-    bool containsTriggerCell(const unsigned cell) const {
-      return ( components_.find(cell) != components_.end() );
+    bool containsTriggerCell(const unsigned trig_cell) const {
+      return ( components_.find(trig_cell) != components_.end() );
+    }
+
+    bool containsCell(const unsigned cell) const {
+      for( const auto& value : tc_components_ ) {
+        if( value.second == cell ) return true;
+      }
+      return false;
     }
 
     const GlobalPoint& position() const { return position_; }
 
-    const std::unordered_set<unsigned>& neighbours() const { return neighbours_; }
-    const std::unordered_set<unsigned>& components() const { return components_; }
+    const list_type& neighbours() const { return neighbours_; }
+    const list_type& components() const { return components_; }
+
+    const tc_map_type& triggerCellComponents() const { return tc_components_; }
 
   private:    
     unsigned module_id_; // module this TC belongs to
     GlobalPoint position_;
     list_type neighbours_; // neighbouring Modules
     list_type components_; // contained HGC trigger cells
+    tc_map_type tc_components_; // cells contained by trigger cells
   };
 }  
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -28,6 +28,7 @@ public:
   }
 
   void setDataPayloadImpl(const Module& mod, 
+                          const HGCalTriggerGeometryBase& geom,
                           const HGCEEDigiCollection& ee,
                           const HGCHEDigiCollection& fh,
                           const HGCHEDigiCollection& bh );

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -2,14 +2,9 @@
 #define __L1Trigger_L1THGCal_HGCal64BitRandomCodec_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodecImpl.h"
 #include <limits>
 
-#include "TRandom3.h"
-
-struct HGCal64BitRandomDataPayload { 
-  uint64_t payload;
-  void reset() { memset(&payload,0,sizeof(uint64_t)); }
-};
 
 inline std::ostream& operator<<(std::ostream& o, 
                                 const HGCal64BitRandomDataPayload& data) { 
@@ -22,9 +17,9 @@ public:
   typedef HGCal64BitRandomDataPayload data_type;
   
   HGCal64BitRandomCodec(const edm::ParameterSet& conf) :
-    Codec(conf) {
+    Codec(conf),
+    codecImpl_(conf) {
     data_.payload = std::numeric_limits<uint64_t>::max();
-    rand.SetSeed(0);
   }
 
   void setDataPayloadImpl(const Module& mod, 
@@ -36,7 +31,7 @@ public:
   data_type         decodeImpl(const std::vector<bool>&) const;  
 
 private:
-  TRandom3 rand;
+  HGCal64BitRandomCodecImpl codecImpl_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -28,7 +28,6 @@ public:
   }
 
   void setDataPayloadImpl(const Module& mod, 
-                          const HGCalTriggerGeometryBase& geom,
                           const HGCEEDigiCollection& ee,
                           const HGCHEDigiCollection& fh,
                           const HGCHEDigiCollection& bh );

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodecImpl.h
@@ -1,0 +1,30 @@
+#ifndef __L1Trigger_L1THGCal_HGCal64BitRandomCodecImpl_h__
+#define __L1Trigger_L1THGCal_HGCal64BitRandomCodecImpl_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "TRandom3.h"
+
+struct HGCal64BitRandomDataPayload { 
+  uint64_t payload;
+  void reset() { memset(&payload,0,sizeof(uint64_t)); }
+};
+
+
+class HGCal64BitRandomCodecImpl{
+public:
+  typedef HGCal64BitRandomDataPayload data_type;
+  
+  HGCal64BitRandomCodecImpl(const edm::ParameterSet& conf){
+    rand_.SetSeed(0);
+  }
+  
+  void setDataPayload(data_type&);
+  std::vector<bool> encode(const data_type&) const ;
+  data_type         decode(const std::vector<bool>&) const;  
+
+private:
+  TRandom3 rand_;
+
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -18,15 +18,14 @@
 
 struct HGCalBestChoiceDataPayload
 {
-    typedef std::array< std::pair<uint32_t, HGCEEDetId>, 64 > trigger_cell_list; // list of (data, ID) pairs
+    typedef std::array<uint32_t, 64 > trigger_cell_list; // list of data in 64 trigger cells
     trigger_cell_list payload;
 
     void reset() 
     { 
-        for(auto& value_id : payload)
+        for(auto& value : payload)
         {
-            value_id.first = 0;
-            value_id.second = HGCEEDetId(0);
+            value = 0;
         }
     }
 };
@@ -34,11 +33,11 @@ struct HGCalBestChoiceDataPayload
 
 inline std::ostream& operator<<(std::ostream& o, const HGCalBestChoiceDataPayload& data) 
 { 
-    for(const auto& dat_id : data.payload)
+    for(const auto& dat : data.payload)
     {
-        o <<  dat_id.second << " -> DATA=" << dat_id.first;
-        o << "\n";
+        o <<  dat << " ";
     }
+    o << "\n";
     return o;
 }
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -46,9 +46,7 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
     public:
         typedef HGCalBestChoiceDataPayload data_type;
 
-        HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Codec(conf)
-        {
-        }
+        HGCalBestChoiceCodec(const edm::ParameterSet& conf);
 
         void setDataPayloadImpl(const Module& mod, 
                 const HGCalTriggerGeometryBase& geom,
@@ -62,6 +60,10 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
     private:
         void triggerCellSums(const HGCalTriggerGeometryBase& , const std::vector<HGCEEDataFrame>&);
         void bestChoiceSelect();
+
+        size_t nData_;
+        size_t dataLength_;
+        size_t nCellsInModule_;
 
 };
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -7,15 +7,6 @@
 #include "TRandom3.h"
 
 
-//struct HGCalBestChoiceDataPayload 
-//{ 
-    //std::vector<HGCEEDataFrame> payload;
-    //void reset() 
-    //{ 
-        //payload.clear();
-    //}
-//};
-
 struct HGCalBestChoiceDataPayload
 {
     typedef std::array<uint32_t, 64 > trigger_cell_list; // list of data in 64 trigger cells

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -1,0 +1,69 @@
+#ifndef __L1Trigger_L1THGCal_HGCalBestChoiceCodec_h__
+#define __L1Trigger_L1THGCal_HGCalBestChoiceCodec_h__
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
+#include <limits>
+
+#include "TRandom3.h"
+
+
+//struct HGCalBestChoiceDataPayload 
+//{ 
+    //std::vector<HGCEEDataFrame> payload;
+    //void reset() 
+    //{ 
+        //payload.clear();
+    //}
+//};
+
+struct HGCalBestChoiceDataPayload
+{
+    typedef std::array< std::pair<uint32_t, HGCEEDetId>, 64 > trigger_cell_list; // list of (data, ID) pairs
+    trigger_cell_list payload;
+
+    void reset() 
+    { 
+        for(auto& value_id : payload)
+        {
+            value_id.first = 0;
+            value_id.second = HGCEEDetId(0);
+        }
+    }
+};
+
+
+inline std::ostream& operator<<(std::ostream& o, const HGCalBestChoiceDataPayload& data) 
+{ 
+    for(const auto& dat_id : data.payload)
+    {
+        o <<  dat_id.second << " -> DATA=" << dat_id.first;
+        o << "\n";
+    }
+    return o;
+}
+
+class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,HGCalBestChoiceDataPayload> 
+{
+    public:
+        typedef HGCalBestChoiceDataPayload data_type;
+
+        HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Codec(conf)
+        {
+        }
+
+        void setDataPayloadImpl(const Module& mod, 
+                const HGCalTriggerGeometryBase& geom,
+                const HGCEEDigiCollection& ee,
+                const HGCHEDigiCollection& fh,
+                const HGCHEDigiCollection& bh );
+
+        std::vector<bool> encodeImpl(const data_type&) const ;
+        data_type         decodeImpl(const std::vector<bool>&) const;  
+
+    private:
+        void triggerCellSums(const HGCalTriggerGeometryBase& , const std::vector<HGCEEDataFrame>&);
+        void bestChoiceSelect();
+
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -37,7 +37,6 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
         HGCalBestChoiceCodec(const edm::ParameterSet& conf);
 
         void setDataPayloadImpl(const Module& mod, 
-                const HGCalTriggerGeometryBase& geom,
                 const HGCEEDigiCollection& ee,
                 const HGCHEDigiCollection& fh,
                 const HGCHEDigiCollection& bh );
@@ -46,7 +45,7 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
         data_type         decodeImpl(const std::vector<bool>&) const;  
 
     private:
-        void triggerCellSums(const HGCalTriggerGeometryBase& , const std::vector<HGCEEDataFrame>&);
+        void triggerCellSums(const Module& , const std::vector<HGCEEDataFrame>&);
         void bestChoiceSelect();
 
         size_t nData_;

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -2,21 +2,7 @@
 #define __L1Trigger_L1THGCal_HGCalBestChoiceCodec_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
-#include <limits>
-
-#include "TRandom3.h"
-
-
-struct HGCalBestChoiceDataPayload
-{
-    typedef std::array<uint32_t, 64 > trigger_cell_list; // list of data in 64 trigger cells
-    trigger_cell_list payload;
-
-    void reset() 
-    { 
-        payload.fill(0);
-    }
-};
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h"
 
 
 inline std::ostream& operator<<(std::ostream& o, const HGCalBestChoiceDataPayload& data) 
@@ -28,6 +14,7 @@ inline std::ostream& operator<<(std::ostream& o, const HGCalBestChoiceDataPayloa
     o << "\n";
     return o;
 }
+
 
 class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,HGCalBestChoiceDataPayload> 
 {
@@ -45,13 +32,7 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
         data_type         decodeImpl(const std::vector<bool>&) const;  
 
     private:
-        void triggerCellSums(const Module& , const std::vector<HGCEEDataFrame>&);
-        void bestChoiceSelect();
-
-        size_t nData_;
-        size_t dataLength_;
-        size_t nCellsInModule_;
-
+        HGCalBestChoiceCodecImpl codecImpl_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -14,10 +14,7 @@ struct HGCalBestChoiceDataPayload
 
     void reset() 
     { 
-        for(auto& value : payload)
-        {
-            value = 0;
-        }
+        payload.fill(0);
     }
 };
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
@@ -1,0 +1,47 @@
+#ifndef __L1Trigger_L1THGCal_HGCalBestChoiceCodecImpl_h__
+#define __L1Trigger_L1THGCal_HGCalBestChoiceCodecImpl_h__
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+
+#include <array>
+#include <vector>
+
+
+struct HGCalBestChoiceDataPayload
+{
+    static const size_t size = 64;
+    typedef std::array<uint32_t, size> trigger_cell_list; // list of data in 64 trigger cells
+    trigger_cell_list payload;
+
+    void reset() 
+    { 
+        payload.fill(0);
+    }
+};
+
+
+
+class HGCalBestChoiceCodecImpl
+{
+    public:
+        typedef HGCalBestChoiceDataPayload data_type;
+
+        HGCalBestChoiceCodecImpl(const edm::ParameterSet& conf);
+
+        std::vector<bool> encode(const data_type&) const ;
+        data_type         decode(const std::vector<bool>&) const;  
+
+        void triggerCellSums(const HGCalTriggerGeometry::Module& , const std::vector<HGCEEDataFrame>&, data_type&);
+        void bestChoiceSelect(data_type&);
+
+    private:
+        size_t nData_;
+        size_t dataLength_;
+        size_t nCellsInModule_;
+
+};
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
@@ -104,6 +105,7 @@ void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es)
     l1t::HGCFETriggerDigi& digi = fe_output->back();
     codec_->setDataPayload(*(module.second),*(triggerGeometry_),ee_digis,fh_digis,bh_digis);
     codec_->encode(digi);
+    digi.setDetId( HGCTriggerDetId(module.first) );
     std::stringstream output;
     codec_->print(digi,output);
     edm::LogInfo("HGCalTriggerDigiProducer")

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -102,7 +102,7 @@ void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es)
   for( const auto& module : triggerGeometry_->modules() ) {    
     fe_output->push_back(l1t::HGCFETriggerDigi());
     l1t::HGCFETriggerDigi& digi = fe_output->back();
-    codec_->setDataPayload(*(module.second),ee_digis,fh_digis,bh_digis);
+    codec_->setDataPayload(*(module.second),*(triggerGeometry_),ee_digis,fh_digis,bh_digis);
     codec_->encode(digi);
     std::stringstream output;
     codec_->print(digi,output);

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -103,7 +103,7 @@ void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es)
   for( const auto& module : triggerGeometry_->modules() ) {    
     fe_output->push_back(l1t::HGCFETriggerDigi());
     l1t::HGCFETriggerDigi& digi = fe_output->back();
-    codec_->setDataPayload(*(module.second),*(triggerGeometry_),ee_digis,fh_digis,bh_digis);
+    codec_->setDataPayload(*(module.second),ee_digis,fh_digis,bh_digis);
     codec_->encode(digi);
     digi.setDetId( HGCTriggerDetId(module.first) );
     std::stringstream output;

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
@@ -51,23 +51,10 @@ void FullModuleSumAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
 
         // Sum of trigger cells inside the module
         uint32_t moduleSum = 0;
-        //unsigned nCells = 0;
         for(const auto& value : data.payload)
         {
-            //if(value>0) nCells++;
             moduleSum += value;
         }
-        //if(nCells>6)
-        //{
-            //std::cout<<"Module Sum = "<<moduleSum<<"\n";
-            //for(const auto& value : data.payload)
-            //{
-                //if(value>0) std::cout<<value<<"+";
-            //}
-            //std::cout<<"\n";
-        //}
-
-
         // dummy cluster without position
         // moduleId filled in place of hardware eta
         l1t::HGCalCluster cluster( reco::LeafCandidate::LorentzVector(), 

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
@@ -1,0 +1,82 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h"
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+
+using namespace HGCalTriggerBackend;
+
+class FullModuleSumAlgo : public Algorithm<HGCalBestChoiceCodec> 
+{
+    public:
+
+        FullModuleSumAlgo(const edm::ParameterSet& conf):
+            Algorithm<HGCalBestChoiceCodec>(conf),
+            cluster_product( new l1t::HGCalClusterBxCollection ){}
+
+        virtual void setProduces(edm::EDProducer& prod) const override final 
+        {
+            prod.produces<l1t::HGCalClusterBxCollection>(name());
+        }
+
+        virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
+                const std::unique_ptr<HGCalTriggerGeometryBase>& geom) override final;
+
+        virtual void putInEvent(edm::Event& evt) override final 
+        {
+            evt.put(cluster_product,name());
+        }
+
+        virtual void reset() override final 
+        {
+            cluster_product.reset( new l1t::HGCalClusterBxCollection );
+        }
+
+    private:
+        std::auto_ptr<l1t::HGCalClusterBxCollection> cluster_product;
+
+};
+
+/*****************************************************************/
+void FullModuleSumAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
+        const std::unique_ptr<HGCalTriggerGeometryBase>& geom) 
+/*****************************************************************/
+{
+    for( const auto& digi : coll ) 
+    {
+        HGCalBestChoiceCodec::data_type data;
+        data.reset();
+        const HGCTriggerDetId& moduleId = digi.getDetId<HGCTriggerDetId>();
+        digi.decode(codec_, data);
+
+        // Sum of trigger cells inside the module
+        uint32_t moduleSum = 0;
+        //unsigned nCells = 0;
+        for(const auto& value : data.payload)
+        {
+            //if(value>0) nCells++;
+            moduleSum += value;
+        }
+        //if(nCells>6)
+        //{
+            //std::cout<<"Module Sum = "<<moduleSum<<"\n";
+            //for(const auto& value : data.payload)
+            //{
+                //if(value>0) std::cout<<value<<"+";
+            //}
+            //std::cout<<"\n";
+        //}
+
+
+        // dummy cluster without position
+        // moduleId filled in place of hardware eta
+        l1t::HGCalCluster cluster( reco::LeafCandidate::LorentzVector(), 
+                moduleSum, moduleId, 0);
+
+        cluster_product->push_back(0,cluster);
+    }
+}
+
+DEFINE_EDM_PLUGIN(HGCalTriggerBackendAlgorithmFactory, 
+        FullModuleSumAlgo,
+        "FullModuleSumAlgo");

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
@@ -11,6 +11,7 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
 
 void HGCal64BitRandomCodec::
 setDataPayloadImpl(const Module& , 
+                   const HGCalTriggerGeometryBase& ,
                    const HGCEEDigiCollection&,
                    const HGCHEDigiCollection&,
                    const HGCHEDigiCollection& ) {

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
@@ -11,7 +11,6 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
 
 void HGCal64BitRandomCodec::
 setDataPayloadImpl(const Module& , 
-                   const HGCalTriggerGeometryBase& ,
                    const HGCEEDigiCollection&,
                    const HGCHEDigiCollection&,
                    const HGCHEDigiCollection& ) {

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
@@ -1,7 +1,4 @@
 #include "L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h"
-#include <limits>
-
-#include "TRandom3.h"
 
 using namespace HGCalTriggerFE;
 
@@ -14,37 +11,19 @@ setDataPayloadImpl(const Module& ,
                    const HGCEEDigiCollection&,
                    const HGCHEDigiCollection&,
                    const HGCHEDigiCollection& ) {
-  data_.payload = 0;
-  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
-    data_.payload |= static_cast<uint64_t>(rand.Rndm() > 0.5) << i;
-  }
+  codecImpl_.setDataPayload(data_);
 }
 
 std::vector<bool>
 HGCal64BitRandomCodec::
 encodeImpl(const HGCal64BitRandomCodec::data_type& data) const {
-  std::vector<bool> result;
-  result.resize(8*sizeof(data_type));
-  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
-    result[i] = static_cast<bool>((data.payload >> i) & 0x1);
-  }
-  return result;
+  return codecImpl_.encode(data);
 }
 
 HGCal64BitRandomCodec::data_type
 HGCal64BitRandomCodec::
 decodeImpl(const std::vector<bool>& data) const {
-  data_type result;
-  result.payload = 0;
-  if( data.size() > 8*sizeof(data_type) ) {
-    edm::LogWarning("HGCal64BitRandomCodec|TruncateInput")
-          << "Input to be encoded was larger than data size: "
-          << sizeof(data_type) << ". Truncating to fit!";
-  }  
-  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
-    result.payload |= static_cast<uint64_t>(data[i]) << i;
-  }
-  return result;
+  return codecImpl_.decode(data);
 }
 
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -87,6 +87,44 @@ HGCalBestChoiceCodec::data_type HGCalBestChoiceCodec::decodeImpl(const std::vect
 {
     data_type result;
     result.reset();
+    // FIXME: the number of best cells and value bits should be given in parameters
+    if(data.size()!=64+8*12)
+    {
+        edm::LogWarning("HGCalBestChoiceCodec") 
+            << "decode: data length ("<<data.size()<<") inconsistent with codec parameters:\n"\
+            << "      : Map size = 64\n"\
+            << "      : Number of energy values = 12\n"\
+            << "      : Energy value length = 8\n";
+        return result;
+    }
+    size_t c = 0;
+    for(size_t b=0; b<64; b++)
+    {
+        if(data[b])
+        {
+            uint32_t value = 0;
+            for(size_t i=0;i<8;i++)
+            {
+                size_t index = 64+c*8+i; 
+                if(data[index]) value |= (0x1<<i);
+            }
+            c++;
+            result.payload[b] = value;
+        }
+    }
+    //unsigned nCells = 0;
+    //for(const auto& value : data_.payload)
+    //{
+        //if(value>0) nCells++;
+    //}
+    //if(nCells>6)
+    //{
+        //std::cout<<"Data after decoding\n";
+        //for(size_t i=0; i<data_.payload.size(); i++)
+        //{
+            //std::cout<<"  "<<i+1<<" -> "<<data_.payload.at(i)<<"\n";
+        //}
+    //}
     return result;
 }
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -94,7 +94,6 @@ HGCalBestChoiceCodec::data_type HGCalBestChoiceCodec::decodeImpl(const std::vect
 {
     data_type result;
     result.reset();
-    // FIXME: the number of best cells and value bits should be given in parameters
     if(data.size()!=nCellsInModule_+dataLength_*nData_)
     {
         edm::LogWarning("HGCalBestChoiceCodec") 
@@ -217,7 +216,6 @@ void HGCalBestChoiceCodec::bestChoiceSelect()
             } 
             );
     // keep only the 12 first trigger cells
-    // FIXME: the number of best cells should be given in parameters
     for(size_t i=nData_; i<nCellsInModule_; i++)
     {
         sortedtriggercells.at(i).first = 0;

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -77,22 +77,22 @@ std::vector<bool> HGCalBestChoiceCodec::encodeImpl(const HGCalBestChoiceCodec::d
             idata++;
         }
     }
-    unsigned nb = 0;
-    for(unsigned i=0;i<64;i++)
-    {
-        if(result[i]) nb++;
-    }
-    if(nb>6)
-    {
-        for(unsigned i=0;i<nCells;i++) std::cout<<result[i];
-        std::cout<<"|";
-        for(unsigned itc=0;itc<nData;itc++)
-        {
-            for(unsigned i=nCells+itc*dataLength;i<nCells+(itc+1)*dataLength;i++) std::cout<<result[i];
-            std::cout<<"|";
-        }
-        std::cout<<"\n";
-    }
+    //unsigned nb = 0;
+    //for(unsigned i=0;i<64;i++)
+    //{
+        //if(result[i]) nb++;
+    //}
+    //if(nb>6)
+    //{
+        //for(unsigned i=0;i<nCells;i++) std::cout<<result[i];
+        //std::cout<<"|";
+        //for(unsigned itc=0;itc<nData;itc++)
+        //{
+            //for(unsigned i=nCells+itc*dataLength;i<nCells+(itc+1)*dataLength;i++) std::cout<<result[i];
+            //std::cout<<"|";
+        //}
+        //std::cout<<"\n";
+    //}
     return result;
 }
 
@@ -140,6 +140,19 @@ void HGCalBestChoiceCodec::triggerCellSums(const HGCalTriggerGeometryBase& geom,
             }
         }
     }
+    unsigned nCells = 0;
+    for(const auto& value_id : data_.payload)
+    {
+        if(value_id.first>0) nCells++;
+    }
+    //if(nCells>6)
+    //{
+        //std::cout<<"Trigger cells in module before selection \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
+        //for(const auto& value_id : data_.payload)
+        //{
+            //std::cout<<"  "<<value_id.second.cell()<<" -> "<<value_id.first<<"\n";//<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
+        //}
+    //}
     //if(data_.payload.size()>0) std::cout<<data_.payload.size()<<" Trigger cells before selection:\n";
     //for(const auto& id_value : data_.payload)
     //{
@@ -183,19 +196,19 @@ void HGCalBestChoiceCodec::bestChoiceSelect()
         }
     }
     //data_.payload.resize(std::min(data_.payload.size(),size_t(12)));
-    unsigned nCells = 0;
-    for(const auto& value_id : data_.payload)
-    {
-        if(value_id.first>0) nCells++;
-    }
-    if(nCells>6)
-    {
-        std::cout<<"Trigger cells in module \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
-        for(const auto& value_id : data_.payload)
-        {
-            std::cout<<"  "<<value_id.second<<" -> "<<value_id.first<<" "<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
-        }
-    }
+    //unsigned nCells = 0;
+    //for(const auto& value_id : data_.payload)
+    //{
+        //if(value_id.first>0) nCells++;
+    //}
+    //if(nCells>6)
+    //{
+        //std::cout<<"Trigger cells in module \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
+        //for(const auto& value_id : data_.payload)
+        //{
+            //std::cout<<"  "<<value_id.second.cell()<<" -> "<<value_id.first<<"\n";//<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
+        //}
+    //}
     // refill the data payload
     //data_.reset();
     //for(const auto& value_id : sortedtriggercells)

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
 #include <limits>
 
 using namespace HGCalTriggerFE;
@@ -26,24 +27,6 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
             dataframes.push_back(eedata);
         }
     }
-    // initialize data payload with trigger cell DetIds contained in the module
-    std::set<HGCEEDetId> triggerCellsInModule;
-    for(const auto& triggercell : mod.components())
-    {
-        triggerCellsInModule.insert( HGCEEDetId(triggercell) );
-    }
-    //triggerCellsInModule.sort();
-    unsigned index = 0;
-    for(const auto& triggercell : triggerCellsInModule)
-    {
-        if(index>data_.payload.size()) 
-        {
-            edm::LogWarning("HGCalBestChoiceCodec") 
-                << "Number of trigger cells in module too large for available data payload\n";
-        }
-        data_.payload.at(index).second = triggercell;
-        index++; 
-    }
 
     // sum energy in trigger cells
     triggerCellSums(geom, dataframes);
@@ -64,12 +47,14 @@ std::vector<bool> HGCalBestChoiceCodec::encodeImpl(const HGCalBestChoiceCodec::d
     unsigned idata = 0;
     for(unsigned itc=0; itc<nCells; itc++)
     {
-        uint32_t value = data.payload.at(itc).first;
+        uint32_t value = data.payload.at(itc);
         result[itc] = (value>0 ? 1 : 0);
         if(value>0)
         {
-            // truncate 12 bits to 8 bits by keeping bits 10----3 + saturation
-            if(value>=1024) value=1023; // 10 bit saturation
+            // FIXME: a proper coding is needed here. Needs studies.
+            // truncate to 8 bits by keeping bits 10----3. 
+            // Values > 0x3FF are saturated to 0x3FF
+            if(value>0x3FF) value=0x3FF; // 10 bit saturation
             for(unsigned i=0; i<dataLength; i++)
             {
                 result[nCells + idata*dataLength + i] = static_cast<bool>(value & (0x1<<(i+2)));// remove the two lowest bits
@@ -115,15 +100,16 @@ void HGCalBestChoiceCodec::triggerCellSums(const HGCalTriggerGeometryBase& geom,
         //std::cout<<">>>>\n";
         //std::cout<<dataframes.size()<<" Cells:\n";
     //}
-    std::map<HGCEEDetId, uint32_t> payload;
+    std::map<HGCTriggerDetId, uint32_t> payload;
     // sum energies in trigger cells
     for(const auto& frame : dataframes)
     {
+        // FIXME: only EE
         HGCEEDetId cellid(frame.id());
-        HGCEEDetId triggercellid( geom.getTriggerCellFromCell(cellid)->triggerCellId() );
+        HGCTriggerDetId triggercellid( geom.getTriggerCellFromCell(cellid)->triggerCellId() );
         payload.insert( std::make_pair(triggercellid, 0) ); // do nothing if key exists already
-        // FIXME: need to check how the cell energy can be retrieved
-        uint32_t data = frame[2].data(); // This is 12 bit data
+        // FIXME: need to transform ADC and TDC to the same linear scale on 12 bits
+        uint32_t data = frame[2].data(); // 'data' has to be a 12 bit word
         //std::cout<<" "<<cellid<<" ("<<triggercellid<<") = "<<data<<"\n";
         payload[triggercellid] += data; // 32 bits integer should be largely enough (maximum 7 12-bits sums are done)
 
@@ -131,26 +117,26 @@ void HGCalBestChoiceCodec::triggerCellSums(const HGCalTriggerGeometryBase& geom,
     // fill data payload
     for(const auto& id_value : payload)
     {
-        for(auto& value_id : data_.payload)
+        uint32_t id = id_value.first.cell();
+        if(static_cast<unsigned>(id>data_.payload.size())) // cell number starts at 1
         {
-            if(id_value.first==value_id.second)
-            {
-                value_id.first = id_value.second;
-                break;
-            }
+            edm::LogWarning("HGCalBestChoiceCodec") 
+                << "Number of trigger cells in module too large for available data payload\n";
+            continue;
         }
+        data_.payload.at(id-1) = id_value.second;
     }
-    unsigned nCells = 0;
-    for(const auto& value_id : data_.payload)
-    {
-        if(value_id.first>0) nCells++;
-    }
+    //unsigned nCells = 0;
+    //for(const auto& value : data_.payload)
+    //{
+        //if(value>0) nCells++;
+    //}
     //if(nCells>6)
     //{
-        //std::cout<<"Trigger cells in module before selection \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
-        //for(const auto& value_id : data_.payload)
+        //std::cout<<"Data before best choice\n";
+        //for(size_t i=0; i<data_.payload.size(); i++)
         //{
-            //std::cout<<"  "<<value_id.second.cell()<<" -> "<<value_id.first<<"\n";//<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
+            //std::cout<<"  "<<i+1<<" -> "<<data_.payload.at(i)<<"\n";
         //}
     //}
     //if(data_.payload.size()>0) std::cout<<data_.payload.size()<<" Trigger cells before selection:\n";
@@ -170,55 +156,48 @@ void HGCalBestChoiceCodec::bestChoiceSelect()
     // Probably not the most efficient way.
     // Should check in the firmware how cells with the same energy are sorted
 
-    HGCalBestChoiceDataPayload::trigger_cell_list sortedtriggercells(data_.payload); // copy for sorting
+    //HGCalBestChoiceDataPayload::trigger_cell_list sortedtriggercells(data_.payload); // copy for sorting
+    std::vector< std::pair<uint32_t, uint32_t> > sortedtriggercells; // value, ID
+    sortedtriggercells.reserve(data_.payload.size());
+    for(size_t i=0; i<data_.payload.size(); i++)
+    {
+        sortedtriggercells.push_back(std::make_pair(data_.payload[i], i));
+    }
     // sort, reverse order
     sort(sortedtriggercells.begin(), sortedtriggercells.end(),
-            [](const HGCalBestChoiceDataPayload::trigger_cell_list::value_type& a, 
-                const  HGCalBestChoiceDataPayload::trigger_cell_list::value_type& b) -> bool
+            [](const std::pair<uint32_t, uint32_t>& a, 
+                const  std::pair<uint32_t, uint32_t>& b) -> bool
             { 
                 return a > b; 
             } 
             );
     // keep only the 12 first trigger cells
+    // FIXME: the number of best cells should be given in parameters
     for(size_t i=12; i<sortedtriggercells.size(); i++)
     {
         sortedtriggercells.at(i).first = 0;
     }
-    for(auto& value_id : data_.payload)
+    for(const auto& value_id : sortedtriggercells)
     {
-        for(const auto& value_id_sort : sortedtriggercells)
+        if(static_cast<unsigned>(value_id.second>data_.payload.size())) // cell number starts at 1
         {
-            if(value_id.second==value_id_sort.second)
-            {
-                value_id.first = value_id_sort.first;
-                break;
-            }
+            edm::LogWarning("HGCalBestChoiceCodec") 
+                << "Number of trigger cells in module too large for available data payload\n";
         }
+        data_.payload.at(value_id.second) = value_id.first;
     }
-    //data_.payload.resize(std::min(data_.payload.size(),size_t(12)));
     //unsigned nCells = 0;
-    //for(const auto& value_id : data_.payload)
+    //for(const auto& value : data_.payload)
     //{
-        //if(value_id.first>0) nCells++;
+        //if(value>0) nCells++;
     //}
     //if(nCells>6)
     //{
-        //std::cout<<"Trigger cells in module \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
-        //for(const auto& value_id : data_.payload)
+        //std::cout<<"Data after best choice\n";
+        //for(size_t i=0; i<data_.payload.size(); i++)
         //{
-            //std::cout<<"  "<<value_id.second.cell()<<" -> "<<value_id.first<<"\n";//<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
+            //std::cout<<"  "<<i+1<<" -> "<<data_.payload.at(i)<<"\n";
         //}
-    //}
-    // refill the data payload
-    //data_.reset();
-    //for(const auto& value_id : sortedtriggercells)
-    //{
-        //data_.payload.insert( std::make_pair(value_id.second, value_id.first) );
-    //}
-    //if(data_.payload.size()>0) std::cout<<data_.payload.size()<<" Trigger cells after selection:\n";
-    //for(const auto& id_value : data_.payload)
-    //{
-        //std::cout<<"  "<<id_value.first<<" = "<<id_value.second<<"\n";
     //}
 }
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -1,0 +1,212 @@
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+#include <limits>
+
+using namespace HGCalTriggerFE;
+
+DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory, 
+        HGCalBestChoiceCodec,
+        "HGCalBestChoiceCodec");
+
+/*****************************************************************/
+void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod, 
+        const HGCalTriggerGeometryBase& geom,
+        const HGCEEDigiCollection& ee,
+        const HGCHEDigiCollection&,
+        const HGCHEDigiCollection& ) 
+/*****************************************************************/
+{
+    data_.reset();
+    std::vector<HGCEEDataFrame> dataframes;
+    // loop over EE digis and fill digis belonging to that module
+    for(const auto& eedata : ee)
+    {
+        //std::cout<<" Cell "<<eedata.id()<<" Module "<<geom.getModuleFromCell(eedata.id())->moduleId()<<"\n";
+        if(geom.getModuleFromCell(eedata.id())->moduleId()==mod.moduleId())
+        {
+            dataframes.push_back(eedata);
+        }
+    }
+    // initialize data payload with trigger cell DetIds contained in the module
+    std::set<HGCEEDetId> triggerCellsInModule;
+    for(const auto& triggercell : mod.components())
+    {
+        triggerCellsInModule.insert( HGCEEDetId(triggercell) );
+    }
+    //triggerCellsInModule.sort();
+    unsigned index = 0;
+    for(const auto& triggercell : triggerCellsInModule)
+    {
+        if(index>data_.payload.size()) 
+        {
+            edm::LogWarning("HGCalBestChoiceCodec") 
+                << "Number of trigger cells in module too large for available data payload\n";
+        }
+        data_.payload.at(index).second = triggercell;
+        index++; 
+    }
+
+    // sum energy in trigger cells
+    triggerCellSums(geom, dataframes);
+    // choose best trigger cells in the module
+    bestChoiceSelect();
+
+}
+
+
+/*****************************************************************/
+std::vector<bool> HGCalBestChoiceCodec::encodeImpl(const HGCalBestChoiceCodec::data_type& data) const 
+/*****************************************************************/
+{
+    unsigned dataLength = 8;
+    unsigned nData = 12;
+    unsigned nCells = data.payload.size();
+    std::vector<bool> result(nCells + dataLength*nData);
+    unsigned idata = 0;
+    for(unsigned itc=0; itc<nCells; itc++)
+    {
+        uint32_t value = data.payload.at(itc).first;
+        result[itc] = (value>0 ? 1 : 0);
+        if(value>0)
+        {
+            // truncate 12 bits to 8 bits by keeping bits 10----3 + saturation
+            if(value>=1024) value=1023; // 10 bit saturation
+            for(unsigned i=0; i<dataLength; i++)
+            {
+                result[nCells + idata*dataLength + i] = static_cast<bool>(value & (0x1<<(i+2)));// remove the two lowest bits
+            }
+            idata++;
+        }
+    }
+    unsigned nb = 0;
+    for(unsigned i=0;i<64;i++)
+    {
+        if(result[i]) nb++;
+    }
+    if(nb>6)
+    {
+        for(unsigned i=0;i<nCells;i++) std::cout<<result[i];
+        std::cout<<"|";
+        for(unsigned itc=0;itc<nData;itc++)
+        {
+            for(unsigned i=nCells+itc*dataLength;i<nCells+(itc+1)*dataLength;i++) std::cout<<result[i];
+            std::cout<<"|";
+        }
+        std::cout<<"\n";
+    }
+    return result;
+}
+
+/*****************************************************************/
+HGCalBestChoiceCodec::data_type HGCalBestChoiceCodec::decodeImpl(const std::vector<bool>& data) const 
+/*****************************************************************/
+{
+    data_type result;
+    result.reset();
+    return result;
+}
+
+
+/*****************************************************************/
+void HGCalBestChoiceCodec::triggerCellSums(const HGCalTriggerGeometryBase& geom, const std::vector<HGCEEDataFrame>& dataframes)
+/*****************************************************************/
+{
+    //if(dataframes.size()>0)
+    //{
+        //std::cout<<">>>>\n";
+        //std::cout<<dataframes.size()<<" Cells:\n";
+    //}
+    std::map<HGCEEDetId, uint32_t> payload;
+    // sum energies in trigger cells
+    for(const auto& frame : dataframes)
+    {
+        HGCEEDetId cellid(frame.id());
+        HGCEEDetId triggercellid( geom.getTriggerCellFromCell(cellid)->triggerCellId() );
+        payload.insert( std::make_pair(triggercellid, 0) ); // do nothing if key exists already
+        // FIXME: need to check how the cell energy can be retrieved
+        uint32_t data = frame[2].data(); // This is 12 bit data
+        //std::cout<<" "<<cellid<<" ("<<triggercellid<<") = "<<data<<"\n";
+        payload[triggercellid] += data; // 32 bits integer should be largely enough (maximum 7 12-bits sums are done)
+
+    }
+    // fill data payload
+    for(const auto& id_value : payload)
+    {
+        for(auto& value_id : data_.payload)
+        {
+            if(id_value.first==value_id.second)
+            {
+                value_id.first = id_value.second;
+                break;
+            }
+        }
+    }
+    //if(data_.payload.size()>0) std::cout<<data_.payload.size()<<" Trigger cells before selection:\n";
+    //for(const auto& id_value : data_.payload)
+    //{
+        //std::cout<<"  "<<id_value.first<<" = "<<id_value.second<<"\n";
+    //}
+}
+
+
+/*****************************************************************/
+void HGCalBestChoiceCodec::bestChoiceSelect()
+/*****************************************************************/
+{
+    // Store data payload in vector for energy sorting. Then refill the data payload after trigger
+    // cell selection.
+    // Probably not the most efficient way.
+    // Should check in the firmware how cells with the same energy are sorted
+
+    HGCalBestChoiceDataPayload::trigger_cell_list sortedtriggercells(data_.payload); // copy for sorting
+    // sort, reverse order
+    sort(sortedtriggercells.begin(), sortedtriggercells.end(),
+            [](const HGCalBestChoiceDataPayload::trigger_cell_list::value_type& a, 
+                const  HGCalBestChoiceDataPayload::trigger_cell_list::value_type& b) -> bool
+            { 
+                return a > b; 
+            } 
+            );
+    // keep only the 12 first trigger cells
+    for(size_t i=12; i<sortedtriggercells.size(); i++)
+    {
+        sortedtriggercells.at(i).first = 0;
+    }
+    for(auto& value_id : data_.payload)
+    {
+        for(const auto& value_id_sort : sortedtriggercells)
+        {
+            if(value_id.second==value_id_sort.second)
+            {
+                value_id.first = value_id_sort.first;
+                break;
+            }
+        }
+    }
+    //data_.payload.resize(std::min(data_.payload.size(),size_t(12)));
+    unsigned nCells = 0;
+    for(const auto& value_id : data_.payload)
+    {
+        if(value_id.first>0) nCells++;
+    }
+    if(nCells>6)
+    {
+        std::cout<<"Trigger cells in module \n";//<<HGCEEDetId(mod.moduleId())<<" : "<<data_.payload.size()<<"\n";
+        for(const auto& value_id : data_.payload)
+        {
+            std::cout<<"  "<<value_id.second<<" -> "<<value_id.first<<" "<<(value_id.second==HGCEEDetId(0) ? "not valid" : "valid")<<"\n";
+        }
+    }
+    // refill the data payload
+    //data_.reset();
+    //for(const auto& value_id : sortedtriggercells)
+    //{
+        //data_.payload.insert( std::make_pair(value_id.second, value_id.first) );
+    //}
+    //if(data_.payload.size()>0) std::cout<<data_.payload.size()<<" Trigger cells after selection:\n";
+    //for(const auto& id_value : data_.payload)
+    //{
+        //std::cout<<"  "<<id_value.first<<" = "<<id_value.second<<"\n";
+    //}
+}
+
+

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -10,9 +10,7 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
 
 /*****************************************************************/
 HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Codec(conf),
-    nData_(conf.getParameter<uint32_t>("NData")),
-    dataLength_(conf.getParameter<uint32_t>("DataLength")),
-    nCellsInModule_(data_.payload.size())
+    codecImpl_(conf)
 /*****************************************************************/
 {
 }
@@ -36,9 +34,9 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
         }
     }
     // sum energy in trigger cells
-    triggerCellSums(mod, dataframes);
+    codecImpl_.triggerCellSums(mod, dataframes, data_);
     // choose best trigger cells in the module
-    bestChoiceSelect();
+    codecImpl_.bestChoiceSelect(data_);
 
 }
 
@@ -47,151 +45,14 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
 std::vector<bool> HGCalBestChoiceCodec::encodeImpl(const HGCalBestChoiceCodec::data_type& data) const 
 /*****************************************************************/
 {
-    // First nCellsInModule_ bits are encoding the map of selected trigger cells
-    // Followed by nData_ words of dataLength_ bits, corresponding to energy/transverse energy of
-    // the selected trigger cells
-    std::vector<bool> result(nCellsInModule_ + dataLength_*nData_);
-    size_t idata = 0;
-    for(size_t itc=0; itc<nCellsInModule_; itc++)
-    {
-        uint32_t value = data.payload.at(itc);
-        result[itc] = (value>0 ? 1 : 0);
-        if(value>0)
-        {
-            // FIXME: a proper coding is needed here. Needs studies.
-            // For the moment truncate to 8 bits by keeping bits 10----3. 
-            // Values > 0x3FF are saturated to 0x3FF
-            if(value>0x3FF) value=0x3FF; // 10 bit saturation
-            for(size_t i=0; i<dataLength_; i++)
-            {
-                result[nCellsInModule_ + idata*dataLength_ + i] = static_cast<bool>(value & (0x1<<(i+2)));// remove the two lowest bits
-            }
-            idata++;
-        }
-    }
-    return result;
+    return codecImpl_.encode(data);
 }
 
 /*****************************************************************/
 HGCalBestChoiceCodec::data_type HGCalBestChoiceCodec::decodeImpl(const std::vector<bool>& data) const 
 /*****************************************************************/
 {
-    data_type result;
-    result.reset();
-    if(data.size()!=nCellsInModule_+dataLength_*nData_)
-    {
-        throw cms::Exception("BadData") 
-            << "decode: data length ("<<data.size()<<") inconsistent with codec parameters:\n"\
-            << "      : Map size = "<<nCellsInModule_<<"\n"\
-            << "      : Number of energy values = "<<nData_<<"\n"\
-            << "      : Energy value length = "<<dataLength_<<"\n";
-        return result;
-    }
-    size_t c = 0;
-    for(size_t b=0; b<nCellsInModule_; b++)
-    {
-        if(data[b])
-        {
-            uint32_t value = 0;
-            for(size_t i=0;i<dataLength_;i++)
-            {
-                size_t index = nCellsInModule_+c*dataLength_+i; 
-                if(data[index]) value |= (0x1<<i);
-            }
-            c++;
-            result.payload[b] = value;
-        }
-    }
-    return result;
-}
-
-
-/*****************************************************************/
-void HGCalBestChoiceCodec::triggerCellSums(const Module& mod, const std::vector<HGCEEDataFrame>& dataframes)
-/*****************************************************************/
-{
-    std::map<HGCTriggerDetId, uint32_t> payload;
-    // sum energies in trigger cells
-    for(const auto& frame : dataframes)
-    {
-        // FIXME: only EE
-        HGCEEDetId cellid(frame.id());
-        // find trigger cell associated to cell
-        uint32_t tcid(0);
-        for(const auto& tc_c : mod.triggerCellComponents())
-        {
-            if(tc_c.second==cellid)
-            {
-                tcid = tc_c.first;
-                break;
-            }
-        }
-        if(!tcid)
-        {
-            throw cms::Exception("BadGeometry")
-                << "Cannot find trigger cell corresponding to HGC cell "<<cellid<<"\n";
-            continue;
-        }
-        HGCTriggerDetId triggercellid( tcid );
-        payload.insert( std::make_pair(triggercellid, 0) ); // do nothing if key exists already
-        // FIXME: need to transform ADC and TDC to the same linear scale on 12 bits
-        uint32_t data = frame[2].data(); // 'data' has to be a 12 bit word
-        payload[triggercellid] += data; // 32 bits integer should be largely enough (maximum 7 12-bits sums are done)
-
-    }
-    // fill data payload
-    for(const auto& id_value : payload)
-    {
-        uint32_t id = id_value.first.cell();
-        if(id>nCellsInModule_) // cell number starts at 1
-        {
-            throw cms::Exception("BadGeometry")
-                << "Number of trigger cells in module too large for available data payload\n";
-            continue;
-        }
-        data_.payload.at(id-1) = id_value.second;
-    }
-}
-
-
-/*****************************************************************/
-void HGCalBestChoiceCodec::bestChoiceSelect()
-/*****************************************************************/
-{
-    // Store data payload in vector for energy sorting. Then refill the data payload after trigger
-    // cell selection.
-    // Probably not the most efficient way.
-    // Should check in the firmware how cells with the same energy are sorted
-
-    // copy for sorting
-    std::vector< std::pair<uint32_t, uint32_t> > sortedtriggercells; // value, ID
-    sortedtriggercells.reserve(nCellsInModule_);
-    for(size_t i=0; i<nCellsInModule_; i++)
-    {
-        sortedtriggercells.push_back(std::make_pair(data_.payload[i], i));
-    }
-    // sort, reverse order
-    sort(sortedtriggercells.begin(), sortedtriggercells.end(),
-            [](const std::pair<uint32_t, uint32_t>& a, 
-                const  std::pair<uint32_t, uint32_t>& b) -> bool
-            { 
-                return a > b; 
-            } 
-            );
-    // keep only the 12 first trigger cells
-    for(size_t i=nData_; i<nCellsInModule_; i++)
-    {
-        sortedtriggercells.at(i).first = 0;
-    }
-    for(const auto& value_id : sortedtriggercells)
-    {
-        if(value_id.second>nCellsInModule_) // cell number starts at 1
-        {
-            throw cms::Exception("BadGeometry")
-                << "Number of trigger cells in module too large for available data payload\n";
-        }
-        data_.payload.at(value_id.second) = value_id.first;
-    }
+    return codecImpl_.decode(data);
 }
 
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -81,7 +81,7 @@ HGCalBestChoiceCodec::data_type HGCalBestChoiceCodec::decodeImpl(const std::vect
     result.reset();
     if(data.size()!=nCellsInModule_+dataLength_*nData_)
     {
-        edm::LogWarning("HGCalBestChoiceCodec") 
+        throw cms::Exception("BadData") 
             << "decode: data length ("<<data.size()<<") inconsistent with codec parameters:\n"\
             << "      : Map size = "<<nCellsInModule_<<"\n"\
             << "      : Number of energy values = "<<nData_<<"\n"\
@@ -130,7 +130,7 @@ void HGCalBestChoiceCodec::triggerCellSums(const HGCalTriggerGeometryBase& geom,
         uint32_t id = id_value.first.cell();
         if(id>nCellsInModule_) // cell number starts at 1
         {
-            edm::LogWarning("HGCalBestChoiceCodec") 
+            throw cms::Exception("BadGeometry")
                 << "Number of trigger cells in module too large for available data payload\n";
             continue;
         }
@@ -172,7 +172,7 @@ void HGCalBestChoiceCodec::bestChoiceSelect()
     {
         if(value_id.second>nCellsInModule_) // cell number starts at 1
         {
-            edm::LogWarning("HGCalBestChoiceCodec") 
+            throw cms::Exception("BadGeometry")
                 << "Number of trigger cells in module too large for available data payload\n";
         }
         data_.payload.at(value_id.second) = value_id.first;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -108,6 +108,7 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
     //
     // Build modules and fill map
     typedef HGCalTriggerGeometry::Module::list_type list_triggercells;
+    typedef HGCalTriggerGeometry::Module::tc_map_type tc_map_to_cells;
     // make list of trigger cells in modules
     std::map<unsigned, list_triggercells> modules_to_trigger_cells;
     for(const auto& triggercell_module : trigger_cells_to_modules_)
@@ -121,15 +122,20 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
     {
         unsigned moduleId = module_triggercell.first;
         list_triggercells triggercellIds = module_triggercell.second;
+        tc_map_to_cells cellsInTriggerCells;
         // Position: for the moment, barycenter of the module, from trigger cell positions
         Basic3DVector<float> moduleVector(0.,0.,0.);
         for(const auto& triggercell : triggercellIds)
         {
+            const auto& cells_in_tc = trigger_cells_to_cells[triggercell];
+            for( const unsigned cell : cells_in_tc ) {
+              cellsInTriggerCells.emplace(triggercell,cell);
+            }
             moduleVector += trigger_cells_.at(triggercell)->position().basicVector();
         }
         GlobalPoint modulePoint( moduleVector/triggercellIds.size() );
         // FIXME: empty neighbours
-        std::unique_ptr<const HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds));
+        std::unique_ptr<const HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds, cellsInTriggerCells));
         modules_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
     }
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
@@ -19,9 +19,11 @@ public:
       
       HGCalTriggerGeometry::Module::list_type mod_empty;
       HGCalTriggerGeometry::Module::list_type mod_comps = { i };
+      HGCalTriggerGeometry::Module::tc_map_type map_empty;
       modules_[i].reset( new HGCalTriggerGeometry::Module(i,GlobalPoint(),
                                                           mod_empty,
-                                                          mod_comps) );
+                                                          mod_comps,
+                                                          map_empty) );
     }
   }
 };

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
-                     CodecIndex = cms.uint32(1) )
+                     CodecIndex = cms.uint32(1),
+                     NData = cms.uint32(12),
+                     DataLength = cms.uint32(8)
+                   )
 
 random_cluster_algo =  cms.PSet( AlgorithmName = cms.string('RandomClusterAlgo'),
                                  FECodec = fe_codec )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-fe_codec = cms.PSet( CodecName  = cms.string('HGCal64BitRandomCodec'),
-                     CodecIndex = cms.uint32(0) )
+fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
+                     CodecIndex = cms.uint32(1) )
 
 random_cluster_algo =  cms.PSet( AlgorithmName = cms.string('RandomClusterAlgo'),
                                  FECodec = fe_codec )
@@ -12,7 +12,9 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     bhDigis = cms.InputTag('mix:HGCDigisHEback'),
     TriggerGeometry = cms.PSet(
-        TriggerGeometryName = cms.string('TrivialGeometry'),
+        TriggerGeometryName = cms.string('HGCalTriggerGeometryImp1'),
+        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/cellsToTriggerCellsMap.txt"),
+        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggerCellsToModulesMap.txt"),
         eeSDName = cms.string('HGCalEESensitive'),
         fhSDName = cms.string('HGCalHESiliconSensitive'),
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -14,7 +14,6 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     TriggerGeometry = cms.PSet(
         TriggerGeometryName = cms.string('HGCalTriggerGeometryImp1'),
         L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/cellsToTriggerCellsMap.txt"),
-        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggerCellsToModulesMap.txt"),
         eeSDName = cms.string('HGCalEESensitive'),
         fhSDName = cms.string('HGCalHESiliconSensitive'),
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -6,7 +6,7 @@ fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
                      DataLength = cms.uint32(8)
                    )
 
-random_cluster_algo =  cms.PSet( AlgorithmName = cms.string('RandomClusterAlgo'),
+cluster_algo =  cms.PSet( AlgorithmName = cms.string('FullModuleSumAlgo'),
                                  FECodec = fe_codec )
 
 hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
@@ -23,6 +23,6 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
         ),
     FECodec = fe_codec,
     BEConfiguration = cms.PSet( 
-        algorithms = cms.VPSet( random_cluster_algo )
+        algorithms = cms.VPSet( cluster_algo )
         )
     )

--- a/L1Trigger/L1THGCal/src/fe_codecs/HGCal64BitRandomCodecImpl.cc
+++ b/L1Trigger/L1THGCal/src/fe_codecs/HGCal64BitRandomCodecImpl.cc
@@ -1,0 +1,43 @@
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodecImpl.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <limits>
+#include "TRandom3.h"
+
+
+void HGCal64BitRandomCodecImpl::
+setDataPayload(data_type& data) {
+  data.payload = 0;
+  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
+    data.payload |= static_cast<uint64_t>(rand_.Rndm() > 0.5) << i;
+  }
+}
+
+std::vector<bool>
+HGCal64BitRandomCodecImpl::
+encode(const HGCal64BitRandomCodecImpl::data_type& data) const {
+  std::vector<bool> result;
+  result.resize(8*sizeof(data_type));
+  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
+    result[i] = static_cast<bool>((data.payload >> i) & 0x1);
+  }
+  return result;
+}
+
+HGCal64BitRandomCodecImpl::data_type
+HGCal64BitRandomCodecImpl::
+decode(const std::vector<bool>& data) const {
+  data_type result;
+  result.payload = 0;
+  if( data.size() > 8*sizeof(data_type) ) {
+    edm::LogWarning("HGCal64BitRandomCodecImpl|TruncateInput")
+          << "Input to be encoded was larger than data size: "
+          << sizeof(data_type) << ". Truncating to fit!";
+  }  
+  for( unsigned i = 0; i < 8*sizeof(data_type); ++i ) {
+    result.payload |= static_cast<uint64_t>(data[i]) << i;
+  }
+  return result;
+}
+
+

--- a/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
+++ b/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
@@ -1,0 +1,170 @@
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+
+/*****************************************************************/
+HGCalBestChoiceCodecImpl::HGCalBestChoiceCodecImpl(const edm::ParameterSet& conf) :
+    nData_(conf.getParameter<uint32_t>("NData")),
+    dataLength_(conf.getParameter<uint32_t>("DataLength")),
+    nCellsInModule_(data_type::size)
+/*****************************************************************/
+{
+}
+
+
+
+/*****************************************************************/
+std::vector<bool> HGCalBestChoiceCodecImpl::encode(const HGCalBestChoiceCodecImpl::data_type& data) const 
+/*****************************************************************/
+{
+    // First nCellsInModule_ bits are encoding the map of selected trigger cells
+    // Followed by nData_ words of dataLength_ bits, corresponding to energy/transverse energy of
+    // the selected trigger cells
+    std::vector<bool> result(nCellsInModule_ + dataLength_*nData_, 0);
+    size_t idata = 0;
+    for(size_t itc=0; itc<nCellsInModule_; itc++)
+    {
+        uint32_t value = data.payload.at(itc);
+        result[itc] = (value>0 ? 1 : 0);
+        if(value>0)
+        {
+            if(idata>=nData_)
+            {
+                throw cms::Exception("BadData") 
+                    << "encode: Number of non-zero trigger cells larger than codec parameter\n"\
+                    << "      : Number of energy values = "<<nData_<<"\n";
+            }
+            // FIXME: a proper coding is needed here. Needs studies.
+            // For the moment truncate to 8 bits by keeping bits 10----3. 
+            // Values > 0x3FF are saturated to 0x3FF
+            if(value>0x3FF) value=0x3FF; // 10 bit saturation
+            for(size_t i=0; i<dataLength_; i++)
+            {
+                result[nCellsInModule_ + idata*dataLength_ + i] = static_cast<bool>(value & (0x1<<(i+2)));// remove the two lowest bits
+            }
+            idata++;
+        }
+    }
+    return result;
+}
+
+/*****************************************************************/
+HGCalBestChoiceCodecImpl::data_type HGCalBestChoiceCodecImpl::decode(const std::vector<bool>& data) const 
+/*****************************************************************/
+{
+    data_type result;
+    result.reset();
+    if(data.size()!=nCellsInModule_+dataLength_*nData_)
+    {
+        throw cms::Exception("BadData") 
+            << "decode: data length ("<<data.size()<<") inconsistent with codec parameters:\n"\
+            << "      : Map size = "<<nCellsInModule_<<"\n"\
+            << "      : Number of energy values = "<<nData_<<"\n"\
+            << "      : Energy value length = "<<dataLength_<<"\n";
+    }
+    size_t c = 0;
+    for(size_t b=0; b<nCellsInModule_; b++)
+    {
+        if(data[b])
+        {
+            uint32_t value = 0;
+            for(size_t i=0;i<dataLength_;i++)
+            {
+                size_t index = nCellsInModule_+c*dataLength_+i; 
+                if(data[index]) value |= (0x1<<i);
+            }
+            c++;
+            result.payload[b] = value;
+        }
+    }
+    return result;
+}
+
+
+/*****************************************************************/
+void HGCalBestChoiceCodecImpl::triggerCellSums(const HGCalTriggerGeometry::Module& mod, const std::vector<HGCEEDataFrame>& dataframes, data_type& data)
+/*****************************************************************/
+{
+    std::map<HGCTriggerDetId, uint32_t> payload;
+    // sum energies in trigger cells
+    for(const auto& frame : dataframes)
+    {
+        // FIXME: only EE
+        HGCEEDetId cellid(frame.id());
+        // find trigger cell associated to cell
+        uint32_t tcid(0);
+        for(const auto& tc_c : mod.triggerCellComponents())
+        {
+            if(tc_c.second==cellid)
+            {
+                tcid = tc_c.first;
+                break;
+            }
+        }
+        if(!tcid)
+        {
+            throw cms::Exception("BadGeometry")
+                << "Cannot find trigger cell corresponding to HGC cell "<<cellid<<"\n";
+        }
+        HGCTriggerDetId triggercellid( tcid );
+        payload.insert( std::make_pair(triggercellid, 0) ); // do nothing if key exists already
+        // FIXME: need to transform ADC and TDC to the same linear scale on 12 bits
+        uint32_t value = frame[2].data(); // 'value' has to be a 12 bit word
+        payload[triggercellid] += value; // 32 bits integer should be largely enough (maximum 7 12-bits sums are done)
+
+    }
+    // fill data payload
+    for(const auto& id_value : payload)
+    {
+        uint32_t id = id_value.first.cell();
+        if(id>nCellsInModule_) // cell number starts at 1
+        {
+            throw cms::Exception("BadGeometry")
+                << "Number of trigger cells in module too large for available data payload\n";
+        }
+        data.payload.at(id-1) = id_value.second;
+    }
+}
+
+
+/*****************************************************************/
+void HGCalBestChoiceCodecImpl::bestChoiceSelect(data_type& data)
+/*****************************************************************/
+{
+    // Store data payload in vector for energy sorting. Then refill the data payload after trigger
+    // cell selection.
+    // Probably not the most efficient way.
+    // Should check in the firmware how cells with the same energy are sorted
+
+    // copy for sorting
+    std::vector< std::pair<uint32_t, uint32_t> > sortedtriggercells; // value, ID
+    sortedtriggercells.reserve(nCellsInModule_);
+    for(size_t i=0; i<nCellsInModule_; i++)
+    {
+        sortedtriggercells.push_back(std::make_pair(data.payload[i], i));
+    }
+    // sort, reverse order
+    sort(sortedtriggercells.begin(), sortedtriggercells.end(),
+            [](const std::pair<uint32_t, uint32_t>& a, 
+                const  std::pair<uint32_t, uint32_t>& b) -> bool
+            { 
+                return a > b; 
+            } 
+            );
+    // keep only the 12 first trigger cells
+    for(size_t i=nData_; i<nCellsInModule_; i++)
+    {
+        sortedtriggercells.at(i).first = 0;
+    }
+    for(const auto& value_id : sortedtriggercells)
+    {
+        if(value_id.second>nCellsInModule_) // cell number starts at 1
+        {
+            throw cms::Exception("BadGeometry")
+                << "Number of trigger cells in module too large for available data payload\n";
+        }
+        data.payload.at(value_id.second) = value_id.first;
+    }
+}
+
+

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -2,10 +2,25 @@
 <!--<use   name="FWCore/ParameterSet"/>-->
 <!--<use   name="FWCore/Utilities"/>-->
 <!--<use   name="DataFormats/ForwardDetId"/>-->
+
 <use   name="Geometry/FCalGeometry"/>
 <use   name="Geometry/CaloTopology"/>
-<use   name="L1Trigger/L1THGCal"/> 
+<use   name="L1Trigger/L1THGCal"/>
 <use   name="Geometry/Records"/>
 <use   name="CommonTools/UtilAlgos"/>
+
+<!--<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerBestChoiceTester.cc">-->
+<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc">
 <flags   EDM_PLUGIN="1"/>
-<library   file="HGCalTriggerGeomTester.cc" name="testL1TriggerL1THGCal"> </library>
+</library>
+
+
+
+<bin name="TestBestChoiceCodec" file="unittest_bestchoicecodec.cc,testRunner.cc">
+<!--<use   name="L1Trigger/L1THGCal"/>-->
+<!--<use name="L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_fe_be"/>-->
+<!--<use name="pluginL1TriggerL1THGCalPlugins_fe_be"/>-->
+<Flags LDFLAGS="-l:pluginL1TriggerL1THGCalPlugins_fe_be.so"/>
+  <use   name="DataFormats/L1THGCal"/>
+<use   name="cppunit"/>
+</bin>

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -9,18 +9,13 @@
 <use   name="Geometry/Records"/>
 <use   name="CommonTools/UtilAlgos"/>
 
-<!--<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerBestChoiceTester.cc">-->
-<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc">
+<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerBestChoiceTester.cc">
 <flags   EDM_PLUGIN="1"/>
 </library>
 
 
 
 <bin name="TestBestChoiceCodec" file="unittest_bestchoicecodec.cc,testRunner.cc">
-<!--<use   name="L1Trigger/L1THGCal"/>-->
-<!--<use name="L1Trigger/L1THGCal/plugins/L1TriggerL1THGCalPlugins_fe_be"/>-->
-<!--<use name="pluginL1TriggerL1THGCalPlugins_fe_be"/>-->
-<Flags LDFLAGS="-l:pluginL1TriggerL1THGCalPlugins_fe_be.so"/>
-  <use   name="DataFormats/L1THGCal"/>
-<use   name="cppunit"/>
+  <!--<use   name="DataFormats/L1THGCal"/>-->
+  <use   name="cppunit"/>
 </bin>

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -1,0 +1,182 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+
+#include <stdlib.h> 
+
+
+class HGCalTriggerBestChoiceTester : public edm::EDAnalyzer 
+{
+    public:
+        explicit HGCalTriggerBestChoiceTester(const edm::ParameterSet& );
+        ~HGCalTriggerBestChoiceTester();
+
+        virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+
+    private:
+        void fill(const l1t::HGCFETriggerDigiCollection&, const HGCEEDigiCollection&);
+        // inputs
+        edm::EDGetToken inputee_, inputfh_, inputbh_;
+        //
+        std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_; 
+        //std::unique_ptr<HGCalTriggerFECodecBase> codec_;
+        HGCalBestChoiceCodec codec_;
+        edm::Service<TFileService> fs_;
+        // histos
+        TH1F* triggerCellsPerModule_;
+        TH1F* triggerCellData_;
+        TH1F* moduleSum_;
+
+};
+
+
+/*****************************************************************/
+HGCalTriggerBestChoiceTester::HGCalTriggerBestChoiceTester(const edm::ParameterSet& conf):
+  inputee_(consumes<HGCEEDigiCollection>(conf.getParameter<edm::InputTag>("eeDigis"))),
+  inputfh_(consumes<HGCHEDigiCollection>(conf.getParameter<edm::InputTag>("fhDigis"))), 
+  inputbh_(consumes<HGCHEDigiCollection>(conf.getParameter<edm::InputTag>("bhDigis"))),
+  codec_(conf.getParameterSet("FECodec"))
+/*****************************************************************/
+{
+    //setup geometry 
+    const edm::ParameterSet& geometryConfig = conf.getParameterSet("TriggerGeometry");
+    const std::string& trigGeomName = geometryConfig.getParameter<std::string>("TriggerGeometryName");
+    HGCalTriggerGeometryBase* geometry = HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
+    triggerGeometry_.reset(geometry);
+
+    //setup FE codec
+    //const edm::ParameterSet& feCodecConfig = conf.getParameterSet("FECodec");
+    //const std::string& feCodecName =feCodecConfig.getParameter<std::string>("CodecName");
+    //HGCalTriggerFECodecBase* codec = HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig);
+    //codec_.reset(codec);
+    codec_.unSetDataPayload();
+
+    // initialize output trees
+    triggerCellsPerModule_ = fs_->make<TH1F>("TriggerCellsPerModule","Number of trigger cells per module", 64, 0., 64.);
+    triggerCellData_       = fs_->make<TH1F>("TriggerCellData","Trigger cell values", 500, 0., 500.);
+    moduleSum_             = fs_->make<TH1F>("ModuleSum","Trigger cell sum in modules", 5000, 0., 5000.);
+}
+
+
+
+/*****************************************************************/
+HGCalTriggerBestChoiceTester::~HGCalTriggerBestChoiceTester() 
+/*****************************************************************/
+{
+}
+
+/*****************************************************************/
+void HGCalTriggerBestChoiceTester::beginRun(const edm::Run& /*run*/, 
+                                          const edm::EventSetup& es)
+/*****************************************************************/
+{
+    triggerGeometry_->reset();
+    HGCalTriggerGeometryBase::es_info info;
+    const std::string& ee_sd_name = triggerGeometry_->eeSDName();
+    const std::string& fh_sd_name = triggerGeometry_->fhSDName();
+    const std::string& bh_sd_name = triggerGeometry_->bhSDName();
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.geom_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.geom_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.geom_bh);
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.topo_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.topo_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.topo_bh);
+    triggerGeometry_->initialize(info);
+}
+
+
+
+/*****************************************************************/
+void HGCalTriggerBestChoiceTester::analyze(const edm::Event& e, 
+			      const edm::EventSetup& es) 
+/*****************************************************************/
+{
+    std::unique_ptr<l1t::HGCFETriggerDigiCollection> fe_coll_ptr( new l1t::HGCFETriggerDigiCollection );
+
+    edm::Handle<HGCEEDigiCollection> ee_digis_h;
+    edm::Handle<HGCHEDigiCollection> fh_digis_h, bh_digis_h;
+
+    e.getByToken(inputee_,ee_digis_h);
+    e.getByToken(inputfh_,fh_digis_h);
+    e.getByToken(inputbh_,bh_digis_h);
+
+    const HGCEEDigiCollection& ee_digis = *ee_digis_h;
+    const HGCHEDigiCollection& fh_digis = *fh_digis_h;
+    const HGCHEDigiCollection& bh_digis = *bh_digis_h;
+
+    for( const auto& module : triggerGeometry_->modules() ) 
+    {    
+        fe_coll_ptr->push_back(l1t::HGCFETriggerDigi());
+        l1t::HGCFETriggerDigi& digi = fe_coll_ptr->back();
+        codec_.setDataPayload(*(module.second),ee_digis,fh_digis,bh_digis);
+        codec_.encode(digi);
+        digi.setDetId( HGCTriggerDetId(module.first) );
+        codec_.unSetDataPayload();
+    }
+
+}
+
+
+/*****************************************************************/
+void HGCalTriggerBestChoiceTester::fill(const l1t::HGCFETriggerDigiCollection& fe_digis, const HGCEEDigiCollection& ee_digis)
+/*****************************************************************/
+{
+    for( const auto& module : triggerGeometry_->modules() ) 
+    { 
+        // Trigger cells
+        unsigned nFEDigi = 0;
+        unsigned moduleSum = 0;
+        for(const auto& fe_digi : fe_digis)
+        {
+            if(fe_digi.getDetId<HGCTriggerDetId>()==module.first)
+            {
+                HGCalBestChoiceCodec::data_type data;
+                data.reset();
+                fe_digi.decode<HGCalBestChoiceCodec, HGCalBestChoiceCodec::data_type>(codec_, data);
+                for(const auto& tc : data.payload)
+                {
+                    if(tc>0)
+                    {
+                        nFEDigi++;
+                        moduleSum += tc;
+                        triggerCellData_->Fill(tc);
+                    }
+                }
+            }
+        }
+        triggerCellsPerModule_->Fill(nFEDigi);
+        moduleSum_->Fill(moduleSum);
+    }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HGCalTriggerBestChoiceTester);

--- a/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
@@ -1,0 +1,137 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('SIMDIGI')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(4)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt50_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test.root")
+    )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(50.01),
+        MinPt = cms.double(49.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(3.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(1.5),
+        MinPhi = cms.double(-3.14159265359)
+    ),
+    Verbosity = cms.untracked.int32(0),
+    psethack = cms.string('single electron pt 50'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+
+process.hgcaltriggerbestchoicetester = cms.EDAnalyzer(
+    "HGCalTriggerBestChoiceTester",
+    eeDigis = cms.InputTag('mix:HGCDigisEE'),
+    fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
+    bhDigis = cms.InputTag('mix:HGCDigisHEback'),
+    TriggerGeometry = cms.PSet(
+        TriggerGeometryName = cms.string('HGCalTriggerGeometryImp1'),
+        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/cellsToTriggerCellsMap.txt"),
+        eeSDName = cms.string('HGCalEESensitive'),
+        fhSDName = cms.string('HGCalHESiliconSensitive'),
+        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
+        ),
+    FECodec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
+                     CodecIndex = cms.uint32(1),
+                     NData = cms.uint32(12),
+                     DataLength = cms.uint32(8)
+                   )
+    )
+process.test_step = cms.Path(process.hgcaltriggerbestchoicetester)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.test_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
+from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023HGCalMuon
+
+#call to customisation function cust_2023HGCalMuon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
+process = cust_2023HGCalMuon(process)
+
+# End of customisation functions
+process.ProfilerService = cms.Service("ProfilerService", firstEvent=cms.untracked.int32(0), lastEvent=cms.untracked.int32(2), paths=cms.untracked.vstring(["test_step"]))
+
+

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -66,16 +66,16 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
 process.generator = cms.EDProducer("FlatRandomPtGunProducer",
     PGunParameters = cms.PSet(
-        MaxPt = cms.double(10.01),
-        MinPt = cms.double(9.99),
-        PartID = cms.vint32(13),
-        MaxEta = cms.double(2.5),
+        MaxPt = cms.double(50.01),
+        MinPt = cms.double(49.99),
+        PartID = cms.vint32(11),
+        MaxEta = cms.double(1.5),
         MaxPhi = cms.double(3.14159265359),
-        MinEta = cms.double(-2.5),
+        MinEta = cms.double(3.),
         MinPhi = cms.double(-3.14159265359)
     ),
     Verbosity = cms.untracked.int32(0),
-    psethack = cms.string('single electron pt 10'),
+    psethack = cms.string('single electron pt 100'),
     AddAntiParticle = cms.bool(True),
     firstRun = cms.untracked.uint32(1)
 )

--- a/L1Trigger/L1THGCal/test/testRunner.cc
+++ b/L1Trigger/L1THGCal/test/testRunner.cc
@@ -1,0 +1,1 @@
+#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/L1Trigger/L1THGCal/test/unittest_bestchoicecodec.cc
+++ b/L1Trigger/L1THGCal/test/unittest_bestchoicecodec.cc
@@ -1,0 +1,74 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+#include <iostream>
+
+
+
+#include "TRandom3.h"
+
+class TestBestChoiceCodec: public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(TestBestChoiceCodec);
+    CPPUNIT_TEST(testCoding);
+    CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp();
+        void tearDown(){}
+        void testCoding();
+
+        std::unique_ptr<HGCalBestChoiceCodec> codec_;
+        TRandom3 rand_;
+};
+
+/// registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(TestBestChoiceCodec);
+
+using namespace std;
+
+/*****************************************************************/
+void TestBestChoiceCodec::setUp()
+/*****************************************************************/
+{
+    std::cerr<<"TestBestChoiceCodec::setUp()"<<"\n";
+    edm::ParameterSet params;
+    params.addParameter<std::string>("CodecName", "HGCalBestChoiceCodec");
+    params.addParameter<uint32_t>("CodecIndex", 1);
+    params.addParameter<uint32_t>("NData", 12);
+    params.addParameter<uint32_t>("DataLength", 8);
+    codec_.reset(new HGCalBestChoiceCodec(params));
+    codec_->unSetDataPayload();
+
+}
+
+/*****************************************************************/
+void TestBestChoiceCodec::testCoding()
+/*****************************************************************/
+{
+    std::cerr<<"TestBestChoiceCodec::testCoding()"<<"\n";
+    HGCalBestChoiceDataPayload payload;
+    for(auto& data : payload.payload)
+    {
+        data = rand_.Integer(0xFFF);
+    }
+    std::vector<bool> dataframe = codec_->encodeImpl(payload);
+    HGCalBestChoiceDataPayload decodedpayload = codec_->decodeImpl(dataframe);
+
+    for(size_t i=0; i<payload.payload.size(); i++)
+    {
+        std::cerr<<"TestBestChoiceCodec::testCoding(). Index "<<i<<"\n";
+        uint32_t data = payload.payload[i];       
+        uint32_t decdata __attribute__((unused))= decodedpayload.payload[i];
+        uint32_t datashift __attribute__((unused))= data;  
+        if(data>0x3FF) datashift = 0x3FF;
+        datashift  = (data >> 2);
+        //std::stringstream message;
+        //message << "**** Payload Index "<<i<<" ****\n";
+        //message << "**** Original data = "<<std::hex<<data<<" Decoded data "<<decdata<<std::dec<<" ****";
+        //CPPUNIT_ASSERT_MESSAGE( message.str(),  datashift!=decdata);
+    }
+    codec_->unSetDataPayload();
+    std::cerr<<"TestBestChoiceCodec::testCoding() OK"<<"\n";
+}
+

--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -17,7 +17,7 @@ hgceeDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"),
                                                noise_fC         = cms.double(0.336),
                                                doTimeSamples    = cms.bool(False),                                         
                                                feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
-                                                                   fwVersion         = cms.uint32(2),
+                                                                   fwVersion         = cms.uint32(0),
                                                                    # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
                                                                    adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
                                                                    pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 
@@ -63,7 +63,7 @@ hgchefrontDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"
                                                     noise_fC         = cms.double(0.336),                                                    
                                                     doTimeSamples    = cms.bool(False),                                         
                                                     feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
-                                                                        fwVersion         = cms.uint32(2),
+                                                                        fwVersion         = cms.uint32(0),
                                                                         # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
                                                                         adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
                                                                         pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 

--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -17,7 +17,7 @@ hgceeDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"),
                                                noise_fC         = cms.double(0.336),
                                                doTimeSamples    = cms.bool(False),                                         
                                                feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
-                                                                   fwVersion         = cms.uint32(0),
+                                                                   fwVersion         = cms.uint32(2),
                                                                    # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
                                                                    adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
                                                                    pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 
@@ -63,7 +63,7 @@ hgchefrontDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"
                                                     noise_fC         = cms.double(0.336),                                                    
                                                     doTimeSamples    = cms.bool(False),                                         
                                                     feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
-                                                                        fwVersion         = cms.uint32(0),
+                                                                        fwVersion         = cms.uint32(2),
                                                                         # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
                                                                         adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
                                                                         pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 


### PR DESCRIPTION
Contribution to issue #7
- New features: 
  - Best choice coding scheme as developed in Split, composed of energy sums in trigger cells and selection of the 12 trigger cells with highest energies.
  - Dummy backend algorithm using this coding scheme as input and performing the sums of trigger cells in each module.
- Changes in base code:
  - Had to pass the geometry to HGCalTriggerFECodecBase::setDataPayload() in order to retrieve HGC cells from trigger cells from modules; the module class gives the list of trigger cell DetId, and the geometry is needed to get HGC cells from that (linked to issue #6 )
  - Had to change HGCFETriggerDigi::setDetId(): DetId class doesn't have a uint32_t() method.
