### PR TITLE
Add trigger cell mapping writer for firmware

### DIFF
--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerCellIndexWriter.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerCellIndexWriter.cc
@@ -1,0 +1,175 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "TTree.h"
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include <stdlib.h> 
+
+
+class HGCalTriggerCellIndexWriter : public edm::EDAnalyzer 
+{
+    public:
+        explicit HGCalTriggerCellIndexWriter(const edm::ParameterSet& );
+        ~HGCalTriggerCellIndexWriter();
+
+        virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+
+    private:
+        void writeTriggerCellMapping(const HGCalTriggerGeometryBase::es_info&);
+        std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_; 
+        //
+};
+
+
+/*****************************************************************/
+HGCalTriggerCellIndexWriter::HGCalTriggerCellIndexWriter(const edm::ParameterSet& conf) 
+/*****************************************************************/
+{
+    //setup geometry 
+    const edm::ParameterSet& geometryConfig = conf.getParameterSet("TriggerGeometry");
+    const std::string& trigGeomName = geometryConfig.getParameter<std::string>("TriggerGeometryName");
+    HGCalTriggerGeometryBase* geometry = HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
+    triggerGeometry_.reset(geometry);
+
+}
+
+
+
+/*****************************************************************/
+HGCalTriggerCellIndexWriter::~HGCalTriggerCellIndexWriter() 
+/*****************************************************************/
+{
+}
+
+/*****************************************************************/
+void HGCalTriggerCellIndexWriter::beginRun(const edm::Run& /*run*/, 
+                                          const edm::EventSetup& es)
+/*****************************************************************/
+{
+    triggerGeometry_->reset();
+    HGCalTriggerGeometryBase::es_info info;
+    const std::string& ee_sd_name = triggerGeometry_->eeSDName();
+    const std::string& fh_sd_name = triggerGeometry_->fhSDName();
+    const std::string& bh_sd_name = triggerGeometry_->bhSDName();
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.geom_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.geom_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.geom_bh);
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.topo_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.topo_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.topo_bh);
+    triggerGeometry_->initialize(info);
+
+    writeTriggerCellMapping(info);
+}
+
+
+/*****************************************************************/
+void HGCalTriggerCellIndexWriter::writeTriggerCellMapping(const HGCalTriggerGeometryBase::es_info& info)
+/*****************************************************************/
+{
+    std::cout<<"In HGCalTriggerCellIndexWriter::writeTriggerCellMapping()\n";
+    int sector = 1;
+    int zside = 1;
+    int layer = 15;
+    int module = 10;
+
+    std::map<uint32_t,uint32_t> cellsIndex;
+    std::map<uint32_t,uint32_t> cellsSortedIndex;
+    std::multimap<uint32_t,uint32_t> triggerCellsAndCells;
+
+    // Loop over modules and choose the specified module
+    for( const auto& id_module : triggerGeometry_->modules() )
+    {
+
+        HGCTriggerDetId id(id_module.first);
+        const auto& modulePtr = id_module.second;
+        // Use only a given module
+        if(id.zside()!=zside ||
+                id.layer()!=layer ||
+                id.sector()!=sector ||
+                id.module()!=module) continue;
+
+        std::cout<<"  Got the module I was looking for\n";
+        std::cout<<"  Now looping on trigger cells inside module\n";
+
+        // fill (trigger cell, cell) list into a sorted map
+        for(const auto& tc_c : modulePtr->triggerCellComponents())
+        {
+            cellsIndex.insert( std::make_pair(tc_c.second, 0) );
+            triggerCellsAndCells.insert( std::make_pair(tc_c.first, tc_c.second) );
+            std::cout<<"   ("<<tc_c.first<<","<<tc_c.second<<")\n";
+        }
+        std::cout<<"  I counted "<<triggerCellsAndCells.size()<<" cells in module\n";
+        // translate the cell ID into an index inside the module
+        uint32_t index = 0;
+        for(auto& c_i : cellsIndex) 
+        {
+            c_i.second = index;
+            index++;
+        }
+        // loop over sorted (trigger cell, cell) and associate sorted index to cells.
+        // "sorted" here means that cells inside a given trigger cell are grouped together
+        // and ordered from trigger cell 1 to trigger cell N in the module
+        index = 0;
+        for(const auto& tc_c : triggerCellsAndCells)
+        {
+            cellsSortedIndex.insert( std::make_pair(index, tc_c.second) );
+            index++;
+        }
+
+        // loop over sorted cells and print index
+        for(const auto& i_c : cellsSortedIndex)
+        {
+            uint32_t originalIndex = cellsIndex.at(i_c.second);
+            HGCTriggerDetId tcDetId( triggerGeometry_->cellsToTriggerCellsMap().at(i_c.second) );
+            std::cout<<"    "<<i_c.second<<" = "<<i_c.first<<" -> "<<originalIndex<<" in TC "<<tcDetId.cell()<<" Module "<<tcDetId.module()<<"\n";
+            //std::cout<<"    "<<c_i.first<<" "<<c_i.second<<" IN TC "<<tcDetId.cell()<<"\n";
+        }
+
+        // reverse list order for printing
+        std::vector<uint32_t> cellsIndexToPrint;
+        for(const auto& i_c : cellsSortedIndex) cellsIndexToPrint.push_back(i_c.first);
+        // Print in file in reversed order
+        for(std::vector<uint32_t>::const_reverse_iterator itr=cellsIndexToPrint.crbegin(); itr!=cellsIndexToPrint.crend(); ++itr)
+        {
+            std::cout<<*itr<<"\n";
+        }
+    }
+}
+
+
+/*****************************************************************/
+void HGCalTriggerCellIndexWriter::analyze(const edm::Event& e, 
+			      const edm::EventSetup& es) 
+/*****************************************************************/
+{
+
+}
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HGCalTriggerCellIndexWriter);

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerCellIndexWriter.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerCellIndexWriter.cc
@@ -102,8 +102,6 @@ void HGCalTriggerCellIndexWriter::beginRun(const edm::Run& /*run*/,
 void HGCalTriggerCellIndexWriter::writeTriggerCellMapping(const HGCalTriggerGeometryBase::es_info& info)
 /*****************************************************************/
 {
-    std::cout<<"In HGCalTriggerCellIndexWriter::writeTriggerCellMapping()\n";
-
     std::map<uint32_t,uint32_t> cellsIndex;
     std::map<uint32_t,uint32_t> cellsSortedIndex;
     std::multimap<uint32_t,uint32_t> triggerCellsAndCells;
@@ -114,23 +112,18 @@ void HGCalTriggerCellIndexWriter::writeTriggerCellMapping(const HGCalTriggerGeom
 
         HGCTriggerDetId id(id_module.first);
         const auto& modulePtr = id_module.second;
-        // Use only a given module
+        // Use only the chosen module
         if(id.zside()!=zside_ ||
                 id.layer()!=layer_ ||
                 id.sector()!=sector_ ||
                 id.module()!=module_) continue;
-
-        std::cout<<"  Got the module I was looking for\n";
-        std::cout<<"  Now looping on trigger cells inside module\n";
 
         // fill (trigger cell, cell) list into a sorted map
         for(const auto& tc_c : modulePtr->triggerCellComponents())
         {
             cellsIndex.insert( std::make_pair(tc_c.second, 0) );
             triggerCellsAndCells.insert( std::make_pair(tc_c.first, tc_c.second) );
-            std::cout<<"   ("<<tc_c.first<<","<<tc_c.second<<")\n";
         }
-        std::cout<<"  I counted "<<triggerCellsAndCells.size()<<" cells in module\n";
         // translate the cell ID into an index inside the module
         uint32_t index = 0;
         for(auto& c_i : cellsIndex) 
@@ -154,9 +147,6 @@ void HGCalTriggerCellIndexWriter::writeTriggerCellMapping(const HGCalTriggerGeom
         {
             uint32_t originalIndex = cellsIndex.at(i_c.second);
             cellsIndexToPrint.push_back(originalIndex);
-            HGCTriggerDetId tcDetId( triggerGeometry_->cellsToTriggerCellsMap().at(i_c.second) );
-            std::cout<<"    "<<i_c.second<<" = "<<i_c.first<<" -> "<<originalIndex<<" in TC "<<tcDetId.cell()<<" Module "<<tcDetId.module()<<"\n";
-            //std::cout<<"    "<<c_i.first<<" "<<c_i.second<<" IN TC "<<tcDetId.cell()<<"\n";
         }
 
         std::fstream output(outputFile_, std::ios::out);

--- a/L1Trigger/L1THGCal/test/macros/DrawingUtilities.py
+++ b/L1Trigger/L1THGCal/test/macros/DrawingUtilities.py
@@ -1,0 +1,107 @@
+import ROOT
+
+
+def float_equal(x1, x2):
+    prec = 1.e-4
+    if abs(x1)<prec and abs(x2)>prec: return False
+    elif abs(x1)<prec and abs(x2)<prec: return True
+    else: return abs( (x1-x2)/x1)<prec
+
+def compare_lines(line1, line2):
+    xy11 = (line1.GetX1(), line1.GetY1())
+    xy12 = (line1.GetX2(), line1.GetY2())
+    xy21 = (line2.GetX1(), line2.GetY1())
+    xy22 = (line2.GetX2(), line2.GetY2())
+    samecorner1 = (float_equal(xy11[0],xy21[0]) and float_equal(xy11[1],xy21[1])) or (float_equal(xy11[0],xy22[0]) and float_equal(xy11[1],xy22[1]))
+    samecorner2 = (float_equal(xy12[0],xy21[0]) and float_equal(xy12[1],xy21[1])) or (float_equal(xy12[0],xy22[0]) and float_equal(xy12[1],xy22[1]))
+    #if prt: print "[",xy11,xy12,"]","[",xy21,xy22,"]",(samecorner1 and samecorner2)
+    return samecorner1 and samecorner2
+
+def boxlines(box):
+    lines = []
+    lines.append(ROOT.TLine(box.GetX1(), box.GetY1(), box.GetX1(), box.GetY2()))
+    lines.append(ROOT.TLine(box.GetX1(), box.GetY1(), box.GetX2(), box.GetY1()))
+    lines.append(ROOT.TLine(box.GetX1(), box.GetY2(), box.GetX2(), box.GetY2()))
+    lines.append(ROOT.TLine(box.GetX2(), box.GetY1(), box.GetX2(), box.GetY2()))
+    return lines
+
+class Position:
+    def __init__(self):
+        self.x = 0.
+        self.y = 0.
+        self.z = 0.
+
+class Cell:
+    def __init__(self):
+        self.id = 0
+        self.zside = 0
+        self.layer = 0
+        self.sector = 0
+        self.center = Position()
+        self.corners = [Position(), Position(), Position(), Position()]
+
+    def box(self):
+        return ROOT.TBox(self.corners[0].x, self.corners[0].y, self.corners[2].x, self.corners[2].y)
+
+    def __eq__(self, other):
+        return self.id==other.id
+
+    def __lt__(self, other):
+        return self.id<other.id
+
+    def __le__(self, other):
+        return self.id<=other.id
+
+class TriggerCell:
+    def __init__(self):
+        self.id = 0
+        self.zside = 0
+        self.layer = 0
+        self.sector = 0
+        self.module = 0
+        self.triggercell = 0
+        self.center = Position()
+        self.cells = []
+        self.borderlines = []
+
+    def fillLines(self):
+        for cell in self.cells:
+            box = cell.box()
+            thisboxlines = boxlines(box)
+            for boxline in thisboxlines:
+                existingline = None
+                for line in self.borderlines:
+                    if compare_lines(boxline, line):
+                        existingline = line
+                        break
+                if existingline:
+                    self.borderlines.remove(existingline)
+                else:
+                    self.borderlines.append(boxline)
+
+class Module:
+    def __init__(self):
+        self.id = 0
+        self.zside = 0
+        self.layer = 0
+        self.sector = 0
+        self.module = 0
+        self.center = Position()
+        self.cells = []
+        self.borderlines = []
+
+    def fillLines(self):
+        for cell in self.cells:
+            for cellline in cell.borderlines:
+                existingline = None
+                for line in self.borderlines:
+                    if compare_lines(cellline, line):
+                        existingline = line
+                        break
+                if existingline:
+                    self.borderlines.remove(existingline)
+                else:
+                    self.borderlines.append(cellline)
+
+
+

--- a/L1Trigger/L1THGCal/test/macros/drawFirmwareTriggerCellMapping.py
+++ b/L1Trigger/L1THGCal/test/macros/drawFirmwareTriggerCellMapping.py
@@ -1,0 +1,203 @@
+import ROOT
+import random
+from DrawingUtilities import *
+
+### PARAMETERS #####
+layer  = 15
+sector = 1
+zside  = 1
+mod    = 10
+inputFileName = "../test.root"
+firmwareMappingFile = "../cell_map_layer15_module10.txt"
+outputName    = "firmware_triggerCell_map"
+####################
+
+
+
+inputFile = ROOT.TFile.Open(inputFileName)
+treeModules      = inputFile.Get("hgcaltriggergeomtester/TreeModules")
+treeTriggerCells = inputFile.Get("hgcaltriggergeomtester/TreeTriggerCells")
+treeCells        = inputFile.Get("hgcaltriggergeomtester/TreeCells")
+treeModules.__class__ = ROOT.TTree
+treeTriggerCells.__class__ = ROOT.TTree
+treeCells.__class__ = ROOT.TTree
+
+## filling cell map
+cells = {}
+cut = "layer=={0} && sector=={1} && zside=={2}".format(layer,sector,zside)
+treeCells.Draw(">>elist1", cut, "entrylist")
+entryList1 = ROOT.gDirectory.Get("elist1")
+entryList1.__class__ = ROOT.TEntryList
+nentry = entryList1.GetN()
+treeCells.SetEntryList(entryList1)
+for ie in xrange(nentry):
+    if ie%10000==0: print "Entry {0}/{1}".format(ie, nentry)
+    entry = entryList1.GetEntry(ie)
+    treeCells.GetEntry(entry)
+    cell = Cell()
+    cell.id       = treeCells.id
+    cell.zside    = treeCells.zside
+    cell.layer    = treeCells.layer
+    cell.sector   = treeCells.sector
+    cell.center.x = treeCells.x
+    cell.center.y = treeCells.y
+    cell.center.z = treeCells.z
+    cell.corners[0].x = treeCells.x1
+    cell.corners[0].y = treeCells.y1
+    cell.corners[1].x = treeCells.x2
+    cell.corners[1].y = treeCells.y2
+    cell.corners[2].x = treeCells.x3
+    cell.corners[2].y = treeCells.y3
+    cell.corners[3].x = treeCells.x4
+    cell.corners[3].y = treeCells.y4
+    if cell.id not in cells: cells[cell.id] = cell
+
+## filling trigger cell map
+triggercells = {}
+treeTriggerCells.Draw(">>elist2", cut, "entrylist")
+entryList2 = ROOT.gDirectory.Get("elist2")
+entryList2.__class__ = ROOT.TEntryList
+nentry = entryList2.GetN()
+treeTriggerCells.SetEntryList(entryList2)
+for ie in xrange(nentry):
+    if ie%10000==0: print "Entry {0}/{1}".format(ie, nentry)
+    entry = entryList2.GetEntry(ie)
+    treeTriggerCells.GetEntry(entry)
+    triggercell = TriggerCell()
+    triggercell.id       = treeTriggerCells.id
+    triggercell.zside    = treeTriggerCells.zside
+    triggercell.layer    = treeTriggerCells.layer
+    triggercell.sector   = treeTriggerCells.sector
+    triggercell.module   = treeTriggerCells.module
+    triggercell.triggercell = treeTriggerCells.triggercell
+    triggercell.center.x = treeTriggerCells.x
+    triggercell.center.y = treeTriggerCells.y
+    triggercell.center.z = treeTriggerCells.z
+    for cellid in treeTriggerCells.c_id:
+        if not cellid in cells: raise StandardError("Cannot find cell {0} in trigger cell".format(cellid))
+        cell = cells[cellid]
+        triggercell.cells.append(cell)
+    triggercells[triggercell.id] = triggercell
+
+for id,triggercell in triggercells.items():
+    triggercell.fillLines()
+
+## filling module map
+modules = {}
+treeModules.Draw(">>elist3", cut, "entrylist")
+entryList3 = ROOT.gDirectory.Get("elist3")
+entryList3.__class__ = ROOT.TEntryList
+nentry = entryList3.GetN()
+treeModules.SetEntryList(entryList3)
+for ie in xrange(nentry):
+    if ie%10000==0: print "Entry {0}/{1}".format(ie, nentry)
+    entry = entryList3.GetEntry(ie)
+    treeModules.GetEntry(entry)
+    module = Module()
+    module.id       = treeModules.id
+    module.zside    = treeModules.zside
+    module.layer    = treeModules.layer
+    module.sector   = treeModules.sector
+    module.module   = treeModules.module
+    module.center.x = treeModules.x
+    module.center.y = treeModules.y
+    module.center.z = treeModules.z
+    for cellid in treeModules.tc_id:
+        if not cellid in triggercells: raise StandardError("Cannot find trigger cell {0} in module".format(cellid))
+        cell = triggercells[cellid]
+        module.cells.append(cell)
+    modules[module.id] = module
+
+for id,module in modules.items():
+    module.fillLines()
+
+print "Read", len(cells), "cells" 
+print "Read", len(triggercells), "trigger cells"
+print "Read", len(modules), "modules"
+
+# Read firmware mapping file
+firmwareMapping = []
+with open(firmwareMappingFile) as f:
+    for line in f:
+        firmwareMapping.append(int(line))
+firmwareMapping.reverse()
+
+# Retrieve cells contained in the chosen module and sort them
+cellsInModule = []
+for id,module in modules.items():
+    if module.module==mod:
+        for triggercell in module.cells:
+            for cell in triggercell.cells:
+                cellsInModule.append(cell)
+cellsInModule.sort()
+
+# Create trigger cells and module from information in the firmware mapping file
+triggercellsforfirmware = []
+moduleforfirmware = Module()
+for i,index in enumerate(firmwareMapping):
+    if i%4==0: triggercellsforfirmware.append(TriggerCell()) # FIXME: works only for trigger cells containing 4 cells
+    cell = cellsInModule[index]
+    triggercellsforfirmware[-1].cells.append(cell)
+
+for triggercell in triggercellsforfirmware:
+    moduleforfirmware.cells.append(triggercell)
+    triggercell.fillLines()
+moduleforfirmware.fillLines()
+
+## create output canvas
+outputFile = ROOT.TFile.Open(outputName+".root", "RECREATE")
+maxx = -99999.
+minx = 99999.
+maxy = -99999.
+miny = 99999.
+for id,triggercell in triggercells.items():
+    x = triggercell.center.x
+    y = triggercell.center.y
+    if x>maxx: maxx=x
+    if x<minx: minx=x
+    if y>maxy: maxy=y
+    if y<miny: miny=y
+minx = minx*0.8 if minx>0 else minx*1.2
+miny = miny*0.8 if miny>0 else miny*1.2
+maxx = maxx*1.1 if maxx>0 else maxx*0.9
+maxy = maxy*1.2 if maxy>0 else maxy*0.8
+canvas = ROOT.TCanvas("triggerCellMap", "triggerCellMap", 1400, int(1400*(maxy-miny)/(maxx-minx)))
+canvas.Range(minx, miny, maxx, maxy)
+
+## Print cells
+drawstyle = "lf"
+boxes = []
+for id,module in modules.items():
+    modulelines = []
+    for triggercell in module.cells:
+        for cell in triggercell.cells:
+            box = cell.box()
+            box.SetFillColor(0)
+            box.SetLineColor(ROOT.kGray)
+            box.Draw(drawstyle)
+            boxes.append(box)
+            if not "same" in drawstyle: drawstyle += " same"
+
+# Print trigger cells and module that have been built from firmware mapping file
+linesTrigger = []
+for triggercell in triggercellsforfirmware:
+    linesTrigger.extend(triggercell.borderlines)
+
+for line in linesTrigger:
+    line.Draw()
+for line in moduleforfirmware.borderlines:
+    line.SetLineColor(ROOT.kBlue)
+    line.SetLineWidth(3)
+    line.Draw()
+
+
+
+canvas.Write()
+canvas.Print(outputName+".png")
+
+
+inputFile.Close()
+
+
+
+

--- a/L1Trigger/L1THGCal/test/writeTriggerMapping_cfg.py
+++ b/L1Trigger/L1THGCal/test/writeTriggerMapping_cfg.py
@@ -58,10 +58,10 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
 )
 
 # Additional output definition
-process.TFileService = cms.Service(
-    "TFileService",
-    fileName = cms.string("test.root")
-    )
+#process.TFileService = cms.Service(
+    #"TFileService",
+    #fileName = cms.string("test.root")
+    #)
 
 
 
@@ -105,7 +105,12 @@ process.hgcalTriggerCellIndexWriter = cms.EDAnalyzer(
         eeSDName = cms.string('HGCalEESensitive'),
         fhSDName = cms.string('HGCalHESiliconSensitive'),
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),
-        )
+        ),
+    Sector = cms.int32(1),
+    ZSide = cms.int32(1),
+    Layer  = cms.int32(15),
+    Module = cms.int32(10),
+    OutputFile = cms.string("cell_map_layer15_module10.txt")
     )
 process.writer_step = cms.Path(process.hgcalTriggerCellIndexWriter)
 

--- a/L1Trigger/L1THGCal/test/writeTriggerMapping_cfg.py
+++ b/L1Trigger/L1THGCal/test/writeTriggerMapping_cfg.py
@@ -1,0 +1,128 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('SIMDIGI')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test.root")
+    )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(10.01),
+        MinPt = cms.double(9.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(2.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-2.5),
+        MinPhi = cms.double(-3.14159265359)
+    ),
+    Verbosity = cms.untracked.int32(0),
+    psethack = cms.string('single electron pt 10'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+
+process.hgcalTriggerCellIndexWriter = cms.EDAnalyzer(
+    "HGCalTriggerCellIndexWriter",
+    TriggerGeometry = cms.PSet(
+        TriggerGeometryName = cms.string('HGCalTriggerGeometryImp1'),
+        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/cellsToTriggerCellsMap.txt"),
+        eeSDName = cms.string('HGCalEESensitive'),
+        fhSDName = cms.string('HGCalHESiliconSensitive'),
+        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
+        )
+    )
+process.writer_step = cms.Path(process.hgcalTriggerCellIndexWriter)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.writer_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
+from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023HGCalMuon
+
+#call to customisation function cust_2023HGCalMuon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
+process = cust_2023HGCalMuon(process)
+
+# End of customisation functions
+
+


### PR DESCRIPTION
**Content of this PR**
- Add a plugin that writes the index cell map used to configure the firmware trigger sums. 
  - `L1Trigger/L1THGCal/plugins/HGCalTriggerCellIndexWriter.cc`
  - For the moment it produces the map for one single chosen module.
- There is a python test script that takes this index map (in addition to the ntuples produced by the geometry test plugin) and draw the corresponding trigger cells, in order to check that the indexes are ordered correctly.
  - `L1Trigger/L1THGCal/test/macros/drawFirmwareTriggerCellMapping.py`
  - For the moment only trigger cells containing 4 cells are supported

**Result of the drawing test script**
![firmware_triggercell_map](https://cloud.githubusercontent.com/assets/5569798/11781619/5ea7c86e-a26b-11e5-9580-c6d391e9d649.png)
