### PR TITLE
Possibility to run FE Codecs on already created FEDigis

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalCluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalCluster.h
@@ -8,26 +8,6 @@ namespace l1t {
   
   class HGCalCluster : public L1Candidate {
     public:
-        // FIXME: remnants of Stage-2 calo trigger to be removed
-      enum ClusterFlag{
-        INCLUDE_SEED        = 0,
-        INCLUDE_NW          = 1,
-        INCLUDE_N           = 2,
-        INCLUDE_NE          = 3,
-        INCLUDE_E           = 4,
-        INCLUDE_SE          = 5,
-        INCLUDE_S           = 6,
-        INCLUDE_SW          = 7,
-        INCLUDE_W           = 8,
-        INCLUDE_NN          = 9,
-        INCLUDE_SS          = 10,
-        TRIM_LEFT           = 11,
-        IS_SECONDARY        = 12,
-        MERGE_UPDOWN        = 13, // 0=up, 1=down
-        MERGE_LEFTRIGHT     = 14 // 0=left, 1=right
-      };
-
-    public:
       HGCalCluster(){}
       HGCalCluster( const LorentzVector p4,
           int pt=0,
@@ -37,28 +17,24 @@ namespace l1t {
 
       ~HGCalCluster();
 
+      void setHwPtEm  (uint32_t pt)    {hwPtEm_= pt;}
+      void setHwPtHad (uint32_t pt)    {hwPtHad_ = pt;}
+      void setHwSeedPt(uint32_t pt)    {hwSeedPt_ = pt;}
+      void setSubDet  (uint32_t subdet){subDet_ = subdet;}
+      void setLayer   (uint32_t layer) {layer_ = layer;}
+      void setModule  (uint32_t module) {module_ = module;}
+      void setHOverE  (uint32_t hOverE){hOverE_ = hOverE;}
 
+      bool isValid()      const {return true;}
+      uint32_t hwPtEm()   const {return hwPtEm_;}
+      uint32_t hwPtHad()  const {return hwPtHad_;}
+      uint32_t hwSeedPt() const {return hwSeedPt_;}
 
+      uint32_t subDet() const {return subDet_;}
+      uint32_t layer()  const {return layer_;}
+      uint32_t module()  const {return module_;}
 
-      void setClusterFlag(ClusterFlag flag, bool val=true);
-      void setHwPtEm( int pt );
-      void setHwPtHad( int pt );
-      void setHwSeedPt(int pt);
-      void setFgEta(int fgEta);
-      void setFgPhi(int fgPhi);
-      void setHOverE(int hOverE);
-      void setFgECAL(int fgECAL);
-
-      bool checkClusterFlag(ClusterFlag flag) const;
-      bool isValid() const;
-      int hwPtEm() const;
-      int hwPtHad() const;
-      int hwSeedPt() const;
-      int fgEta() const;
-      int fgPhi() const;
-      int hOverE() const;
-      int fgECAL() const;
-      int clusterFlags() const{return m_clusterFlags;}
+      uint32_t hOverE() const {return hOverE_;}
 
       bool operator<(const HGCalCluster& cl) const;
       bool operator>(const HGCalCluster& cl) const {return  cl<*this;};
@@ -66,21 +42,18 @@ namespace l1t {
       bool operator>=(const HGCalCluster& cl) const {return !(cl<*this);};
 
     private:
-      // Summary of clustering outcomes
-      int m_clusterFlags; // see ClusterFlag bits (15 bits, will evolve)
-
       // Energies
-      int m_hwPtEm;
-      int m_hwPtHad;
-      int m_hwSeedPt;
+      uint32_t hwPtEm_;
+      uint32_t hwPtHad_;
+      uint32_t hwSeedPt_;
 
-      // fine grained position
-      int m_fgEta; // 2 bits (to be defined in agreement with GT inputs)
-      int m_fgPhi; // 2 bits (to be defined in agreement with GT inputs)
+      // HGC specific information
+      uint32_t subDet_;
+      uint32_t layer_;
+      uint32_t module_;
 
       // identification variables
-      int m_hOverE; // 8 bits (between 0 and 1 -> resolution=1/256=0.39%). Number of bits is not definitive
-      int m_fgECAL; // FG bit of the seed tower
+      uint32_t hOverE_; 
   };
 
   typedef BXVector<HGCalCluster> HGCalClusterBxCollection;

--- a/DataFormats/L1THGCal/src/HGCalCluster.cc
+++ b/DataFormats/L1THGCal/src/HGCalCluster.cc
@@ -6,8 +6,7 @@ HGCalCluster::HGCalCluster( const LorentzVector p4,
 			     int pt,
 			     int eta,
 			     int phi)
-  : L1Candidate(p4, pt, eta, phi),
-    m_clusterFlags(0x7FF) // first 11 flags at 1
+  : L1Candidate(p4, pt, eta, phi)
 {
   
 }
@@ -15,98 +14,6 @@ HGCalCluster::HGCalCluster( const LorentzVector p4,
 HGCalCluster::~HGCalCluster() 
 {
   
-}
-
-void HGCalCluster::setClusterFlag(ClusterFlag flag, bool val)
-{
-  if(val) 
-  {
-    m_clusterFlags |= (0x1<<flag);
-  }
-  else
-  {
-    m_clusterFlags &= ~(0x1<<flag);
-  }
-};
-
-void HGCalCluster::setHwPtEm(int pt)
-{
-  m_hwPtEm = pt;
-}
-
-void HGCalCluster::setHwPtHad(int pt)
-{
-  m_hwPtHad = pt;
-}
-
-void HGCalCluster::setHwSeedPt(int pt)
-{
-  m_hwSeedPt = pt;
-}
-
-void HGCalCluster::setFgEta(int fgEta)
-{
-  m_fgEta = fgEta;
-}
-
-void HGCalCluster::setFgPhi(int fgPhi)
-{
-  m_fgPhi = fgPhi;
-}
-
-void HGCalCluster::setHOverE(int hOverE)
-{
-  m_hOverE = hOverE;
-}
-
-void HGCalCluster::setFgECAL(int fgECAL)
-{
-  m_fgECAL = fgECAL;
-}
-
-bool HGCalCluster::checkClusterFlag(ClusterFlag flag) const 
-{
-  return (m_clusterFlags & (0x1<<flag));
-};
-
-bool HGCalCluster::isValid() const
-{
-    return ( checkClusterFlag(INCLUDE_SEED) );
-}
-
-int HGCalCluster::hwPtEm()const
-{
-  return m_hwPtEm;
-}
-
-int HGCalCluster::hwPtHad()const
-{
-  return m_hwPtHad;
-}
-
-int HGCalCluster::hwSeedPt() const
-{
-  return m_hwSeedPt;
-}
-
-int HGCalCluster::fgEta() const
-{
-  return m_fgEta;
-}
-
-int HGCalCluster::fgPhi() const
-{
-  return m_fgPhi;
-}
-
-int HGCalCluster::hOverE() const
-{
-  return m_hOverE;
-}
-
-int HGCalCluster::fgECAL() const
-{
-  return m_fgECAL;
 }
 
 bool HGCalCluster::operator<(const HGCalCluster& cl) const

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
@@ -44,7 +44,7 @@ class HGCalTriggerFECodecBase {
                               const HGCHEDigiCollection&,
                               const HGCHEDigiCollection& ) = 0;
   virtual void setDataPayload(const Module& ,
-                              const l1t::HGCFETriggerDigi& ) = 0;
+                              const l1t::HGCFETriggerDigi&) = 0;
   virtual void unSetDataPayload() = 0;
   // get the set data out for your own enjoyment
   virtual std::vector<bool> getDataPayload() const = 0;
@@ -52,7 +52,7 @@ class HGCalTriggerFECodecBase {
   // abstract interface to manipulating l1t::HGCFETriggerDigis
   // these will yell at you if you haven't set the data in the Codec class
   virtual void encode(l1t::HGCFETriggerDigi&) = 0;
-  virtual void decode(l1t::HGCFETriggerDigi&) = 0;
+  virtual void decode(const l1t::HGCFETriggerDigi&) = 0;
   virtual void print(const l1t::HGCFETriggerDigi& digi,
                      std::ostream& out = std::cout) const = 0;
 
@@ -82,7 +82,7 @@ namespace HGCalTriggerFE {
       }
       digi.encode(static_cast<const Impl&>(*this),data_);      
     }
-    virtual void decode(l1t::HGCFETriggerDigi& digi) override final {
+    virtual void decode(const l1t::HGCFETriggerDigi& digi) override final {
       if( dataIsSet_ ) {
         edm::LogWarning("HGCalTriggerFECodec|OverwritePayload")
           << "Data payload was already set for HGCTriggerFECodec: "

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
@@ -43,6 +43,8 @@ class HGCalTriggerFECodecBase {
                               const HGCEEDigiCollection&,
                               const HGCHEDigiCollection&,
                               const HGCHEDigiCollection& ) = 0;
+  virtual void setDataPayload(const Module& ,
+                              const l1t::HGCFETriggerDigi& ) = 0;
   virtual void unSetDataPayload() = 0;
   // get the set data out for your own enjoyment
   virtual std::vector<bool> getDataPayload() const = 0;
@@ -100,6 +102,17 @@ namespace HGCalTriggerFE {
           << this->name() << " overwriting current data!";
       }
       static_cast<Impl&>(*this).setDataPayloadImpl(mod,ee,fh,bh);
+      dataIsSet_ = true;
+    }
+
+    virtual void setDataPayload(const Module& mod, 
+                              const l1t::HGCFETriggerDigi& digi) override final {
+      if( dataIsSet_ ) {
+        edm::LogWarning("HGCalTriggerFECodec|OverwritePayload")
+          << "Data payload was already set for HGCTriggerFECodec: "
+          << this->name() << " overwriting current data!";
+      }
+      static_cast<Impl&>(*this).setDataPayloadImpl(mod,digi);
       dataIsSet_ = true;
     }
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -26,6 +26,9 @@ public:
                           const HGCEEDigiCollection& ee,
                           const HGCHEDigiCollection& fh,
                           const HGCHEDigiCollection& bh );
+
+  void setDataPayloadImpl(const Module& mod, 
+                          const l1t::HGCFETriggerDigi& digi);
   
   std::vector<bool> encodeImpl(const data_type&) const ;
   data_type         decodeImpl(const std::vector<bool>&) const;  

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -28,6 +28,9 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
                 const HGCHEDigiCollection& fh,
                 const HGCHEDigiCollection& bh );
 
+        void setDataPayloadImpl(const Module& mod, 
+                const l1t::HGCFETriggerDigi& digi);
+
         std::vector<bool> encodeImpl(const data_type&) const ;
         data_type         decodeImpl(const std::vector<bool>&) const;  
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
@@ -12,8 +12,8 @@
 
 struct HGCalBestChoiceDataPayload
 {
-    static const size_t size = 128;
-    typedef std::array<uint32_t, size> trigger_cell_list; // list of data in 128 trigger cells
+    static const size_t size = 114;
+    typedef std::array<uint32_t, size> trigger_cell_list; // list of trigger cell values
     trigger_cell_list payload;
 
     void reset() 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
@@ -39,6 +39,17 @@ class HGCalBestChoiceCodecImpl
         void triggerCellSums(const HGCalTriggerGeometry::Module& , const std::vector<std::pair<HGCEEDetId, uint32_t > >&, data_type&);
         void bestChoiceSelect(data_type&);
 
+        // Retrieve parameters
+        size_t   nData()         const {return nData_;}
+        size_t   dataLength()    const {return dataLength_;}
+        double   linLSB()        const {return linLSB_;}
+        double   adcsaturation() const {return adcsaturation_;}
+        uint32_t adcnBits()      const {return adcnBits_;}
+        double   tdcsaturation() const {return tdcsaturation_;}
+        uint32_t tdcnBits()      const {return tdcnBits_;}
+        double   tdcOnsetfC()    const {return tdcOnsetfC_;}
+
+
     private:
         size_t   nData_;
         size_t   dataLength_;

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
@@ -48,6 +48,8 @@ class HGCalBestChoiceCodecImpl
         double   tdcsaturation() const {return tdcsaturation_;}
         uint32_t tdcnBits()      const {return tdcnBits_;}
         double   tdcOnsetfC()    const {return tdcOnsetfC_;}
+        uint32_t triggerCellTruncationBits() const {return triggerCellTruncationBits_;}
+        uint32_t triggerCellSaturationBits() const {return triggerCellSaturationBits_;}
 
 
     private:
@@ -62,6 +64,8 @@ class HGCalBestChoiceCodecImpl
         double   tdcOnsetfC_ ;
         double   adcLSB_;
         double   tdcLSB_;
+        uint32_t triggerCellTruncationBits_;
+        uint32_t triggerCellSaturationBits_;
 
 };
 

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
@@ -1,0 +1,117 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h"
+
+#include <sstream>
+#include <memory>
+
+class HGCalTriggerDigiFEReproducer : public edm::EDProducer 
+{  
+    public:    
+        HGCalTriggerDigiFEReproducer(const edm::ParameterSet&);
+        ~HGCalTriggerDigiFEReproducer() { }
+
+        virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+        virtual void produce(edm::Event&, const edm::EventSetup&);
+
+    private:
+        // inputs
+        edm::EDGetToken inputdigi_;
+        // algorithm containers
+        std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_;
+        std::unique_ptr<HGCalTriggerFECodecBase> codec_;
+        HGCalTriggerBackendProcessor backEndProcessor_;
+};
+
+DEFINE_FWK_MODULE(HGCalTriggerDigiFEReproducer);
+
+
+/*****************************************************************/
+HGCalTriggerDigiFEReproducer::HGCalTriggerDigiFEReproducer(const edm::ParameterSet& conf):
+    inputdigi_(consumes<l1t::HGCFETriggerDigiCollection>(conf.getParameter<edm::InputTag>("feDigis"))), 
+    backEndProcessor_(conf.getParameterSet("BEConfiguration")) 
+/*****************************************************************/
+{
+    //setup geometry configuration
+    const edm::ParameterSet& geometryConfig = conf.getParameterSet("TriggerGeometry");
+    const std::string& trigGeomName = geometryConfig.getParameter<std::string>("TriggerGeometryName");
+    HGCalTriggerGeometryBase* geometry = HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
+    triggerGeometry_.reset(geometry);
+
+    //setup FE codec
+    const edm::ParameterSet& feCodecConfig =  conf.getParameterSet("FECodec");
+    const std::string& feCodecName = feCodecConfig.getParameter<std::string>("CodecName");
+    HGCalTriggerFECodecBase* codec = HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig);
+    codec_.reset(codec);
+    codec_->unSetDataPayload();
+
+    produces<l1t::HGCFETriggerDigiCollection>();
+    // register backend processor products
+    backEndProcessor_.setProduces(*this);
+}
+
+/*****************************************************************/
+void HGCalTriggerDigiFEReproducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) 
+/*****************************************************************/
+{
+    triggerGeometry_->reset();
+    HGCalTriggerGeometryBase::es_info info;
+    const std::string& ee_sd_name = triggerGeometry_->eeSDName();
+    const std::string& fh_sd_name = triggerGeometry_->fhSDName();
+    const std::string& bh_sd_name = triggerGeometry_->bhSDName();
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.geom_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.geom_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.geom_bh);
+    es.get<IdealGeometryRecord>().get(ee_sd_name,info.topo_ee);
+    es.get<IdealGeometryRecord>().get(fh_sd_name,info.topo_fh);
+    es.get<IdealGeometryRecord>().get(bh_sd_name,info.topo_bh);
+    triggerGeometry_->initialize(info);
+}
+
+/*****************************************************************/
+void HGCalTriggerDigiFEReproducer::produce(edm::Event& e, const edm::EventSetup& es)
+/*****************************************************************/
+{
+    std::auto_ptr<l1t::HGCFETriggerDigiCollection> fe_output( new l1t::HGCFETriggerDigiCollection );
+
+    edm::Handle<l1t::HGCFETriggerDigiCollection> digis_h;
+
+    e.getByToken(inputdigi_,digis_h);
+
+    const l1t::HGCFETriggerDigiCollection& digis = *digis_h;
+
+    for( const auto& digi_in : digis ) 
+    {    
+        const auto& module = triggerGeometry_->modules().at(digi_in.id());
+        fe_output->push_back(l1t::HGCFETriggerDigi());
+        l1t::HGCFETriggerDigi& digi_out = fe_output->back();
+        codec_->setDataPayload(*module, digi_in);
+        codec_->encode(digi_out);
+        digi_out.setDetId( digi_in.getDetId<HGCalDetId>() );
+        std::stringstream output;
+        codec_->print(digi_out,output);
+        edm::LogInfo("HGCalTriggerDigiFEReproducer")
+            << output.str();
+        codec_->unSetDataPayload();
+    }
+
+    // get the orphan handle and fe digi collection
+    auto fe_digis_handle = e.put(fe_output);
+    auto fe_digis_coll = *fe_digis_handle;
+
+    //now we run the emulation of the back-end processor
+    backEndProcessor_.run(fe_digis_coll,triggerGeometry_);
+    backEndProcessor_.putInEvent(e);
+    backEndProcessor_.reset();  
+}

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
@@ -42,18 +42,15 @@ void SingleCellClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
         const std::unique_ptr<HGCalTriggerGeometryBase>& geom) 
 /*****************************************************************/
 {
-    std::cout<<"####################################\n";
     for( const auto& digi : coll ) 
     {
         HGCalBestChoiceCodec::data_type data;
         data.reset();
         const HGCalDetId& moduleId = digi.getDetId<HGCalDetId>();
         digi.decode(codec_, data);
-        std::cout<<"zside="<<moduleId.zside()<<",layer="<<moduleId.layer()<<",module="<<moduleId.wafer()<<"\n";
         int i = 0;
         for(const auto& value : data.payload)
         {
-            std::cout<<"  "<<i<<"="<<value<<"\n";
             if(value>0)
             {
                 // dummy cluster without position

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
@@ -1,0 +1,76 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h"
+#include "L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h"
+#include "DataFormats/ForwardDetId/interface/HGCTriggerDetId.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+
+using namespace HGCalTriggerBackend;
+
+class SingleCellClusterAlgo : public Algorithm<HGCalBestChoiceCodec> 
+{
+    public:
+
+        SingleCellClusterAlgo(const edm::ParameterSet& conf):
+            Algorithm<HGCalBestChoiceCodec>(conf),
+            cluster_product( new l1t::HGCalClusterBxCollection ){}
+
+        virtual void setProduces(edm::EDProducer& prod) const override final 
+        {
+            prod.produces<l1t::HGCalClusterBxCollection>(name());
+        }
+
+        virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
+                const std::unique_ptr<HGCalTriggerGeometryBase>& geom) override final;
+
+        virtual void putInEvent(edm::Event& evt) override final 
+        {
+            evt.put(cluster_product,name());
+        }
+
+        virtual void reset() override final 
+        {
+            cluster_product.reset( new l1t::HGCalClusterBxCollection );
+        }
+
+    private:
+        std::auto_ptr<l1t::HGCalClusterBxCollection> cluster_product;
+
+};
+
+/*****************************************************************/
+void SingleCellClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
+        const std::unique_ptr<HGCalTriggerGeometryBase>& geom) 
+/*****************************************************************/
+{
+    std::cout<<"####################################\n";
+    for( const auto& digi : coll ) 
+    {
+        HGCalBestChoiceCodec::data_type data;
+        data.reset();
+        const HGCalDetId& moduleId = digi.getDetId<HGCalDetId>();
+        digi.decode(codec_, data);
+        std::cout<<"zside="<<moduleId.zside()<<",layer="<<moduleId.layer()<<",module="<<moduleId.wafer()<<"\n";
+        int i = 0;
+        for(const auto& value : data.payload)
+        {
+            std::cout<<"  "<<i<<"="<<value<<"\n";
+            if(value>0)
+            {
+                // dummy cluster without position
+                // index in module stored as hwEta
+                l1t::HGCalCluster cluster( reco::LeafCandidate::LorentzVector(),
+                        value, i, 0);
+                cluster.setModule(moduleId.wafer());
+                cluster.setLayer(moduleId.layer());
+                cluster.setSubDet(moduleId.zside()<0 ? 0 : 1);
+                cluster_product->push_back(0,cluster);
+            }
+            i++;
+        }
+
+    }
+}
+
+DEFINE_EDM_PLUGIN(HGCalTriggerBackendAlgorithmFactory, 
+        SingleCellClusterAlgo,
+        "SingleCellClusterAlgo");

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
@@ -14,6 +14,12 @@ setDataPayloadImpl(const Module& ,
   codecImpl_.setDataPayload(data_);
 }
 
+void HGCal64BitRandomCodec::
+setDataPayloadImpl(const Module& mod, 
+                   const l1t::HGCFETriggerDigi& digi) {
+  codecImpl_.setDataPayload(data_);
+}
+
 std::vector<bool>
 HGCal64BitRandomCodec::
 encodeImpl(const HGCal64BitRandomCodec::data_type& data) const {

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -48,7 +48,22 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
 /*****************************************************************/
 {
     data_.reset();
-    digi.decode(*this,data_);
+    edm::ParameterSet conf;
+    conf.addParameter<std::string>("CodecName",     name());
+    conf.addParameter<uint32_t>   ("CodecIndex",    getCodecType());
+    conf.addParameter<uint32_t>   ("NData",         HGCalBestChoiceCodec::data_type::size);
+    conf.addParameter<uint32_t>   ("DataLength",    codecImpl_.dataLength());
+    conf.addParameter<double>     ("linLSB",        codecImpl_.linLSB());
+    conf.addParameter<double>     ("adcsaturation", codecImpl_.adcsaturation());
+    conf.addParameter<uint32_t>   ("adcnBits",      codecImpl_.adcnBits());
+    conf.addParameter<double>     ("tdcsaturation", codecImpl_.tdcsaturation());
+    conf.addParameter<uint32_t>   ("tdcnBits",      codecImpl_.tdcnBits());
+    conf.addParameter<double>     ("tdcOnsetfC",    codecImpl_.tdcOnsetfC());
+    // decode input data with different parameters
+    // (no selection, so NData=number of trigger cells in module)
+    // Not very clean to define an alternative codec within this codec 
+    HGCalBestChoiceCodec codecInput(conf);
+    digi.decode(codecInput,data_);
     // choose best trigger cells in the module
     codecImpl_.bestChoiceSelect(data_);
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -61,7 +61,9 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
     conf.addParameter<double>     ("tdcOnsetfC",    codecImpl_.tdcOnsetfC());
     // decode input data with different parameters
     // (no selection, so NData=number of trigger cells in module)
+    // FIXME:
     // Not very clean to define an alternative codec within this codec 
+    // Also, the codec is built each time the method is called, which is not very efficient
     HGCalBestChoiceCodec codecInput(conf);
     digi.decode(codecInput,data_);
     // choose best trigger cells in the module

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -42,6 +42,18 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
 
 }
 
+/*****************************************************************/
+void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod, 
+        const l1t::HGCFETriggerDigi& digi)
+/*****************************************************************/
+{
+    data_.reset();
+    digi.decode(*this,data_);
+    // choose best trigger cells in the module
+    codecImpl_.bestChoiceSelect(data_);
+
+}
+
 
 /*****************************************************************/
 std::vector<bool> HGCalBestChoiceCodec::encodeImpl(const HGCalBestChoiceCodec::data_type& data) const 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -48,10 +48,17 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
 /*****************************************************************/
 {
     data_.reset();
+    // decode input data with different parameters
+    // (no selection, so NData=number of trigger cells in module)
+    // FIXME:
+    // Not very clean to define an alternative codec within this codec 
+    // Also, the codec is built each time the method is called, which is not very efficient
+    // This may need a restructuration of the FECodec
     edm::ParameterSet conf;
     conf.addParameter<std::string>("CodecName",     name());
     conf.addParameter<uint32_t>   ("CodecIndex",    getCodecType());
     conf.addParameter<uint32_t>   ("NData",         HGCalBestChoiceCodec::data_type::size);
+    // The data length should be the same for input and output, which is limiting
     conf.addParameter<uint32_t>   ("DataLength",    codecImpl_.dataLength());
     conf.addParameter<double>     ("linLSB",        codecImpl_.linLSB());
     conf.addParameter<double>     ("adcsaturation", codecImpl_.adcsaturation());
@@ -59,16 +66,11 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const Module& mod,
     conf.addParameter<double>     ("tdcsaturation", codecImpl_.tdcsaturation());
     conf.addParameter<uint32_t>   ("tdcnBits",      codecImpl_.tdcnBits());
     conf.addParameter<double>     ("tdcOnsetfC",    codecImpl_.tdcOnsetfC());
-    // decode input data with different parameters
-    // (no selection, so NData=number of trigger cells in module)
-    // FIXME:
-    // Not very clean to define an alternative codec within this codec 
-    // Also, the codec is built each time the method is called, which is not very efficient
+    conf.addParameter<uint32_t>   ("triggerCellTruncationBits", codecImpl_.triggerCellTruncationBits());
     HGCalBestChoiceCodec codecInput(conf);
     digi.decode(codecInput,data_);
     // choose best trigger cells in the module
     codecImpl_.bestChoiceSelect(data_);
-
 }
 
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -7,6 +7,7 @@ fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
                      NData = cms.uint32(12),
                      DataLength = cms.uint32(8),
                      linLSB = cms.double(100./1024.),
+                     triggerCellTruncationBits = cms.uint32(2),
                      #take the following parameters from the digitization config file
                      adcsaturation = digiparam.hgceeDigitizer.digiCfg.feCfg.adcSaturation_fC,
                      adcnBits = digiparam.hgceeDigitizer.digiCfg.feCfg.adcNbits,
@@ -33,7 +34,7 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     bhDigis = cms.InputTag('mix:HGCDigisHEback'),
     TriggerGeometry = geometry,
-    FECodec = fe_codec,
+    FECodec = fe_codec.clone(),
     BEConfiguration = cms.PSet( 
         algorithms = cms.VPSet( cluster_algo )
         )
@@ -43,7 +44,7 @@ hgcalTriggerPrimitiveDigiFEReproducer = cms.EDProducer(
     "HGCalTriggerDigiFEReproducer",
     feDigis = cms.InputTag('hgcalTriggerPrimitiveDigiProducer'),
     TriggerGeometry = geometry,
-    FECodec = fe_codec,
+    FECodec = fe_codec.clone(),
     BEConfiguration = cms.PSet( 
         algorithms = cms.VPSet( cluster_algo )
         )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -15,6 +15,14 @@ fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
                      tdcOnsetfC = digiparam.hgceeDigitizer.digiCfg.feCfg.tdcOnset_fC
                    )
 
+geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp1'),
+                     L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
+                     L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
+                     eeSDName = cms.string('HGCalEESensitive'),
+                     fhSDName = cms.string('HGCalHESiliconSensitive'),
+                     bhSDName = cms.string('HGCalHEScintillatorSensitive'),
+                   )
+
 
 cluster_algo =  cms.PSet( AlgorithmName = cms.string('FullModuleSumAlgo'),
                                  FECodec = fe_codec )
@@ -24,14 +32,17 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     eeDigis = cms.InputTag('mix:HGCDigisEE'),
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     bhDigis = cms.InputTag('mix:HGCDigisHEback'),
-    TriggerGeometry = cms.PSet(
-        TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp1'),
-        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
-        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
-        eeSDName = cms.string('HGCalEESensitive'),
-        fhSDName = cms.string('HGCalHESiliconSensitive'),
-        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
-        ),
+    TriggerGeometry = geometry,
+    FECodec = fe_codec,
+    BEConfiguration = cms.PSet( 
+        algorithms = cms.VPSet( cluster_algo )
+        )
+    )
+
+hgcalTriggerPrimitiveDigiFEReproducer = cms.EDProducer(
+    "HGCalTriggerDigiFEReproducer",
+    feDigis = cms.InputTag('hgcalTriggerPrimitiveDigiProducer'),
+    TriggerGeometry = geometry,
     FECodec = fe_codec,
     BEConfiguration = cms.PSet( 
         algorithms = cms.VPSet( cluster_algo )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -3,3 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1THGCal.hgcalTriggerPrimitiveDigiProducer_cfi import *
 
 hgcalTriggerPrimitives = cms.Sequence(hgcalTriggerPrimitiveDigiProducer)
+
+hgcalTriggerPrimitives_reproduce = cms.Sequence(hgcalTriggerPrimitiveDigiFEReproducer)

--- a/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
+++ b/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
@@ -17,6 +17,8 @@ HGCalBestChoiceCodecImpl::HGCalBestChoiceCodecImpl(const edm::ParameterSet& conf
     triggerCellTruncationBits_(conf.getParameter<uint32_t>("triggerCellTruncationBits"))
 /*****************************************************************/
 {
+  // Cannot have more selected cells than the max number of cells
+  if(nData_>nCellsInModule_) nData_ = nCellsInModule_;
   adcLSB_ =  adcsaturation_/pow(2.,adcnBits_);
   tdcLSB_ =  tdcsaturation_/pow(2.,tdcnBits_);
   triggerCellSaturationBits_ = triggerCellTruncationBits_ + dataLength_;

--- a/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
+++ b/L1Trigger/L1THGCal/src/fe_codecs/HGCalBestChoiceCodecImpl.cc
@@ -13,11 +13,13 @@ HGCalBestChoiceCodecImpl::HGCalBestChoiceCodecImpl(const edm::ParameterSet& conf
     adcnBits_(conf.getParameter<uint32_t>("adcnBits")),
     tdcsaturation_(conf.getParameter<double>("tdcsaturation")), 
     tdcnBits_(conf.getParameter<uint32_t>("tdcnBits")), 
-    tdcOnsetfC_(conf.getParameter<double>("tdcOnsetfC"))
+    tdcOnsetfC_(conf.getParameter<double>("tdcOnsetfC")),
+    triggerCellTruncationBits_(conf.getParameter<uint32_t>("triggerCellTruncationBits"))
 /*****************************************************************/
 {
   adcLSB_ =  adcsaturation_/pow(2.,adcnBits_);
   tdcLSB_ =  tdcsaturation_/pow(2.,tdcnBits_);
+  triggerCellSaturationBits_ = triggerCellTruncationBits_ + dataLength_;
 }
 
 
@@ -43,13 +45,11 @@ std::vector<bool> HGCalBestChoiceCodecImpl::encode(const HGCalBestChoiceCodecImp
                     << "encode: Number of non-zero trigger cells larger than codec parameter\n"\
                     << "      : Number of energy values = "<<nData_<<"\n";
             }
-            // FIXME: a proper coding is needed here. Needs studies.
-            // For the moment truncate to 8 bits by keeping bits 10----3. 
-            // Values > 0x3FF are saturated to 0x3FF
-            if(value>0x3FF) value=0x3FF; // 10 bit saturation
+            // Saturate and truncate energy values
+            if(value+1>(0x1u<<triggerCellSaturationBits_)) value = (0x1<<triggerCellSaturationBits_);
             for(size_t i=0; i<dataLength_; i++)
             {
-                result[nCellsInModule_ + idata*dataLength_ + i] = static_cast<bool>(value & (0x1<<(i+2)));// remove the two lowest bits
+                result[nCellsInModule_ + idata*dataLength_ + i] = static_cast<bool>(value & (0x1<<(i+triggerCellTruncationBits_)));// remove the lowest bits (=triggerCellTruncationBits_)
             }
             idata++;
         }
@@ -186,14 +186,14 @@ void HGCalBestChoiceCodecImpl::bestChoiceSelect(data_type& data)
                 return a > b; 
             } 
             );
-    // keep only the 12 first trigger cells
+    // keep only the first trigger cells
     for(size_t i=nData_; i<nCellsInModule_; i++)
     {
         sortedtriggercells.at(i).first = 0;
     }
     for(const auto& value_id : sortedtriggercells)
     {
-        if(value_id.second>nCellsInModule_) // cell number starts at 1
+        if(value_id.second>=nCellsInModule_)
         {
             throw cms::Exception("BadGeometry")
                 << "Number of trigger cells in module too large for available data payload\n";

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="L1Trigger/L1THGCal"/>
 <use   name="Geometry/Records"/>
 <use   name="CommonTools/UtilAlgos"/>
+<use   name="DataFormats/L1Trigger"/>
 
 <library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerBestChoiceTester.cc">
 <flags   EDM_PLUGIN="1"/>

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -136,7 +136,7 @@ void HGCalTriggerBestChoiceTester::analyze(const edm::Event& e,
 /*****************************************************************/
 {
     checkSelectedCells(e, es);
-    rerunBestChoice(e, es);
+    rerunBestChoiceFragments(e, es);
 
 }
 

--- a/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
@@ -22,8 +22,9 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(4)
+    input = cms.untracked.int32(1)
 )
 
 # Input source
@@ -41,23 +42,23 @@ process.configurationMetadata = cms.untracked.PSet(
 )
 
 # Output definition
-
 process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-   # outputCommands = process.FEVTDEBUGEventContent.outputCommands,
-    fileName = cms.untracked.string('file:junk.root'),
-    dataset = cms.untracked.PSet(
-        filterName = cms.untracked.string(''),
-        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
-    ), 
+    #outputCommands = process.FEVTDEBUGEventContent.outputCommands,
     outputCommands = cms.untracked.vstring(
-        'drop *',
         'keep *_*_HGCHitsEE_*',
         'keep *_*_HGCHitsHEback_*',
         'keep *_*_HGCHitsHEfront_*',
         'keep *_mix_*_*',
-        'keep *_genParticles_*_*'
+        'keep *_genParticles_*_*',
+        'keep *_hgcalTriggerPrimitiveDigiProducer_*_*',
+        'keep *_hgcalTriggerPrimitiveDigiFEReproducer_*_*'
+    ),
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
     ),
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('generation_step')
@@ -67,7 +68,7 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
 # Additional output definition
 process.TFileService = cms.Service(
     "TFileService",
-    fileName = cms.string("test.root")
+    fileName = cms.string("test_bestchoice.root")
     )
 
 
@@ -79,13 +80,13 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.generator = cms.EDProducer("FlatRandomPtGunProducer",
     PGunParameters = cms.PSet(
-        MaxPt = cms.double(50.01),
         MinPt = cms.double(49.99),
-        PartID = cms.vint32(13),
-        MaxEta = cms.double(3.0),
-        MaxPhi = cms.double(3.14159265359),
+        MaxPt = cms.double(50.01),
+        PartID = cms.vint32(11),
         MinEta = cms.double(1.5),
-        MinPhi = cms.double(-3.14159265359)
+        MaxEta = cms.double(3.0),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359)
     ),
     Verbosity = cms.untracked.int32(0),
     psethack = cms.string('single electron pt 50'),
@@ -106,11 +107,29 @@ process.digi2raw_step = cms.Path(process.DigiToRaw)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+## define trigger emulator without trigger cell selection
+process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(128)
+cluster_algo_all =  cms.PSet( AlgorithmName = cms.string('SingleCellClusterAlgo'),
+                                 FECodec = process.hgcalTriggerPrimitiveDigiProducer.FECodec )
+process.hgcalTriggerPrimitiveDigiProducer.BEConfiguration.algorithms = cms.VPSet( cluster_algo_all )
+process.hgcl1tpg_step1 = cms.Path(process.hgcalTriggerPrimitives)
+
+## define trigger emulator with trigger cell selection
+process.hgcalTriggerPrimitiveDigiFEReproducer.FECodec.triggerCellTruncationBits = cms.uint32(0)
+cluster_algo_select =  cms.PSet( AlgorithmName = cms.string('SingleCellClusterAlgo'),
+                                 FECodec = process.hgcalTriggerPrimitiveDigiFEReproducer.FECodec )
+process.hgcalTriggerPrimitiveDigiFEReproducer.BEConfiguration.algorithms = cms.VPSet( cluster_algo_select )
+process.hgcl1tpg_step2 = cms.Path(process.hgcalTriggerPrimitives_reproduce)
+
+# define best choice tester
 process.hgcaltriggerbestchoicetester = cms.EDAnalyzer(
     "HGCalTriggerBestChoiceTester",
     eeDigis = cms.InputTag('mix:HGCDigisEE'),
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     bhDigis = cms.InputTag('mix:HGCDigisHEback'),
+    beClustersAll = cms.InputTag('hgcalTriggerPrimitiveDigiProducer:SingleCellClusterAlgo'),
+    beClustersSelect = cms.InputTag('hgcalTriggerPrimitiveDigiFEReproducer:SingleCellClusterAlgo'),
     TriggerGeometry = cms.PSet(
         TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp1'),
         L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
@@ -120,21 +139,22 @@ process.hgcaltriggerbestchoicetester = cms.EDAnalyzer(
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),
         ),
     FECodec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
-                     CodecIndex = cms.uint32(1),
-                     NData = cms.uint32(12),
-                     DataLength = cms.uint32(8),
-                     linLSB = cms.double(100./1024.),
+                     CodecIndex    = cms.uint32(1),
+                     NData         = cms.uint32(12),
+                     DataLength    = cms.uint32(8),
+                     linLSB        = cms.double(100./1024.),
                      adcsaturation = cms.double(100),
-                     adcnBits =  cms.uint32(10),
+                     adcnBits      =  cms.uint32(10),
                      tdcsaturation = cms.double(10000),
-                     tdcnBits =  cms.uint32(12),
-                     tdcOnsetfC = cms.double(60)  
+                     tdcnBits      =  cms.uint32(12),
+                     tdcOnsetfC    = cms.double(60),
+                     triggerCellTruncationBits = cms.uint32(2)
                    )
     )
 process.test_step = cms.Path(process.hgcaltriggerbestchoicetester)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.test_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.hgcl1tpg_step1,process.hgcl1tpg_step2,process.digi2raw_step,process.test_step,process.endjob_step,process.FEVTDEBUGoutput_step)
 
 # filter all path with the production filter sequence
 for path in process.paths:

--- a/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
@@ -109,7 +109,7 @@ process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 ## define trigger emulator without trigger cell selection
-process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(128)
+process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(999) # put number larger than max number of trigger cells in module
 cluster_algo_all =  cms.PSet( AlgorithmName = cms.string('SingleCellClusterAlgo'),
                                  FECodec = process.hgcalTriggerPrimitiveDigiProducer.FECodec )
 process.hgcalTriggerPrimitiveDigiProducer.BEConfiguration.algorithms = cms.VPSet( cluster_algo_all )

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -99,7 +99,11 @@ process.digitisation_step = cms.Path(process.pdigi_valid)
 process.L1simulation_step = cms.Path(process.SimL1Emulator)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
-process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(128)
+# Remove best choice selection
+process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(999)
+cluster_algo_all =  cms.PSet( AlgorithmName = cms.string('SingleCellClusterAlgo'),
+                                 FECodec = process.hgcalTriggerPrimitiveDigiProducer.FECodec )
+process.hgcalTriggerPrimitiveDigiProducer.BEConfiguration.algorithms = cms.VPSet( cluster_algo_all )
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 
 process.digi2raw_step = cms.Path(process.DigiToRaw)

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -1,17 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process('SIMDIGI')
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('DIGI',eras.Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('FWCore.MessageService.MessageLogger_cfi')
-process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
+process.load('Configuration.Geometry.GeometryExtended2023LRecoReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
@@ -23,8 +22,9 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(1)
 )
 
 # Input source
@@ -43,11 +43,11 @@ process.configurationMetadata = cms.untracked.PSet(
 
 # Output definition
 
-process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
-    fileName = cms.untracked.string('file:junk.root'),
+    outputCommands = process.FEVTDEBUGEventContent.outputCommands,
+    fileName = cms.untracked.string('file:test.root'),
     dataset = cms.untracked.PSet(
         filterName = cms.untracked.string(''),
         dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
@@ -62,7 +62,7 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
 # Other statements
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.generator = cms.EDProducer("FlatRandomPtGunProducer",
     PGunParameters = cms.PSet(
@@ -94,6 +94,8 @@ process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 
 process.digi2raw_step = cms.Path(process.DigiToRaw)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
 # Schedule definition
 process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.hgcl1tpg_step,process.digi2raw_step)
@@ -104,10 +106,10 @@ for path in process.paths:
 # customisation of the process.
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
-from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023HGCalMuon
+from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023LReco
 
 #call to customisation function cust_2023HGCalMuon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
-process = cust_2023HGCalMuon(process)
+process = cust_2023LReco(process)
 
 # End of customisation functions
 

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -46,7 +46,15 @@ process.configurationMetadata = cms.untracked.PSet(
 process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    outputCommands = process.FEVTDEBUGEventContent.outputCommands,
+    #outputCommands = process.FEVTDEBUGEventContent.outputCommands,
+    outputCommands = cms.untracked.vstring(
+        'keep *_*_HGCHitsEE_*',
+        'keep *_*_HGCHitsHEback_*',
+        'keep *_*_HGCHitsHEfront_*',
+        'keep *_mix_*_*',
+        'keep *_genParticles_*_*',
+        'keep *_hgcalTriggerPrimitiveDigiProducer_*_*'
+    ),
     fileName = cms.untracked.string('file:test.root'),
     dataset = cms.untracked.PSet(
         filterName = cms.untracked.string(''),
@@ -98,7 +106,7 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.hgcl1tpg_step,process.digi2raw_step)
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.hgcl1tpg_step,process.digi2raw_step,process.endjob_step, process.FEVTDEBUGoutput_step)
 # filter all path with the production filter sequence
 for path in process.paths:
         getattr(process,path)._seq = process.generator * getattr(process,path)._seq

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -99,6 +99,7 @@ process.digitisation_step = cms.Path(process.pdigi_valid)
 process.L1simulation_step = cms.Path(process.SimL1Emulator)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+process.hgcalTriggerPrimitiveDigiProducer.FECodec.NData = cms.uint32(128)
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 
 process.digi2raw_step = cms.Path(process.DigiToRaw)

--- a/L1Trigger/L1THGCal/test/unittest_bestchoicecodec.cc
+++ b/L1Trigger/L1THGCal/test/unittest_bestchoicecodec.cc
@@ -30,10 +30,16 @@ void TestBestChoiceCodec::setUp()
 /*****************************************************************/
 {
     edm::ParameterSet params;
-    params.addParameter<std::string>("CodecName", "HGCalBestChoiceCodec");
-    params.addParameter<uint32_t>("CodecIndex", 1);
-    params.addParameter<uint32_t>("NData", 12);
-    params.addParameter<uint32_t>("DataLength", 8);
+    params.addParameter<std::string>("CodecName",     "HGCalBestChoiceCodec");
+    params.addParameter<uint32_t>   ("CodecIndex",    1);
+    params.addParameter<uint32_t>   ("NData",         12);
+    params.addParameter<uint32_t>   ("DataLength",    8);
+    params.addParameter<double>     ("linLSB",        100./1024. );
+    params.addParameter<double>     ("adcsaturation", 100.);
+    params.addParameter<uint32_t>   ("adcnBits",      10);
+    params.addParameter<double>     ("tdcsaturation", 10000 );
+    params.addParameter<uint32_t>   ("tdcnBits",      12);
+    params.addParameter<double>     ("tdcOnsetfC",    60);
     codec_.reset(new HGCalBestChoiceCodecImpl(params));
 
 }


### PR DESCRIPTION
Linked to issue #24 
Add the ability to run FE Codecs on already created FEDIgis while keeping the code infrastructure the same.
- Done using an additional producer that runs on already created FE Digis instead of HGC Digis and defining a new setDataPayload() method.
- Not very elegant. May need an update of the FE code infrastructure in the future.
- The BestChoice tester has been updated in order to test FEDigis selected from already created FEDigis.
