### PR TITLE
Optimize front-end processing time

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -146,9 +146,9 @@ class HGCalTriggerGeometryBase {
   // const access to the geometry class  
   // all of the get*From* functions return nullptr if the thing you
   // ask for doesn't exist
-  const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
-  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
-  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
+  virtual const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
+  virtual const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
+  virtual const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
 
   const geom_map& cellsToTriggerCellsMap() const { return cells_to_trigger_cells_; }
   const geom_map& triggerCellsToModulesMap() const { return trigger_cells_to_modules_; }

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -146,9 +146,9 @@ class HGCalTriggerGeometryBase {
   // const access to the geometry class  
   // all of the get*From* functions return nullptr if the thing you
   // ask for doesn't exist
-  virtual const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
-  virtual const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
-  virtual const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
+  const std::unique_ptr<const HGCalTriggerGeometry::TriggerCell>& getTriggerCellFromCell( const unsigned cell_det_id ) const;
+  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromCell( const unsigned cell_det_id ) const;
+  const std::unique_ptr<const HGCalTriggerGeometry::Module>& getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const;
 
   const geom_map& cellsToTriggerCellsMap() const { return cells_to_trigger_cells_; }
   const geom_map& triggerCellsToModulesMap() const { return trigger_cells_to_modules_; }

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodecImpl.h
@@ -12,7 +12,7 @@
 
 struct HGCalBestChoiceDataPayload
 {
-    static const size_t size = 114;
+    static const size_t size = 130; // FIXME: check why 114 is not working
     typedef std::array<uint32_t, size> trigger_cell_list; // list of trigger cell values
     trigger_cell_list payload;
 

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -102,13 +102,13 @@ void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es)
   std::unordered_map<uint32_t, HGCEEDigiCollection> hit_modules_ee;
   for(const auto& eedata : ee_digis) {
     const auto& module = triggerGeometry_->getModuleFromCell(eedata.id());
-    auto itr_insert = hit_modules_ee.insert(std::make_pair(module->moduleId(),HGCEEDigiCollection()));
+    auto itr_insert = hit_modules_ee.emplace(module->moduleId(),HGCEEDigiCollection());
     itr_insert.first->second.push_back(eedata);
   }
   std::unordered_map<uint32_t,HGCHEDigiCollection> hit_modules_fh;
   for(const auto& fhdata : fh_digis) {
     const auto& module = triggerGeometry_->getModuleFromCell(fhdata.id());
-    auto itr_insert = hit_modules_fh.insert(std::make_pair(module->moduleId(), HGCHEDigiCollection()));
+    auto itr_insert = hit_modules_fh.emplace(module->moduleId(), HGCHEDigiCollection());
     itr_insert.first->second.push_back(fhdata);
   }
   // loop on modules containing hits and call front-end processing

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -98,20 +98,48 @@ void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es)
   const HGCHEDigiCollection& fh_digis = *fh_digis_h;
   const HGCHEDigiCollection& bh_digis = *bh_digis_h;
 
-  //we produce one output trigger digi per module in the FE
-  //so we use the geometry to tell us what to loop over
-  for( const auto& module : triggerGeometry_->modules() ) {    
+  // First find modules containing hits and prepare list of hits for each module
+  std::unordered_map<uint32_t, HGCEEDigiCollection> hit_modules_ee;
+  for(const auto& eedata : ee_digis) {
+    const auto& module = triggerGeometry_->getModuleFromCell(eedata.id());
+    auto itr_insert = hit_modules_ee.insert(std::make_pair(module->moduleId(),HGCEEDigiCollection()));
+    itr_insert.first->second.push_back(eedata);
+  }
+  std::unordered_map<uint32_t,HGCHEDigiCollection> hit_modules_fh;
+  for(const auto& fhdata : fh_digis) {
+    const auto& module = triggerGeometry_->getModuleFromCell(fhdata.id());
+    auto itr_insert = hit_modules_fh.insert(std::make_pair(module->moduleId(), HGCHEDigiCollection()));
+    itr_insert.first->second.push_back(fhdata);
+  }
+  // loop on modules containing hits and call front-end processing
+  // we produce one output trigger digi per module in the FE
+  for( const auto& module_hits : hit_modules_ee ) {        
+    const auto& module = triggerGeometry_->modules().at(module_hits.first);
     fe_output->push_back(l1t::HGCFETriggerDigi());
     l1t::HGCFETriggerDigi& digi = fe_output->back();
-    codec_->setDataPayload(*(module.second),ee_digis,fh_digis,bh_digis);
+    codec_->setDataPayload(*module,module_hits.second,HGCHEDigiCollection(),HGCHEDigiCollection());
     codec_->encode(digi);
-    digi.setDetId( HGCalDetId(module.first) );
+    digi.setDetId( HGCalDetId(module_hits.first) );
+    std::stringstream output;
+    codec_->print(digi,output);
+    edm::LogInfo("HGCalTriggerDigiProducer")
+      << output.str();
+    codec_->unSetDataPayload(); 
+  } //end loop on EE modules
+  for( const auto& module_hits : hit_modules_fh ) {        
+    const auto& module = triggerGeometry_->modules().at(module_hits.first);
+    fe_output->push_back(l1t::HGCFETriggerDigi());
+    l1t::HGCFETriggerDigi& digi = fe_output->back();
+    codec_->setDataPayload(*module,HGCEEDigiCollection(),module_hits.second,HGCHEDigiCollection());
+    codec_->encode(digi);
+    digi.setDetId( HGCalDetId(module_hits.first) );
     std::stringstream output;
     codec_->print(digi,output);
     edm::LogInfo("HGCalTriggerDigiProducer")
       << output.str();
     codec_->unSetDataPayload();
-  }
+  } //end loop on FH modules
+
 
   // get the orphan handle and fe digi collection
   auto fe_digis_handle = e.put(std::move(fe_output));

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
@@ -56,8 +56,8 @@ void HGCalTriggerGeometryHexImp1::fillMaps(const es_info& esInfo)
     // read module mapping file
     std::unordered_map<short, short> wafer_to_module_ee;
     std::unordered_map<short, short> wafer_to_module_fh;
-    std::unordered_map<short, std::unordered_map<short,short>> module_to_wafers_ee;
-    std::unordered_map<short, std::unordered_map<short,short>> module_to_wafers_fh;
+    std::unordered_map<short, std::map<short,short>> module_to_wafers_ee;
+    std::unordered_map<short, std::map<short,short>> module_to_wafers_fh;
     std::ifstream l1tModulesMappingStream(l1tModulesMapping_.fullPath());
     if(!l1tModulesMappingStream.is_open()) edm::LogError("HGCalTriggerGeometry") << "Cannot open L1TModulesMapping file\n";
     short subdet  = 0;
@@ -68,13 +68,13 @@ void HGCalTriggerGeometryHexImp1::fillMaps(const es_info& esInfo)
         if(subdet==3)
         {
             wafer_to_module_ee.emplace(wafer,module);
-            auto itr_insert = module_to_wafers_ee.emplace(module, std::unordered_map<short,short>());
+            auto itr_insert = module_to_wafers_ee.emplace(module, std::map<short,short>());
             itr_insert.first->second.emplace(wafer, 0);
         }
         else if(subdet==4)
         {
             wafer_to_module_fh.emplace(wafer,module);
-            auto itr_insert = module_to_wafers_fh.emplace(module, std::unordered_map<short,short>());
+            auto itr_insert = module_to_wafers_fh.emplace(module, std::map<short,short>());
             itr_insert.first->second.emplace(wafer, 0);
         }
         else edm::LogWarning("HGCalTriggerGeometry") << "Unsupported subdetector number ("<<subdet<<") in L1TModulesMapping file\n";

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
@@ -54,10 +54,10 @@ void HGCalTriggerGeometryHexImp1::fillMaps(const es_info& esInfo)
 {
     //
     // read module mapping file
-    std::map<short, short> wafer_to_module_ee;
-    std::map<short, short> wafer_to_module_fh;
-    std::map<short, std::map<short,short>> module_to_wafers_ee;
-    std::map<short, std::map<short,short>> module_to_wafers_fh;
+    std::unordered_map<short, short> wafer_to_module_ee;
+    std::unordered_map<short, short> wafer_to_module_fh;
+    std::unordered_map<short, std::unordered_map<short,short>> module_to_wafers_ee;
+    std::unordered_map<short, std::unordered_map<short,short>> module_to_wafers_fh;
     std::ifstream l1tModulesMappingStream(l1tModulesMapping_.fullPath());
     if(!l1tModulesMappingStream.is_open()) edm::LogError("HGCalTriggerGeometry") << "Cannot open L1TModulesMapping file\n";
     short subdet  = 0;
@@ -68,13 +68,13 @@ void HGCalTriggerGeometryHexImp1::fillMaps(const es_info& esInfo)
         if(subdet==3)
         {
             wafer_to_module_ee.emplace(wafer,module);
-            auto itr_insert = module_to_wafers_ee.emplace(module, std::map<short,short>());
+            auto itr_insert = module_to_wafers_ee.emplace(module, std::unordered_map<short,short>());
             itr_insert.first->second.emplace(wafer, 0);
         }
         else if(subdet==4)
         {
             wafer_to_module_fh.emplace(wafer,module);
-            auto itr_insert = module_to_wafers_fh.emplace(module, std::map<short,short>());
+            auto itr_insert = module_to_wafers_fh.emplace(module, std::unordered_map<short,short>());
             itr_insert.first->second.emplace(wafer, 0);
         }
         else edm::LogWarning("HGCalTriggerGeometry") << "Unsupported subdetector number ("<<subdet<<") in L1TModulesMapping file\n";
@@ -83,7 +83,7 @@ void HGCalTriggerGeometryHexImp1::fillMaps(const es_info& esInfo)
     l1tModulesMappingStream.close();
     // read trigger cell mapping file
     std::map<std::pair<short,short>, short> cells_to_trigger_cells;
-    std::map<short, short> number_trigger_cells_in_wafers; // the map key is the wafer type
+    std::unordered_map<short, short> number_trigger_cells_in_wafers; // the map key is the wafer type
     std::ifstream l1tCellsMappingStream(l1tCellsMapping_.fullPath());
     if(!l1tCellsMappingStream.is_open()) edm::LogError("HGCalTriggerGeometry") << "Cannot open L1TCellsMapping file\n";
     short waferType   = 0;
@@ -181,7 +181,7 @@ void HGCalTriggerGeometryHexImp1::buildTriggerCellsAndModules(const es_info& esI
     // Build trigger cells and fill map
     typedef HGCalTriggerGeometry::TriggerCell::list_type list_cells;
     // make list of cells in trigger cells
-    std::map<unsigned, list_cells> trigger_cells_to_cells;
+    std::unordered_map<unsigned, list_cells> trigger_cells_to_cells;
     for(const auto& cell_triggerCell : cells_to_trigger_cells_)
     {
         unsigned cell        = cell_triggerCell.first;
@@ -213,7 +213,7 @@ void HGCalTriggerGeometryHexImp1::buildTriggerCellsAndModules(const es_info& esI
     typedef HGCalTriggerGeometry::Module::list_type list_triggerCells;
     typedef HGCalTriggerGeometry::Module::tc_map_type tc_map_to_cells;
     // make list of trigger cells in modules
-    std::map<unsigned, list_triggerCells> modules_to_trigger_cells;
+    std::unordered_map<unsigned, list_triggerCells> modules_to_trigger_cells;
     for(const auto& triggerCell_module : trigger_cells_to_modules_)
     {
         unsigned triggerCell = triggerCell_module.first;

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -347,14 +347,14 @@ void HGCalTriggerBestChoiceTester::rerunBestChoiceFragments(const edm::Event& e,
     for(const auto& eedata : ee_digis)
     {
         const auto& module = triggerGeometry_->getModuleFromCell(eedata.id());
-        auto itr_insert = hit_modules_ee.insert(std::make_pair(module->moduleId(),std::vector<HGCEEDataFrame>()));
+        auto itr_insert = hit_modules_ee.emplace(module->moduleId(),std::vector<HGCEEDataFrame>());
         itr_insert.first->second.push_back(eedata);
     }
     std::unordered_map<uint32_t,std::vector<HGCHEDataFrame>> hit_modules_fh;
     for(const auto& fhdata : fh_digis)
     {
         const auto& module = triggerGeometry_->getModuleFromCell(fhdata.id());
-        auto itr_insert = hit_modules_fh.insert(std::make_pair(module->moduleId(), std::vector<HGCHEDataFrame>()));
+        auto itr_insert = hit_modules_fh.emplace(module->moduleId(), std::vector<HGCHEDataFrame>());
         itr_insert.first->second.push_back(fhdata);
     }
     // loop on modules containing hits and call front-end processing

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -52,7 +52,7 @@ class HGCalTriggerBestChoiceTester : public edm::EDAnalyzer
     private:
         void checkSelectedCells(const edm::Event&, const edm::EventSetup&);
         void rerunBestChoiceFragments(const edm::Event&, const edm::EventSetup&);
-        void fillModule(const std::vector<HGCDataFrame<HGCalDetId,HGCSample>>&, const std::vector<std::pair<HGCalDetId, uint32_t > >&, const HGCalBestChoiceDataPayload&,  const HGCalBestChoiceDataPayload&,const HGCalBestChoiceDataPayload&,   const std::map <HGCalDetId,double>&, const std::map<uint32_t, double>& );
+        void fillModule(const std::vector<HGCDataFrame<HGCalDetId,HGCSample>>&, const std::vector<std::pair<HGCalDetId, uint32_t > >&, const HGCalBestChoiceDataPayload&,  const HGCalBestChoiceDataPayload&,const HGCalBestChoiceDataPayload&,   const std::map <HGCalDetId,double>&, const std::unordered_map<uint32_t, double>& );
 
         // inputs
         edm::EDGetToken inputee_, inputfh_, inputbh_, inputbeall_, inputbeselect_;
@@ -378,7 +378,7 @@ void HGCalTriggerBestChoiceTester::rerunBestChoiceFragments(const edm::Event& e,
         }
         const auto& module_ptr = triggerGeometry_->modules().at(module_hits.first);
         // Association simhit energies with trigger cells
-        std::map<uint32_t, double> TC_simhit_energies;
+        std::unordered_map<uint32_t, double> TC_simhit_energies;
         if (is_Simhit_comp_) 
         {
             for(const auto& tc_c : module_ptr->triggerCellComponents())
@@ -422,7 +422,7 @@ void HGCalTriggerBestChoiceTester::rerunBestChoiceFragments(const edm::Event& e,
         }
         const auto& module_ptr = triggerGeometry_->modules().at(module_hits.first);
         // Association simhit energies with trigger cells
-        std::map<uint32_t, double> TC_simhit_energies;
+        std::unordered_map<uint32_t, double> TC_simhit_energies;
         if (is_Simhit_comp_) 
         {
             for(const auto& tc_c : module_ptr->triggerCellComponents())
@@ -452,7 +452,7 @@ void HGCalTriggerBestChoiceTester::rerunBestChoiceFragments(const edm::Event& e,
 
 
 /*****************************************************************/
-void HGCalTriggerBestChoiceTester::fillModule( const std::vector<HGCDataFrame<HGCalDetId,HGCSample>>& dataframes,  const std::vector<std::pair<HGCalDetId, uint32_t > >& linearized_dataframes, const HGCalBestChoiceDataPayload& fe_payload_TCsums_woBestChoice, const HGCalBestChoiceDataPayload& fe_payload_TCsums_BestChoice, const HGCalBestChoiceDataPayload& fe_payload, const std::map <HGCalDetId,double>& simhit_energies, const std::map<uint32_t, double>& TC_simhit_energies)
+void HGCalTriggerBestChoiceTester::fillModule( const std::vector<HGCDataFrame<HGCalDetId,HGCSample>>& dataframes,  const std::vector<std::pair<HGCalDetId, uint32_t > >& linearized_dataframes, const HGCalBestChoiceDataPayload& fe_payload_TCsums_woBestChoice, const HGCalBestChoiceDataPayload& fe_payload_TCsums_BestChoice, const HGCalBestChoiceDataPayload& fe_payload, const std::map <HGCalDetId,double>& simhit_energies, const std::unordered_map<uint32_t, double>& TC_simhit_energies)
 
 /*****************************************************************/
 {


### PR DESCRIPTION
- Reduce front-end processing time by a factor of ~1000-2000 for events without pile-up (from about 3min / evt to about 100ms / event, tested with particle guns).
- Only modules containing hits are processed, and hits in each module are preselected before the codec is called. 
- It removes a double loop on all modules + all hits and replace it with a single loop on all hits followed by a double loop on selected modules and associated hits.
