### PR TITLE
Neighbours finder

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -77,32 +77,45 @@ namespace HGCalTriggerGeometry {
   class Module {
   public:
     typedef std::unordered_set<unsigned> list_type;
+    typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
     
     Module(unsigned mod_id, const GlobalPoint& pos,
-           const list_type& neighbs, const list_type& comps):
+           const list_type& neighbs, const list_type& comps,
+           const tc_map_type& tc_comps):
       module_id_(mod_id),
       position_(pos),
       neighbours_(neighbs),
-      components_(comps)
+      components_(comps),
+      tc_components_(tc_comps)  
       {}
     ~Module() {}
     
     unsigned moduleId()      const { return module_id_; }
 
-    bool containsTriggerCell(const unsigned cell) const {
-      return ( components_.find(cell) != components_.end() );
+    bool containsTriggerCell(const unsigned trig_cell) const {
+      return ( components_.find(trig_cell) != components_.end() );
+    }
+
+    bool containsCell(const unsigned cell) const {
+      for( const auto& value : tc_components_ ) {
+        if( value.second == cell ) return true;
+      }
+      return false;
     }
 
     const GlobalPoint& position() const { return position_; }
 
-    const std::unordered_set<unsigned>& neighbours() const { return neighbours_; }
-    const std::unordered_set<unsigned>& components() const { return components_; }
+    const list_type& neighbours() const { return neighbours_; }
+    const list_type& components() const { return components_; }
+
+    const tc_map_type& triggerCellComponents() const { return tc_components_; }
 
   private:    
     unsigned module_id_; // module this TC belongs to
     GlobalPoint position_;
     list_type neighbours_; // neighbouring Modules
     list_type components_; // contained HGC trigger cells
+    tc_map_type tc_components_; // cells contained by trigger cells
   };
 }  
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -220,6 +220,7 @@ class HGCalTriggerGeometryBase {
     // the unique ptr do not loose ownership of these objects!
     HGCalTriggerGeometry::TriggerCell* getTriggerCellFromCellInConstruction( const unsigned cell_det_id); 
     HGCalTriggerGeometry::Module* getModuleFromCellInConstruction( const unsigned cell_det_id); 
+    HGCalTriggerGeometry::Module* getModuleFromTriggerCellInConstruction( const unsigned cell_det_id); 
 
     private:
     const std::string name_;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -2,6 +2,7 @@
 #define __L1Trigger_L1THGCal_HGCalTriggerGeometryBase_h__
 
 #include <iostream>
+#include <functional>
 #include <unordered_set>
 #include <unordered_map>
 
@@ -42,6 +43,18 @@ class HGCalTriggerGeometryBase;
 namespace HGCalTriggerGeometry {
 
 
+    enum TopoBit{
+        north   = 1UL <<0 ,
+        south   = 1UL <<1,
+        east    = 1UL <<2,
+        west    = 1UL <<3,
+        up      = 1UL <<4,
+        down    = 1UL <<5,
+        generic = 1UL <<6 // if nswe is not known, not guarrantee to be set if something else is
+    };
+    // ---- topological pair
+    typedef uint8_t TopoBits;
+    typedef std::unordered_map< unsigned, TopoBits > topo_list_type;
 
     // fwd declaration
     class HGCalTriggerTopologyFinder;
@@ -54,7 +67,7 @@ namespace HGCalTriggerGeometry {
         typedef std::unordered_set<unsigned> list_type;
 
         TriggerCell(unsigned tc_id, unsigned mod_id, const GlobalPoint& pos,
-                const list_type& neighbs, const list_type& comps) :
+                const topo_list_type& neighbs, const list_type& comps) :
             trigger_cell_id_(tc_id),
             module_id_(mod_id),
             position_(pos),
@@ -73,14 +86,23 @@ namespace HGCalTriggerGeometry {
 
         const GlobalPoint& position() const { return position_; }
 
-        const std::unordered_set<unsigned>& neighbours() const { return neighbours_; }
+        const topo_list_type& neighbours() const { return neighbours_; }
         const std::unordered_set<unsigned>& components() const { return components_; }
+
+        // FIXME: cache
+        const list_type topoNeighbours(const TopoBits tb) const { list_type a; for(auto& x : neighbours_) if (x.second & tb) a.insert(x.first) ; return a;}
+        const list_type north() const { return topoNeighbours(HGCalTriggerGeometry::north) ; }
+        const list_type east() const { return topoNeighbours(HGCalTriggerGeometry::east) ; }
+        const list_type west() const { return topoNeighbours(HGCalTriggerGeometry::west) ; }
+        const list_type south() const { return topoNeighbours(HGCalTriggerGeometry::south) ; }
+        const list_type up() const { return topoNeighbours(HGCalTriggerGeometry::up) ; }
+        const list_type down() const { return topoNeighbours(HGCalTriggerGeometry::down) ; }
 
         private:
         unsigned trigger_cell_id_; // the ID of this trigger cell
         unsigned module_id_; // module this TC belongs to
         GlobalPoint position_;
-        list_type neighbours_; // neighbouring trigger cells
+        topo_list_type neighbours_; // neighbouring trigger cells
         list_type components_; // contained HGC cells
     };
 
@@ -91,7 +113,7 @@ namespace HGCalTriggerGeometry {
         typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
 
         Module(unsigned mod_id, const GlobalPoint& pos,
-                const list_type& neighbs, const list_type& comps,
+                const topo_list_type& neighbs, const list_type& comps,
                 const tc_map_type& tc_comps):
             module_id_(mod_id),
             position_(pos),
@@ -116,15 +138,24 @@ namespace HGCalTriggerGeometry {
 
         const GlobalPoint& position() const { return position_; }
 
-        const list_type& neighbours() const { return neighbours_; }
+        const topo_list_type& neighbours() const { return neighbours_; }
         const list_type& components() const { return components_; }
 
         const tc_map_type& triggerCellComponents() const { return tc_components_; }
 
+        //FIXME: cache
+        const list_type topoNeighbours(const TopoBits tb) const { list_type a; for(auto& x : neighbours_) if (x.second & tb) a.insert(x.first) ; return a;}
+        const list_type north() const { return topoNeighbours(HGCalTriggerGeometry::north) ; }
+        const list_type east() const { return topoNeighbours(HGCalTriggerGeometry::east) ; }
+        const list_type west() const { return topoNeighbours(HGCalTriggerGeometry::west) ; }
+        const list_type south() const { return topoNeighbours(HGCalTriggerGeometry::south) ; }
+        const list_type up() const { return topoNeighbours(HGCalTriggerGeometry::up) ; }
+        const list_type down() const { return topoNeighbours(HGCalTriggerGeometry::down) ; }
+
         private:    
         unsigned module_id_; // module this TC belongs to
         GlobalPoint position_;
-        list_type neighbours_; // neighbouring Modules
+        topo_list_type neighbours_; // neighbouring Modules
         list_type components_; // contained HGC trigger cells
         tc_map_type tc_components_; // cells contained by trigger cells
     };

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -42,145 +42,191 @@ class HGCalTriggerGeometryBase;
 namespace HGCalTriggerGeometry {
 
 
-  // fwd declaration
-  class HGCalTriggerTopologyFinder;
+
+    // fwd declaration
+    class HGCalTriggerTopologyFinder;
+    class HGCalTriggerGeometryModifier;
 
 
-  class TriggerCell {
-  friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
-  public:
-    typedef std::unordered_set<unsigned> list_type;
+    class TriggerCell {
+        friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder; // REMOVE
+        friend class HGCalTriggerGeometry::HGCalTriggerGeometryModifier;
+        public:
+        typedef std::unordered_set<unsigned> list_type;
 
-    TriggerCell(unsigned tc_id, unsigned mod_id, const GlobalPoint& pos,
+        TriggerCell(unsigned tc_id, unsigned mod_id, const GlobalPoint& pos,
                 const list_type& neighbs, const list_type& comps) :
-      trigger_cell_id_(tc_id),
-      module_id_(mod_id),
-      position_(pos),
-      neighbours_(neighbs),
-      components_(comps)
-      {}
-    ~TriggerCell() {}
-   
-    
-    unsigned triggerCellId() const { return trigger_cell_id_; }
-    unsigned moduleId()      const { return module_id_; }
-    
-    bool containsCell(const unsigned cell) const {
-      return ( components_.find(cell) != components_.end() );
-    }
+            trigger_cell_id_(tc_id),
+            module_id_(mod_id),
+            position_(pos),
+            neighbours_(neighbs),
+            components_(comps)
+        {}
+        ~TriggerCell() {}
 
-    const GlobalPoint& position() const { return position_; }
 
-    const std::unordered_set<unsigned>& neighbours() const { return neighbours_; }
-    const std::unordered_set<unsigned>& components() const { return components_; }
+        unsigned triggerCellId() const { return trigger_cell_id_; }
+        unsigned moduleId()      const { return module_id_; }
 
-  private:
-    unsigned trigger_cell_id_; // the ID of this trigger cell
-    unsigned module_id_; // module this TC belongs to
-    GlobalPoint position_;
-    list_type neighbours_; // neighbouring trigger cells
-    list_type components_; // contained HGC cells
-  };
-  
-  class Module {
-  friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
-  public:
-    typedef std::unordered_set<unsigned> list_type;
-    typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
-    
-    Module(unsigned mod_id, const GlobalPoint& pos,
-           const list_type& neighbs, const list_type& comps,
-           const tc_map_type& tc_comps):
-      module_id_(mod_id),
-      position_(pos),
-      neighbours_(neighbs),
-      components_(comps),
-      tc_components_(tc_comps)  
-      {}
-    ~Module() {}
-    
-    unsigned moduleId()      const { return module_id_; }
+        bool containsCell(const unsigned cell) const {
+            return ( components_.find(cell) != components_.end() );
+        }
 
-    bool containsTriggerCell(const unsigned trig_cell) const {
-      return ( components_.find(trig_cell) != components_.end() );
-    }
+        const GlobalPoint& position() const { return position_; }
 
-    bool containsCell(const unsigned cell) const {
-      for( const auto& value : tc_components_ ) {
-        if( value.second == cell ) return true;
-      }
-      return false;
-    }
+        const std::unordered_set<unsigned>& neighbours() const { return neighbours_; }
+        const std::unordered_set<unsigned>& components() const { return components_; }
 
-    const GlobalPoint& position() const { return position_; }
+        private:
+        unsigned trigger_cell_id_; // the ID of this trigger cell
+        unsigned module_id_; // module this TC belongs to
+        GlobalPoint position_;
+        list_type neighbours_; // neighbouring trigger cells
+        list_type components_; // contained HGC cells
+    };
 
-    const list_type& neighbours() const { return neighbours_; }
-    const list_type& components() const { return components_; }
+    class Module {
+        friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder; // REMOVE
+        friend class HGCalTriggerGeometry::HGCalTriggerGeometryModifier;
+        public:
+        typedef std::unordered_set<unsigned> list_type;
+        typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
 
-    const tc_map_type& triggerCellComponents() const { return tc_components_; }
+        Module(unsigned mod_id, const GlobalPoint& pos,
+                const list_type& neighbs, const list_type& comps,
+                const tc_map_type& tc_comps):
+            module_id_(mod_id),
+            position_(pos),
+            neighbours_(neighbs),
+            components_(comps),
+            tc_components_(tc_comps)  
+        {}
+        ~Module() {}
 
-  private:    
-    unsigned module_id_; // module this TC belongs to
-    GlobalPoint position_;
-    list_type neighbours_; // neighbouring Modules
-    list_type components_; // contained HGC trigger cells
-    tc_map_type tc_components_; // cells contained by trigger cells
-  };
+        unsigned moduleId()      const { return module_id_; }
+
+        bool containsTriggerCell(const unsigned trig_cell) const {
+            return ( components_.find(trig_cell) != components_.end() );
+        }
+
+        bool containsCell(const unsigned cell) const {
+            for( const auto& value : tc_components_ ) {
+                if( value.second == cell ) return true;
+            }
+            return false;
+        }
+
+        const GlobalPoint& position() const { return position_; }
+
+        const list_type& neighbours() const { return neighbours_; }
+        const list_type& components() const { return components_; }
+
+        const tc_map_type& triggerCellComponents() const { return tc_components_; }
+
+        private:    
+        unsigned module_id_; // module this TC belongs to
+        GlobalPoint position_;
+        list_type neighbours_; // neighbouring Modules
+        list_type components_; // contained HGC trigger cells
+        tc_map_type tc_components_; // cells contained by trigger cells
+    };
 }  
 
 class HGCalTriggerGeometryBase { 
- friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
- public:  
-  struct es_info {
-    edm::ESHandle<HGCalGeometry> geom_ee, geom_fh, geom_bh;
-    edm::ESHandle<HGCalTopology> topo_ee, topo_fh, topo_bh;
-  };
+    friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder; // REMOVE
+    friend class HGCalTriggerGeometry::HGCalTriggerGeometryModifier;
 
-  typedef std::unordered_map<unsigned,unsigned> geom_map;
-  typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::Module> > module_map;
-  typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::TriggerCell> > trigger_cell_map;
 
-  HGCalTriggerGeometryBase(const edm::ParameterSet& conf);
-  virtual ~HGCalTriggerGeometryBase() {}
+    public:  
+    struct es_info {
+        edm::ESHandle<HGCalGeometry> geom_ee, geom_fh, geom_bh;
+        edm::ESHandle<HGCalTopology> topo_ee, topo_fh, topo_bh;
+    };
 
-  const std::string& name() const { return name_; } 
+    typedef std::unordered_map<unsigned,unsigned> geom_map;
+    typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::Module> > module_map;
+    typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::TriggerCell> > trigger_cell_map;
 
-  const std::string& eeSDName() const { return ee_sd_name_; } 
-  const std::string& fhSDName() const { return fh_sd_name_; } 
-  const std::string& bhSDName() const { return bh_sd_name_; } 
+    HGCalTriggerGeometryBase(const edm::ParameterSet& conf);
+    virtual ~HGCalTriggerGeometryBase() {}
 
-  // non-const access to the geometry class
-  virtual void initialize( const es_info& ) = 0;
-  void reset();
-  
-  // const access to the geometry class  
-  // all of the get*From* functions return nullptr if the thing you
-  // ask for doesn't exist
-  const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
-  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
-  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
+    const std::string& name() const { return name_; } 
 
-  const geom_map& cellsToTriggerCellsMap() const { return cells_to_trigger_cells_; }
-  const geom_map& triggerCellsToModulesMap() const { return trigger_cells_to_modules_; }
-  
-  const module_map& modules() const { return modules_; }
-  const trigger_cell_map& triggerCells() const { return trigger_cells_; }
+    const std::string& eeSDName() const { return ee_sd_name_; } 
+    const std::string& fhSDName() const { return fh_sd_name_; } 
+    const std::string& bhSDName() const { return bh_sd_name_; } 
 
- protected:
-  geom_map cells_to_trigger_cells_;
-  geom_map trigger_cells_to_modules_;
-  
-  module_map modules_;
-  trigger_cell_map trigger_cells_;
-  
- private:
-  const std::string name_;
-  const std::string ee_sd_name_;
-  const std::string fh_sd_name_;
-  const std::string bh_sd_name_;  
+    // non-const access to the geometry class
+    std::vector<HGCalTriggerGeometry::HGCalTriggerGeometryModifier*> geometryModifiers_; // TODO, private + Set + Get
+    void initModifiers();
+    virtual void initialize( const es_info& ) = 0;
+    void reset();
+
+    // const access to the geometry class  
+    // all of the get*From* functions return nullptr if the thing you
+    // ask for doesn't exist
+    const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
+    const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
+    const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
+
+    const geom_map& cellsToTriggerCellsMap() const { return cells_to_trigger_cells_; }
+    const geom_map& triggerCellsToModulesMap() const { return trigger_cells_to_modules_; }
+
+    const module_map& modules() const { return modules_; }
+    const trigger_cell_map& triggerCells() const { return trigger_cells_; }
+
+    protected:
+    geom_map cells_to_trigger_cells_;
+    geom_map trigger_cells_to_modules_;
+
+    module_map modules_;
+    trigger_cell_map trigger_cells_;
+    // -- used by the modifier
+    //
+    typedef std::unordered_map<unsigned, std::unique_ptr<HGCalTriggerGeometry::Module> > module_construction_container;
+    typedef std::unordered_map<unsigned, std::unique_ptr<HGCalTriggerGeometry::TriggerCell> > trigger_cell_construction_container;
+
+    module_construction_container modules_inconstruction_;
+    trigger_cell_construction_container triggercells_inconstruction_;
+
+    // TODO, move in the CC
+    void finalizeInitialization(){ 
+        // --- make maps const. destroy non const maps
+        // these pointeres are released from the inconstruction and cost cast to be placed in the final geometry
+        for( auto& p : modules_inconstruction_) 
+            modules_ . insert( std::make_pair(p.first, std::unique_ptr<const HGCalTriggerGeometry::Module >(p.second.release()))) ;
+        for(auto&p : triggercells_inconstruction_ ) 
+            trigger_cells_ . insert( std::make_pair(p.first, std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>(p.second.release())) );
+        modules_inconstruction_.clear();
+        triggercells_inconstruction_.clear();
+    } 
+    //
+    HGCalTriggerGeometry::TriggerCell* getTriggerCellFromCellInConstruction( const unsigned cell_det_id); 
+
+    HGCalTriggerGeometry::Module* getModuleFromCellInConstruction( const unsigned cell_det_id); 
+    /* FIXME
+       getTriggerCellFromCell
+       getModuleFromTriggerCell
+       trigger_cells_
+       modules_
+
+*/
+
+    private:
+    const std::string name_;
+    const std::string ee_sd_name_;
+    const std::string fh_sd_name_;
+    const std::string bh_sd_name_;  
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory< HGCalTriggerGeometryBase* (const edm::ParameterSet&) > HGCalTriggerGeometryFactory;
 
 #endif
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -38,8 +38,16 @@
 
 class HGCalTriggerGeometryBase;
 
+
 namespace HGCalTriggerGeometry {
+
+
+  // fwd declaration
+  class HGCalTriggerTopologyFinder;
+
+
   class TriggerCell {
+  friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
   public:
     typedef std::unordered_set<unsigned> list_type;
 
@@ -75,6 +83,7 @@ namespace HGCalTriggerGeometry {
   };
   
   class Module {
+  friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
   public:
     typedef std::unordered_set<unsigned> list_type;
     typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
@@ -120,6 +129,7 @@ namespace HGCalTriggerGeometry {
 }  
 
 class HGCalTriggerGeometryBase { 
+ friend class HGCalTriggerGeometry::HGCalTriggerTopologyFinder;
  public:  
   struct es_info {
     edm::ESHandle<HGCalGeometry> geom_ee, geom_fh, geom_bh;
@@ -172,6 +182,5 @@ class HGCalTriggerGeometryBase {
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory< HGCalTriggerGeometryBase* (const edm::ParameterSet&) > HGCalTriggerGeometryFactory;
-
 
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -92,11 +92,6 @@ namespace HGCalTriggerGeometry{
             HGCalTriggerGeometryModifier* create( const HGCalGeometry &g) override final{ return new T(g); }
     };
 
-/*
-#define REGISTER(classname) \
-    private: \
-             static const HGCalTriggerGeometry::CreatorImpl<classname> _creator_ ;
-             */
 #define REGISTER(classname)\
     namespace { \
     HGCalTriggerGeometry::CreatorImpl<classname> _creator_ (#classname); \
@@ -123,15 +118,6 @@ namespace HGCalTriggerGeometry{
 
     };
 
-    /*
-    class HGCalTriggerGeometryCopy : public HGCalTriggerGeometry::HGCalTriggerGeometryModifier
-    {
-        // copy trigger geometry from hgcal geometry 1->1
-        public: 
-        HGCalTriggerGeometryCopy( const HGCalGeometry &g): HGCalTriggerGeometryModifier(g) {} 
-        int initialize(HGCalTriggerGeometryBase &g ) override final;
-    };
-    */
 
 }; // namespace
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -71,13 +71,16 @@ namespace HGCalTriggerGeometry{
             static HGCalTriggerGeometryModifierFactory& get(){ static HGCalTriggerGeometryModifierFactory instance; return instance; }
             //
             HGCalTriggerGeometryModifier* create(const std::string &name,  const HGCalGeometry &g) ;
-            void inline registerit(const std::string& classname, Creator* creator){table_[classname] = creator;};
+            void inline registerit(const std::string& classname, Creator* creator){
+                std::cout<<"[HGCalTriggerGeometryModifierFactory]"<<"::[INFO]"<<"Registering "<<classname<<std::endl;
+                table_[classname] = creator;
+            };
     };
 
     class Creator{
         public:
             virtual HGCalTriggerGeometryModifier* create(const HGCalGeometry &g)=0;
-            Creator(const std::string& classname) { HGCalTriggerGeometryModifierFactory::get() . registerit(classname,this) ; }
+            Creator(const std::string& classname) { std::cout<<" called creator const for"<<classname<<std::endl; HGCalTriggerGeometryModifierFactory::get() . registerit(classname,this) ; }
     };
     // creator
     template <class T>

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -46,6 +46,7 @@ namespace HGCalTriggerGeometry{
             // -- getTrigger ... In Construction
             HGCalTriggerGeometry::TriggerCell* getTriggerCellFromCellInConstruction( HGCalTriggerGeometryBase &b, unsigned id) { return b . getTriggerCellFromCellInConstruction(id )  ;}
             HGCalTriggerGeometry::Module* getModuleFromCellInConstruction(HGCalTriggerGeometryBase &b, unsigned id){ return b.getModuleFromCellInConstruction( id ) ;}
+            HGCalTriggerGeometry::Module* getModuleFromTriggerCellInConstruction(HGCalTriggerGeometryBase &b, unsigned id){ return b.getModuleFromTriggerCellInConstruction( id ) ;}
 
         public:
             HGCalTriggerGeometryModifier( const HGCalGeometry &g): mGeometry(g) {} 
@@ -121,6 +122,16 @@ namespace HGCalTriggerGeometry{
         { return initTriggerCells(g) | initTriggerModules(g) ; }
 
     };
+
+    /*
+    class HGCalTriggerGeometryCopy : public HGCalTriggerGeometry::HGCalTriggerGeometryModifier
+    {
+        // copy trigger geometry from hgcal geometry 1->1
+        public: 
+        HGCalTriggerGeometryCopy( const HGCalGeometry &g): HGCalTriggerGeometryModifier(g) {} 
+        int initialize(HGCalTriggerGeometryBase &g ) override final;
+    };
+    */
 
 }; // namespace
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -24,17 +24,6 @@
 
 namespace HGCalTriggerGeometry{
 
-    typedef uint8_t TopoBits;
-
-    enum TopoBit{
-        north   = 1UL <<0 ,
-        south   = 1UL <<1,
-        east    = 1UL <<2,
-        west    = 1UL <<3,
-        up      = 1UL <<4,
-        down    = 1UL <<5,
-        generic = 1UL <<6 // if nswe is not known, not guarrantee to be set if something else is
-    };
 
     // base class for a geometry modifier
     class HGCalTriggerGeometryModifier{
@@ -43,13 +32,13 @@ namespace HGCalTriggerGeometry{
             const HGCalGeometry & mGeometry;
 
             // --- the trigger cell modifier base class is friend of TriggerCell and Module: access to their private members 
-            void insertNeighbour(TriggerCell* tc, unsigned tc_id)
+            void insertNeighbour(TriggerCell* tc, unsigned tc_id, HGCalTriggerGeometry::TopoBits tb)
             {
-                tc->neighbours_ . insert( tc_id);
+                tc->neighbours_ . insert( std::make_pair(tc_id,tb));
             }
-            void insertNeighbour(Module* mod, unsigned mod_id)
+            void insertNeighbour(Module* mod, unsigned mod_id, HGCalTriggerGeometry::TopoBits tb)
             {
-                mod -> neighbours_ . insert ( mod_id);
+                mod -> neighbours_ . insert ( std::make_pair(mod_id,tb));
             }
             HGCalTriggerGeometryBase::module_construction_container & get_modules_inconstruction( HGCalTriggerGeometryBase &b) { return b.modules_inconstruction_ ;}
             HGCalTriggerGeometryBase::trigger_cell_construction_container & get_triggercells_inconstruction( HGCalTriggerGeometryBase &b) { return b.triggercells_inconstruction_ ;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -1,0 +1,71 @@
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "Geometry/FCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <map>
+
+/* Original Author: Andrea Carlo Marini
+ * email : andrea.carlo.marini@cern.ch
+ * date : 09/10/2015
+ *
+ * This plugins want to read the HGCal geometry/topology and fill the Trigger geometry with a navigation system.
+ * May be slow, but generic
+ */
+
+#ifndef HGCAL_TRIGGERTOPOLOGY_FINDER_H
+#define HGCAL_TRIGGERTOPOLOGY_FINDER_H 1
+
+namespace HGCalTriggerGeometry{
+
+    typedef uint8_t TopoBits;
+
+    enum TopoBit{
+         north   = 1UL <<0 ,
+         south   = 1UL <<1,
+         east    = 1UL <<2,
+         west    = 1UL <<3,
+         up      = 1UL <<4,
+         down    = 1UL <<5,
+         generic = 1UL <<6 // if nswe is not known, not guarrantee to be set if something else is
+    };
+
+
+class HGCalTriggerTopologyFinder{	
+   // const HGCalTopology & mTopology; geometry knows about topology
+    const HGCalGeometry & mGeometry;
+
+    // fill tr cell neigh
+    int initTC(HGCalTriggerGeometryBase &);
+    //fill tr module neigh
+    int initTM(HGCalTriggerGeometryBase &);
+
+
+public:
+
+    HGCalTriggerTopologyFinder( const HGCalGeometry &g): mGeometry(g) {} 
+   
+    // this is const 
+    inline int initialize(HGCalTriggerGeometryBase &g ) 
+    { return initTC(g) | initTM(g) ; }
+        
+};
+
+}; // namespace
+
+
+#endif
+
+// Local Variables:
+// mode:c++
+// indent-tabs-mode:nil
+// tab-width:4
+// c-basic-offset:4
+// End:
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -39,14 +39,35 @@ namespace HGCalTriggerGeometry{
     // base class for a geometry modifier
     class HGCalTriggerGeometryModifier{
         // * general class to be derived from for a geometry modifier, passed into the init
+        protected:
+            const HGCalGeometry & mGeometry;
+
+            // --- the trigger cell modifier base class is friend of TriggerCell and Module: access to their private members 
+            void insertNeighbour(TriggerCell* tc, unsigned tc_id)
+            {
+                tc->neighbours_ . insert( tc_id);
+            }
+            void insertNeighbour(Module* mod, unsigned mod_id)
+            {
+                mod -> neighbours_ . insert ( mod_id);
+            }
+            HGCalTriggerGeometryBase::module_construction_container & get_modules_inconstruction( HGCalTriggerGeometryBase &b) { return b.modules_inconstruction_ ;}
+            HGCalTriggerGeometryBase::trigger_cell_construction_container & get_triggercells_inconstruction( HGCalTriggerGeometryBase &b) { return b.triggercells_inconstruction_ ;}
+
+            // -- getTrigger ... In Construction
+            HGCalTriggerGeometry::TriggerCell* getTriggerCellFromCellInConstruction( HGCalTriggerGeometryBase &b, unsigned id) { return b . getTriggerCellFromCellInConstruction(id )  ;}
+            HGCalTriggerGeometry::Module* getModuleFromCellInConstruction(HGCalTriggerGeometryBase &b, unsigned id){ return b.getModuleFromCellInConstruction( id ) ;}
+
         public:
+            HGCalTriggerGeometryModifier( const HGCalGeometry &g): mGeometry(g) {} 
             virtual int initialize(HGCalTriggerGeometryBase &g )  =0;
+
     };
 
 
     class HGCalTriggerTopologyFinder : public HGCalTriggerGeometry::HGCalTriggerGeometryModifier {	
         // const HGCalTopology & mTopology; geometry knows about topology
-        const HGCalGeometry & mGeometry;
+        
 
         // fill tr cell neigh
         int initTriggerCells(HGCalTriggerGeometryBase &);
@@ -56,7 +77,7 @@ namespace HGCalTriggerGeometry{
 
         public:
 
-        HGCalTriggerTopologyFinder( const HGCalGeometry &g): mGeometry(g) {} 
+        HGCalTriggerTopologyFinder( const HGCalGeometry &g): HGCalTriggerGeometryModifier(g) {} 
 
         // this is const 
         inline int initialize(HGCalTriggerGeometryBase &g ) 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h
@@ -27,35 +27,42 @@ namespace HGCalTriggerGeometry{
     typedef uint8_t TopoBits;
 
     enum TopoBit{
-         north   = 1UL <<0 ,
-         south   = 1UL <<1,
-         east    = 1UL <<2,
-         west    = 1UL <<3,
-         up      = 1UL <<4,
-         down    = 1UL <<5,
-         generic = 1UL <<6 // if nswe is not known, not guarrantee to be set if something else is
+        north   = 1UL <<0 ,
+        south   = 1UL <<1,
+        east    = 1UL <<2,
+        west    = 1UL <<3,
+        up      = 1UL <<4,
+        down    = 1UL <<5,
+        generic = 1UL <<6 // if nswe is not known, not guarrantee to be set if something else is
+    };
+
+    // base class for a geometry modifier
+    class HGCalTriggerGeometryModifier{
+        // * general class to be derived from for a geometry modifier, passed into the init
+        public:
+            virtual int initialize(HGCalTriggerGeometryBase &g )  =0;
     };
 
 
-class HGCalTriggerTopologyFinder{	
-   // const HGCalTopology & mTopology; geometry knows about topology
-    const HGCalGeometry & mGeometry;
+    class HGCalTriggerTopologyFinder : public HGCalTriggerGeometry::HGCalTriggerGeometryModifier {	
+        // const HGCalTopology & mTopology; geometry knows about topology
+        const HGCalGeometry & mGeometry;
 
-    // fill tr cell neigh
-    int initTC(HGCalTriggerGeometryBase &);
-    //fill tr module neigh
-    int initTM(HGCalTriggerGeometryBase &);
+        // fill tr cell neigh
+        int initTriggerCells(HGCalTriggerGeometryBase &);
+        //fill tr module neigh
+        int initTriggerModules(HGCalTriggerGeometryBase &);
 
 
-public:
+        public:
 
-    HGCalTriggerTopologyFinder( const HGCalGeometry &g): mGeometry(g) {} 
-   
-    // this is const 
-    inline int initialize(HGCalTriggerGeometryBase &g ) 
-    { return initTC(g) | initTM(g) ; }
-        
-};
+        HGCalTriggerTopologyFinder( const HGCalGeometry &g): mGeometry(g) {} 
+
+        // this is const 
+        inline int initialize(HGCalTriggerGeometryBase &g ) 
+        { return initTriggerCells(g) | initTriggerModules(g) ; }
+
+    };
 
 }; // namespace
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -108,6 +108,7 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
     //
     // Build modules and fill map
     typedef HGCalTriggerGeometry::Module::list_type list_triggercells;
+    typedef HGCalTriggerGeometry::Module::tc_map_type tc_map_to_cells;
     // make list of trigger cells in modules
     std::map<unsigned, list_triggercells> modules_to_trigger_cells;
     for(const auto& triggercell_module : trigger_cells_to_modules_)
@@ -121,15 +122,20 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
     {
         unsigned moduleId = module_triggercell.first;
         list_triggercells triggercellIds = module_triggercell.second;
+        tc_map_to_cells cellsInTriggerCells;
         // Position: for the moment, barycenter of the module, from trigger cell positions
         Basic3DVector<float> moduleVector(0.,0.,0.);
         for(const auto& triggercell : triggercellIds)
         {
+            const auto& cells_in_tc = trigger_cells_to_cells[triggercell];
+            for( const unsigned cell : cells_in_tc ) {
+              cellsInTriggerCells.emplace(triggercell,cell);
+            }
             moduleVector += trigger_cells_.at(triggercell)->position().basicVector();
         }
         GlobalPoint modulePoint( moduleVector/triggercellIds.size() );
         // FIXME: empty neighbours
-        std::unique_ptr<const HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds));
+        std::unique_ptr<const HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds, cellsInTriggerCells));
         modules_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
     }
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <fstream>
 
-#define DEBUG 1
+//#define DEBUG 1
 
 #ifdef DEBUG
 #include <iostream>
@@ -69,6 +69,7 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
             for(unsigned sector=1; sector<=18; sector++)
             {
                 HGCEEDetId detid(HGCEE, zside, layer, sector, subsector, cell); 
+	
                 // 
                 // Fill cell -> trigger cell mapping
                 HGCTriggerDetId triggerDetid(HGCTrigger, zside, layer, sector, module, triggercell); 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -101,8 +101,8 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
         const auto& tc2mItr = trigger_cells_to_modules_.find(triggercellId);
         unsigned moduleId = (tc2mItr!=trigger_cells_to_modules_.end() ? tc2mItr->second : 0); // 0 if the trigger cell doesn't belong to a module
         //unsigned moduleId = trigger_cells_to_modules_.at(triggercellId);
-        // FIXME: empty neighbours
-        std::unique_ptr<HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, list_cells(), cellIds));
+        // FIXME: empty neighbours. will be filled by the geometry modifier
+        std::unique_ptr<HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, HGCalTriggerGeometry::topo_list_type(), cellIds));
         triggercells_inconstruction_.insert( std::make_pair(triggercellId, std::move(triggercellPtr)) );
     }
     //
@@ -134,8 +134,8 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
             moduleVector += trigger_cells_.at(triggercell)->position().basicVector();
         }
         GlobalPoint modulePoint( moduleVector/triggercellIds.size() );
-        // FIXME: empty neighbours
-        std::unique_ptr<HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds, cellsInTriggerCells));
+        // FIXME: empty neighbours. Will be filled by the Geometry Modifier
+        std::unique_ptr<HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, HGCalTriggerGeometry::topo_list_type(), triggercellIds, cellsInTriggerCells));
         modules_inconstruction_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
     }
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -142,7 +142,7 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
     // --- call the modifiers
 	initModifiers();
     // --- froze the geometry in the const structures
-	finilizeInitialization();
+	finalizeInitialization();
 }
 
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -102,8 +102,8 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
         unsigned moduleId = (tc2mItr!=trigger_cells_to_modules_.end() ? tc2mItr->second : 0); // 0 if the trigger cell doesn't belong to a module
         //unsigned moduleId = trigger_cells_to_modules_.at(triggercellId);
         // FIXME: empty neighbours
-        std::unique_ptr<const HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, list_cells(), cellIds));
-        trigger_cells_.insert( std::make_pair(triggercellId, std::move(triggercellPtr)) );
+        std::unique_ptr<HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, list_cells(), cellIds));
+        triggercells_inconstruction_.insert( std::make_pair(triggercellId, std::move(triggercellPtr)) );
     }
     //
     // Build modules and fill map
@@ -135,9 +135,14 @@ void HGCalTriggerGeometryImp1::initialize(const es_info& esInfo)
         }
         GlobalPoint modulePoint( moduleVector/triggercellIds.size() );
         // FIXME: empty neighbours
-        std::unique_ptr<const HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds, cellsInTriggerCells));
-        modules_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
+        std::unique_ptr<HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, list_triggercells(), triggercellIds, cellsInTriggerCells));
+        modules_inconstruction_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
     }
+
+    // --- call the modifiers
+	initModifiers();
+    // --- froze the geometry in the const structures
+	finilizeInitialization();
 }
 
 

--- a/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
@@ -19,9 +19,11 @@ public:
       
       HGCalTriggerGeometry::Module::list_type mod_empty;
       HGCalTriggerGeometry::Module::list_type mod_comps = { i };
+      HGCalTriggerGeometry::Module::tc_map_type map_empty;
       modules_[i].reset( new HGCalTriggerGeometry::Module(i,GlobalPoint(),
                                                           mod_empty,
-                                                          mod_comps) );
+                                                          mod_comps,
+                                                          map_empty) );
     }
   }
 };

--- a/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
@@ -12,16 +12,17 @@ public:
       trigger_cells_to_modules_[i] = i;
 
       HGCalTriggerGeometry::TriggerCell::list_type tc_empty;
+      HGCalTriggerGeometry::topo_list_type neigh_empty;
       trigger_cells_[i].reset( new HGCalTriggerGeometry::TriggerCell(i,i,
                                                                      GlobalPoint(),
-                                                                     tc_empty,
+                                                                     neigh_empty,
                                                                      tc_empty) );
       
       HGCalTriggerGeometry::Module::list_type mod_empty;
       HGCalTriggerGeometry::Module::list_type mod_comps = { i };
       HGCalTriggerGeometry::Module::tc_map_type map_empty;
       modules_[i].reset( new HGCalTriggerGeometry::Module(i,GlobalPoint(),
-                                                          mod_empty,
+                                                          neigh_empty,
                                                           mod_comps,
                                                           map_empty) );
     }

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -17,6 +17,7 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     TriggerGeometry = cms.PSet(
         TriggerGeometryName = cms.string('HGCalTriggerGeometryImp1'),
         L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/cellsToTriggerCellsMap.txt"),
+	geometryModifiers = cms.vstring(["HGCalTriggerGeometry::HGCalTriggerTopologyFinder"]),
         eeSDName = cms.string('HGCalEESensitive'),
         fhSDName = cms.string('HGCalHESiliconSensitive'),
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -80,6 +80,19 @@ HGCalTriggerGeometry::Module* HGCalTriggerGeometryBase::getModuleFromCellInConst
 void HGCalTriggerGeometryBase::finalizeInitialization(){ 
         // --- make maps const. destroy non const maps
         // these pointeres are released from the inconstruction and cost cast to be placed in the final geometry
+	
+	// check if modules_ and trigger_cells_ are empty
+	if (not modules_ . empty() )
+	{
+		edm::LogWarning("HGCalTriggerGeometryBase") <<
+			" modules map is not empty in finalization of the geometry modifiers. ";
+	}
+	if (not trigger_cells_ . empty() )
+	{
+		edm::LogWarning("HGCalTriggerGeometryBase") <<
+			" trigger cells map is not empty in finalization of the geometry modifiers";
+	}
+	//---      
         for( auto& p : modules_inconstruction_) 
             modules_ . insert( std::make_pair(p.first, std::unique_ptr<const HGCalTriggerGeometry::Module >(p.second.release()))) ;
         for(auto&p : triggercells_inconstruction_ ) 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -102,6 +102,5 @@ void HGCalTriggerGeometryBase::finalizeInitialization(){
  } 
 
 
-
 EDM_REGISTER_PLUGINFACTORY(HGCalTriggerGeometryFactory,
 			   "HGCalTriggerGeometryFactory");

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -70,8 +70,16 @@ HGCalTriggerGeometry::TriggerCell* HGCalTriggerGeometryBase::getTriggerCellFromC
 
 HGCalTriggerGeometry::Module* HGCalTriggerGeometryBase::getModuleFromCellInConstruction( const unsigned cell_det_id) { 
         auto found_tc = cells_to_trigger_cells_.find(cell_det_id) ; 
-        if (found_tc == cells_to_trigger_cells_.end() ) return (Module*)(NULL); 
-        auto found_mod = trigger_cells_to_modules_.find(found_tc->second);
+        if (found_tc == cells_to_trigger_cells_.end() )
+	{
+		return (Module*)(NULL); 
+	}
+	return getModuleFromTriggerCellInConstruction(found_tc->second);
+
+}
+
+HGCalTriggerGeometry::Module* HGCalTriggerGeometryBase::getModuleFromTriggerCellInConstruction( const unsigned trcell_det_id) {    
+        auto found_mod = trigger_cells_to_modules_.find( trcell_det_id);
         if(found_mod == trigger_cells_to_modules_.end() ) return (Module*)(NULL);
         return modules_inconstruction_ . find( found_mod->second) ->second.get();
     }

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h"
 
 using namespace HGCalTriggerGeometry;
 
@@ -55,6 +56,27 @@ getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const {
   }
   return modules_.find(found_mod->second)->second;
 }
+
+void HGCalTriggerGeometryBase::initModifiers(){ 
+	 for (auto &gMod : geometryModifiers_) gMod -> initialize( *this); 
+ }
+
+// the unique pointers don't loose ownership
+HGCalTriggerGeometry::TriggerCell* HGCalTriggerGeometryBase::getTriggerCellFromCellInConstruction( const unsigned cell_det_id) { 
+        auto found_tc = cells_to_trigger_cells_.find(cell_det_id) ; 
+        if (found_tc == cells_to_trigger_cells_.end()) return (TriggerCell*)(NULL);
+        return triggercells_inconstruction_.find( found_tc ->second)->second.get(); 
+    }
+
+HGCalTriggerGeometry::Module* HGCalTriggerGeometryBase::getModuleFromCellInConstruction( const unsigned cell_det_id) { 
+        auto found_tc = cells_to_trigger_cells_.find(cell_det_id) ; 
+        if (found_tc == cells_to_trigger_cells_.end() ) return (Module*)(NULL); 
+        auto found_mod = trigger_cells_to_modules_.find(found_tc->second);
+        if(found_mod == trigger_cells_to_modules_.end() ) return (Module*)(NULL);
+        return modules_inconstruction_ . find( found_mod->second) ->second.get();
+    }
+
+
 
 EDM_REGISTER_PLUGINFACTORY(HGCalTriggerGeometryFactory,
 			   "HGCalTriggerGeometryFactory");

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -77,6 +77,18 @@ HGCalTriggerGeometry::Module* HGCalTriggerGeometryBase::getModuleFromCellInConst
     }
 
 
+void HGCalTriggerGeometryBase::finalizeInitialization(){ 
+        // --- make maps const. destroy non const maps
+        // these pointeres are released from the inconstruction and cost cast to be placed in the final geometry
+        for( auto& p : modules_inconstruction_) 
+            modules_ . insert( std::make_pair(p.first, std::unique_ptr<const HGCalTriggerGeometry::Module >(p.second.release()))) ;
+        for(auto&p : triggercells_inconstruction_ ) 
+            trigger_cells_ . insert( std::make_pair(p.first, std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>(p.second.release())) );
+        modules_inconstruction_.clear();
+        triggercells_inconstruction_.clear();
+ } 
+
+
 
 EDM_REGISTER_PLUGINFACTORY(HGCalTriggerGeometryFactory,
 			   "HGCalTriggerGeometryFactory");

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -35,7 +35,13 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
         {
             //- find the tr cells that corresponds to the neigh cells
             //unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
-            unsigned neigh_tc =  getTriggerCellFromCellInConstruction(mTriggerGeometry, n.first ) -> triggerCellId();
+	    //
+	    TriggerCell *triggercell = getTriggerCellFromCellInConstruction(mTriggerGeometry, n.first ) ;
+	    if (triggercell == NULL) {
+	   		cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")<<
+				"Trigger Cell referenced but not present in the map";
+	    }
+            unsigned neigh_tc =  triggercell -> triggerCellId();
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
@@ -70,7 +76,12 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            unsigned neigh_mod =  getModuleFromCellInConstruction(mTriggerGeometry, n.first ) -> moduleId();
+	    Module *module = getModuleFromCellInConstruction(mTriggerGeometry, n.first );
+	    if ( module == NULL) {
+	    	cms::Exception("HGCalTriggerTopologyFinder::initTriggerModule")<<
+			"Trigger Module referenced but not present in the map";
+	    }
+            unsigned neigh_mod =  module -> moduleId();
             //- remove the cells that are in the trigger cell
             if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -60,12 +60,19 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
 				compstream <<"\n";
 			}
 
-	   		throw cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")
-				<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
-				<< compstream.str() 
-				<<", but not present in the map";
-	    }
+	   		// throw cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")
+			// 	<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
+			// 	<< compstream.str() 
+			// 	<<", but not present in the map";
 
+			//std::cout 	<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
+			//	<< compstream.str() 
+			//	<<", but not present in the map"
+			//	<<std::endl;
+			//continue;
+	    }
+	
+	    if (triggercell == NULL) continue;
 
             unsigned neigh_tc =  triggercell -> triggerCellId();
             //- remove the cells that are in the trigger cell
@@ -96,7 +103,8 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         {
             // I used these methods, so if we want to collect also this informations is simplier
 	    //                                                                  [ id ] remove const 
-            for (const auto & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
+            //for (const auto & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
+            for (const auto & tcell_n : get_triggercells_inconstruction ( mTriggerGeometry) . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
                 neigh[ tcell_n.first ] |=  tcell_n.second; 
 	    	// auto is a topo_list_type
                 //neigh[ tcell_n ] |=  HGCalTriggerGeometry::generic; // TODO -- north sud ovest west
@@ -106,7 +114,7 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-	    Module *module = getModuleFromCellInConstruction(mTriggerGeometry, n.first );
+	    Module *module = getModuleFromTriggerCellInConstruction(mTriggerGeometry, n.first );
 	    if ( module == NULL) {
 		        std::stringstream compstream("");
 		 	for(auto & mod : tmod.second -> components()  ) compstream << mod<<" " ;
@@ -141,3 +149,26 @@ HGCalTriggerGeometry::HGCalTriggerGeometryModifier* HGCalTriggerGeometryModifier
                 };
 
 REGISTER(HGCalTriggerGeometry::HGCalTriggerTopologyFinder);
+
+/*
+int HGCalTriggerGeometry::HGCalTriggerGeometryCopy::initialize(HGCalTriggerGeometryBase &g){
+	// populate trigger cell
+    	short layer       = 0;
+    	short subsector   = 0;
+    	short cell        = 0;
+    	short module      = 0;
+    	short triggercell = 0;
+       HGCEEDetId detid(HGCEE, zside, layer, sector, subsector, cell); 
+       HGCTriggerDetId triggerDetid(HGCTrigger, zside, layer, sector, module, triggercell); 
+       const auto& ret = cells_to_trigger_cells_.insert( std::make_pair(detid, triggerDetid) );
+       trigger_cells_to_modules_.insert( std::make_pair(triggerDetid, moduleDetid) ); 
+       //
+        std::unique_ptr<HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, HGCalTriggerGeometry::topo_list_type(), cellIds));
+        triggercells_inconstruction_.insert( std::make_pair(triggercellId, std::move(triggercellPtr)) );
+	
+        std::unique_ptr<HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, HGCalTriggerGeometry::topo_list_type(), triggercellIds, cellsInTriggerCells));
+        modules_inconstruction_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
+}
+
+REGISTER(HGCalTriggerGeometry::HGCalTriggerGeometryCopy);
+*/

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -94,3 +94,11 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
 
     return 0;
 }
+
+HGCalTriggerGeometry::HGCalTriggerGeometryModifier* HGCalTriggerGeometryModifierFactory::create(const std::string &name,  const HGCalGeometry &g) {
+                const auto& i = table_.find(name);
+                if ( i == table_.end() ) return (HGCalTriggerGeometryModifier*)NULL;
+                else return i -> second ->create(g);
+                };
+
+REGISTER(HGCalTriggerGeometry::HGCalTriggerTopologyFinder);

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -36,49 +36,16 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            //unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
-	    //
 
 	    TriggerCell *triggercell = getTriggerCellFromCellInConstruction(mTriggerGeometry, n.first ) ;
-	    if (triggercell == NULL) {
-		        std::stringstream compstream("");
-		 	for(auto & cell : tcell.second -> components()  ) 
-			{
-				compstream << cell<<": " ; // I need to reapet because I want the neigh per HGCal Cell for debug
-				for(auto & nb_id :  mTopology . north( cell) )
-					compstream <<"N "<< unsigned(nb_id )<<"|";
-				for(auto & nb_id :  mTopology . south( cell)  )
-					compstream <<"S " << unsigned(nb_id) <<"|";
-				for(auto & nb_id :  mTopology . east( cell) )
-					compstream <<"E " << unsigned(nb_id) <<"|";
-				for(auto & nb_id :  mTopology . west( cell) )
-					compstream <<"W " << unsigned(nb_id) <<"|";
-				for(auto & nb_id :  mTopology . up( cell) )
-					compstream <<"U " << unsigned(nb_id) <<"|";
-				for(auto & nb_id :  mTopology . down( cell) )
-					compstream <<"D " << unsigned(nb_id) <<"|";
-				compstream <<"\n";
-			}
-
-	   		// throw cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")
-			// 	<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
-			// 	<< compstream.str() 
-			// 	<<", but not present in the map";
-
-			//std::cout 	<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
-			//	<< compstream.str() 
-			//	<<", but not present in the map"
-			//	<<std::endl;
-			//continue;
-	    }
-	
+			
+	    // when the navigation in the underlaying geometry should give only existing and valid cells, throw an exceptions, instead of ignoring
 	    if (triggercell == NULL) continue;
 
             unsigned neigh_tc =  triggercell -> triggerCellId();
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-            //tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions
 	    insertNeighbour( tcell.second.get(), neigh_tc, n.second);
         }
     } // tcell loop
@@ -103,11 +70,9 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         {
             // I used these methods, so if we want to collect also this informations is simplier
 	    //                                                                  [ id ] remove const 
-            //for (const auto & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
             for (const auto & tcell_n : get_triggercells_inconstruction ( mTriggerGeometry) . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
                 neigh[ tcell_n.first ] |=  tcell_n.second; 
 	    	// auto is a topo_list_type
-                //neigh[ tcell_n ] |=  HGCalTriggerGeometry::generic; // TODO -- north sud ovest west
 
         } // components loop
         // ---
@@ -129,7 +94,6 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
             //- remove the cells that are in the trigger cell
             if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-            //tmod . second  -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
 	    insertNeighbour( tmod . second.get(), neigh_mod, n.second );
         }
     } // tcell loop
@@ -150,25 +114,3 @@ HGCalTriggerGeometry::HGCalTriggerGeometryModifier* HGCalTriggerGeometryModifier
 
 REGISTER(HGCalTriggerGeometry::HGCalTriggerTopologyFinder);
 
-/*
-int HGCalTriggerGeometry::HGCalTriggerGeometryCopy::initialize(HGCalTriggerGeometryBase &g){
-	// populate trigger cell
-    	short layer       = 0;
-    	short subsector   = 0;
-    	short cell        = 0;
-    	short module      = 0;
-    	short triggercell = 0;
-       HGCEEDetId detid(HGCEE, zside, layer, sector, subsector, cell); 
-       HGCTriggerDetId triggerDetid(HGCTrigger, zside, layer, sector, module, triggercell); 
-       const auto& ret = cells_to_trigger_cells_.insert( std::make_pair(detid, triggerDetid) );
-       trigger_cells_to_modules_.insert( std::make_pair(triggerDetid, moduleDetid) ); 
-       //
-        std::unique_ptr<HGCalTriggerGeometry::TriggerCell> triggercellPtr(new HGCalTriggerGeometry::TriggerCell(triggercellId, moduleId, triggercellPoint, HGCalTriggerGeometry::topo_list_type(), cellIds));
-        triggercells_inconstruction_.insert( std::make_pair(triggercellId, std::move(triggercellPtr)) );
-	
-        std::unique_ptr<HGCalTriggerGeometry::Module> modulePtr(new HGCalTriggerGeometry::Module(moduleId, modulePoint, HGCalTriggerGeometry::topo_list_type(), triggercellIds, cellsInTriggerCells));
-        modules_inconstruction_.insert( std::make_pair(moduleId, std::move(modulePtr)) );
-}
-
-REGISTER(HGCalTriggerGeometry::HGCalTriggerGeometryCopy);
-*/

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -4,6 +4,8 @@ using namespace HGCalTriggerGeometry;
 
 int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTriggerGeometryBase & mTriggerGeometry) 
 {
+   edm::LogInfo("HGCalTriggerTopologyFinder::initTriggerCells")<<
+	   "Initialiazing trigger cell topology from hgcal topology";
 
     const HGCalTopology& mTopology =  mGeometry.topology () ;
     // I need access to the non-const objects
@@ -36,11 +38,35 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
             //- find the tr cells that corresponds to the neigh cells
             //unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
 	    //
+
 	    TriggerCell *triggercell = getTriggerCellFromCellInConstruction(mTriggerGeometry, n.first ) ;
 	    if (triggercell == NULL) {
-	   		cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")<<
-				"Trigger Cell referenced but not present in the map";
+		        std::stringstream compstream("");
+		 	for(auto & cell : tcell.second -> components()  ) 
+			{
+				compstream << cell<<": " ; // I need to reapet because I want the neigh per HGCal Cell for debug
+				for(auto & nb_id :  mTopology . north( cell) )
+					compstream <<"N "<< unsigned(nb_id )<<"|";
+				for(auto & nb_id :  mTopology . south( cell)  )
+					compstream <<"S " << unsigned(nb_id) <<"|";
+				for(auto & nb_id :  mTopology . east( cell) )
+					compstream <<"E " << unsigned(nb_id) <<"|";
+				for(auto & nb_id :  mTopology . west( cell) )
+					compstream <<"W " << unsigned(nb_id) <<"|";
+				for(auto & nb_id :  mTopology . up( cell) )
+					compstream <<"U " << unsigned(nb_id) <<"|";
+				for(auto & nb_id :  mTopology . down( cell) )
+					compstream <<"D " << unsigned(nb_id) <<"|";
+				compstream <<"\n";
+			}
+
+	   		throw cms::Exception("HGCalTriggerTopologyFinder::initTriggerCells")
+				<<"HGCal Cell ID="<<n.first <<" referenced in trigger cell (id="<< tcell.first<<")  components:"
+				<< compstream.str() 
+				<<", but not present in the map";
 	    }
+
+
             unsigned neigh_tc =  triggercell -> triggerCellId();
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
@@ -50,7 +76,8 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
         }
     } // tcell loop
 
-    return 0;
+   edm::LogInfo("HGCalTriggerTopologyFinder::initTriggerCells")<<"Done";
+   return 0;
 }
 
 // ----
@@ -58,6 +85,7 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
 {
 
     // I need access to the non-const objects
+   edm::LogInfo("HGCalTriggerTopologyFinder::initTriggerModules")<<"init module topology from trigger cell topology";
 
     // loop over modules
     for( auto & tmod : get_modules_inconstruction(mTriggerGeometry) ) //  map : unsigned ->  Module
@@ -80,8 +108,14 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
             //- find the tr cells that corresponds to the neigh cells
 	    Module *module = getModuleFromCellInConstruction(mTriggerGeometry, n.first );
 	    if ( module == NULL) {
-	    	cms::Exception("HGCalTriggerTopologyFinder::initTriggerModule")<<
-			"Trigger Module referenced but not present in the map";
+		        std::stringstream compstream("");
+		 	for(auto & mod : tmod.second -> components()  ) compstream << mod<<" " ;
+
+	    		throw cms::Exception("HGCalTriggerTopologyFinder::initTriggerModule")
+				<<"Trigger Cell ID="<<n.first
+				<<" referenced in trigger module ("<<tmod.first<<") components:"
+				<< compstream.str()
+				<<", but not present in the map";
 	    }
             unsigned neigh_mod =  module -> moduleId();
             //- remove the cells that are in the trigger cell
@@ -92,12 +126,17 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         }
     } // tcell loop
 
+   edm::LogInfo("HGCalTriggerTopologyFinder::initTriggerModules")<<"Done";
     return 0;
 }
 
 HGCalTriggerGeometry::HGCalTriggerGeometryModifier* HGCalTriggerGeometryModifierFactory::create(const std::string &name,  const HGCalGeometry &g) {
                 const auto& i = table_.find(name);
-                if ( i == table_.end() ) return (HGCalTriggerGeometryModifier*)NULL;
+                if ( i == table_.end() ) {
+			throw cms::Exception("HGCalTriggerGeometryModifierFactory::create")<< 
+				"Unable to construct class named "<<name;
+			return (HGCalTriggerGeometryModifier*)NULL;
+		}
                 else return i -> second ->create(g);
                 };
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -45,8 +45,8 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-            //tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
-	    insertNeighbour( tcell.second.get(), neigh_tc);
+            //tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions
+	    insertNeighbour( tcell.second.get(), neigh_tc, n.second);
         }
     } // tcell loop
 
@@ -68,8 +68,10 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         {
             // I used these methods, so if we want to collect also this informations is simplier
 	    //                                                                  [ id ] remove const 
-            for (const unsigned & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
-                neigh[ tcell_n ] |=  HGCalTriggerGeometry::generic; // TODO -- north sud ovest west
+            for (const auto & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
+                neigh[ tcell_n.first ] |=  tcell_n.second; 
+	    	// auto is a topo_list_type
+                //neigh[ tcell_n ] |=  HGCalTriggerGeometry::generic; // TODO -- north sud ovest west
 
         } // components loop
         // ---
@@ -86,7 +88,7 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
             if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
             //tmod . second  -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
-	    insertNeighbour( tmod . second.get(), neigh_mod );
+	    insertNeighbour( tmod . second.get(), neigh_mod, n.second );
         }
     } // tcell loop
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -9,7 +9,7 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
     // I need access to the non-const objects
 
     // loop over cells
-    for( auto & tcell : mTriggerGeometry.triggercells_inconstruction_) // trigger cells map : unsigned -> triggerCell
+    for( auto & tcell : get_triggercells_inconstruction(mTriggerGeometry)) // trigger cells map : unsigned -> triggerCell
     {
         std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
 
@@ -34,11 +34,13 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTrig
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
+            //unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
+            unsigned neigh_tc =  getTriggerCellFromCellInConstruction(mTriggerGeometry, n.first ) -> triggerCellId();
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-            tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
+            //tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
+	    insertNeighbour( tcell.second.get(), neigh_tc);
         }
     } // tcell loop
 
@@ -52,7 +54,7 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
     // I need access to the non-const objects
 
     // loop over modules
-    for( auto & tmod : mTriggerGeometry.modules_inconstruction_ ) //  map : unsigned ->  Module
+    for( auto & tmod : get_modules_inconstruction(mTriggerGeometry) ) //  map : unsigned ->  Module
     {
         std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
 
@@ -68,11 +70,12 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTr
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            unsigned neigh_mod =  mTriggerGeometry . getModuleFromCellInConstruction( n.first ) -> moduleId();
+            unsigned neigh_mod =  getModuleFromCellInConstruction(mTriggerGeometry, n.first ) -> moduleId();
             //- remove the cells that are in the trigger cell
             if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-            tmod . second  -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
+            //tmod . second  -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
+	    insertNeighbour( tmod . second.get(), neigh_mod );
         }
     } // tcell loop
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -1,0 +1,82 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTopologyFinder.h"
+
+using namespace HGCalTriggerGeometry;
+
+int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTC(HGCalTriggerGeometryBase & mTriggerGeometry) 
+{
+
+    const HGCalTopology& mTopology =  mGeometry.topology () ;
+    // I need access to the non-const objects
+
+    // loop over cells
+    for( auto & tcell : mTriggerGeometry.trigger_cells_ ) // trigger cells map : unsigned -> triggerCell
+    {
+        std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
+
+        for(auto & cell : tcell.second -> components()  )
+        {
+            // I used these methods, so if we want to collect also this informations is simplier
+            for (auto id : mTopology . north( cell )  )
+                neigh[id] |=  HGCalTriggerGeometry::north;
+            for (auto id : mTopology . south( cell  ) )
+                neigh[id] |=  HGCalTriggerGeometry::south;
+            for (auto id : mTopology . east(  cell  ) )
+                neigh[id] |=  HGCalTriggerGeometry::east;
+            for (auto id : mTopology . west( cell  ) )
+                neigh[id] |=  HGCalTriggerGeometry::west;
+            for (auto id : mTopology . up(    cell  ) )
+                neigh[id] |=  HGCalTriggerGeometry::up;
+            for (auto id : mTopology . down(  cell  ) )
+                neigh[id] |=  HGCalTriggerGeometry::down;
+
+        } // components loop
+        // ---
+        for (auto & n : neigh ) 
+        {
+            //- find the tr cells that corresponds to the neigh cells
+            unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCell( n.first ) -> triggerCellId();
+            //- remove the cells that are in the trigger cell
+            if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
+            //- add them to the list of neighbours
+	    //I need to cast away constantness :(
+            const_cast<HGCalTriggerGeometry::TriggerCell*> (tcell . second .get()) -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
+        }
+    } // tcell loop
+
+    return 0;
+}
+
+// ----
+int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTM(HGCalTriggerGeometryBase & mTriggerGeometry) 
+{
+
+    // I need access to the non-const objects
+
+    // loop over modules
+    for( auto & tmod : mTriggerGeometry.modules_ ) //  map : unsigned ->  Module
+    {
+        std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
+
+        for(const unsigned & tcell_id : tmod.second -> components()  )
+        {
+            // I used these methods, so if we want to collect also this informations is simplier
+	    //                                                                  [ id ] remove const 
+            for (const unsigned & tcell_n : mTriggerGeometry . triggerCells() . find( tcell_id ) -> second -> neighbours()  ) // neihbours tr cells are filled
+                neigh[ tcell_n ] |=  HGCalTriggerGeometry::generic; // TODO -- north sud ovest west
+
+        } // components loop
+        // ---
+        for (auto & n : neigh ) 
+        {
+            //- find the tr cells that corresponds to the neigh cells
+            unsigned neigh_mod =  mTriggerGeometry . getModuleFromTriggerCell( n.first ) -> moduleId();
+            //- remove the cells that are in the trigger cell
+            if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
+            //- add them to the list of neighbours
+	    //I need to cast away constantness :(
+            const_cast<HGCalTriggerGeometry::Module*> (tmod . second .get()) -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
+        }
+    } // tcell loop
+
+    return 0;
+}

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTopologyFinder.cc
@@ -2,14 +2,14 @@
 
 using namespace HGCalTriggerGeometry;
 
-int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTC(HGCalTriggerGeometryBase & mTriggerGeometry) 
+int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerCells(HGCalTriggerGeometryBase & mTriggerGeometry) 
 {
 
     const HGCalTopology& mTopology =  mGeometry.topology () ;
     // I need access to the non-const objects
 
     // loop over cells
-    for( auto & tcell : mTriggerGeometry.trigger_cells_ ) // trigger cells map : unsigned -> triggerCell
+    for( auto & tcell : mTriggerGeometry.triggercells_inconstruction_) // trigger cells map : unsigned -> triggerCell
     {
         std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
 
@@ -34,12 +34,11 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTC(HGCalTriggerGeometr
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCell( n.first ) -> triggerCellId();
+            unsigned neigh_tc =  mTriggerGeometry . getTriggerCellFromCellInConstruction( n.first ) -> triggerCellId();
             //- remove the cells that are in the trigger cell
             if (neigh_tc == tcell.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-	    //I need to cast away constantness :(
-            const_cast<HGCalTriggerGeometry::TriggerCell*> (tcell . second .get()) -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
+            tcell . second  -> neighbours_ . insert (  neigh_tc ) ; // use n.second if you want directions TODO
         }
     } // tcell loop
 
@@ -47,13 +46,13 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTC(HGCalTriggerGeometr
 }
 
 // ----
-int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTM(HGCalTriggerGeometryBase & mTriggerGeometry) 
+int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTriggerModules(HGCalTriggerGeometryBase & mTriggerGeometry) 
 {
 
     // I need access to the non-const objects
 
     // loop over modules
-    for( auto & tmod : mTriggerGeometry.modules_ ) //  map : unsigned ->  Module
+    for( auto & tmod : mTriggerGeometry.modules_inconstruction_ ) //  map : unsigned ->  Module
     {
         std::map< unsigned, HGCalTriggerGeometry::TopoBits >  neigh;
 
@@ -69,12 +68,11 @@ int HGCalTriggerGeometry::HGCalTriggerTopologyFinder::initTM(HGCalTriggerGeometr
         for (auto & n : neigh ) 
         {
             //- find the tr cells that corresponds to the neigh cells
-            unsigned neigh_mod =  mTriggerGeometry . getModuleFromTriggerCell( n.first ) -> moduleId();
+            unsigned neigh_mod =  mTriggerGeometry . getModuleFromCellInConstruction( n.first ) -> moduleId();
             //- remove the cells that are in the trigger cell
             if (neigh_mod == tmod.first) continue; // I am what I am and what I am needs no excuses
             //- add them to the list of neighbours
-	    //I need to cast away constantness :(
-            const_cast<HGCalTriggerGeometry::Module*> (tmod . second .get()) -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
+            tmod . second  -> neighbours_ . insert (  neigh_mod ) ; // use n.second if you want directions TODO
         }
     } // tcell loop
 


### PR DESCRIPTION
#4
- Portable implementation of a neighbours finder: may be slow, but should work with any geometry and topology. 
- Not sure if it is better in the library, and eventually call it from the geometry construction 
    geom::initiliaze(..) { ... }
  or have it as a sperate plugin.
- Not sure if you like all constructions. (const_cast, friend) 
- The next thing to add before merging (**TODO**) is the directional navigation n-s-w-e-u-d (here partially suggested)
- @lgray, can you remind me how to run run_matrix, and I will test it.
