### PR TITLE
Preliminary ntuplizer

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h
@@ -1,0 +1,27 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTriggerNtupleBase_h__
+#define __L1Trigger_L1THGCal_HGCalTriggerNtupleBase_h__
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include"TTree.h"
+
+
+class HGCalTriggerNtupleBase
+{
+    public:
+        HGCalTriggerNtupleBase(const edm::ParameterSet& conf) {};
+        virtual ~HGCalTriggerNtupleBase(){};	
+        virtual void initialize(TTree& , const edm::ParameterSet&, edm::ConsumesCollector&& ) = 0;
+        virtual void fill(const edm::Event& , const edm::EventSetup& ) = 0;
+
+    protected:
+        virtual void clear() = 0;
+};
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory< HGCalTriggerNtupleBase* (const edm::ParameterSet&) > HGCalTriggerNtupleFactory;
+
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCal/plugins/BuildFile.xml
@@ -21,3 +21,9 @@
   <use   name="DataFormats/L1THGCal"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+
+<library   name="L1TriggerL1THGCalPlugins_ntuples" file="ntuples/*.cc">
+  <use   name="L1Trigger/L1THGCal"/>  
+  <use   name="CommonTools/UtilAlgos"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleEvent.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleEvent.cc
@@ -1,0 +1,58 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+
+class HGCalTriggerNtupleEvent : public HGCalTriggerNtupleBase
+{
+    public:
+        HGCalTriggerNtupleEvent(const edm::ParameterSet&);
+
+        virtual void initialize(TTree&,const edm::ParameterSet&, edm::ConsumesCollector &&) override final;
+        virtual void fill(const edm::Event&,const edm::EventSetup&) override final;
+
+    private:
+        virtual void clear() override final;
+
+        int run_;
+        int event_;
+        int lumi_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+        HGCalTriggerNtupleEvent,
+        "HGCalTriggerNtupleEvent" );
+
+
+HGCalTriggerNtupleEvent::
+HGCalTriggerNtupleEvent(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+HGCalTriggerNtupleEvent::
+initialize(TTree& tree,const edm::ParameterSet&, edm::ConsumesCollector&&)
+{
+    clear();
+    tree.Branch("run", &run_, "run/I"  );
+    tree.Branch("event", &event_, "event/I");
+    tree.Branch("lumi", &lumi_, "lumi/I");
+}
+
+void
+HGCalTriggerNtupleEvent::
+fill(const edm::Event& e,const edm::EventSetup& es)
+{
+    run_ = e.id().run();
+    lumi_ = e.luminosityBlock();
+    event_ = e.id().event();
+}
+
+void
+HGCalTriggerNtupleEvent::
+clear()
+{
+    run_ = 0;
+    lumi_ = 0;
+    event_ = 0;
+}
+
+
+

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -1,0 +1,98 @@
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+
+
+
+class HGCalTriggerNtupleGen : public HGCalTriggerNtupleBase
+{
+
+    public:
+        HGCalTriggerNtupleGen(const edm::ParameterSet& );
+
+        virtual void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) override final;
+        virtual void fill(const edm::Event&, const edm::EventSetup& ) override final;
+
+    private:
+        virtual void clear() override final;
+
+        edm::EDGetToken gen_token_;
+        int gen_n_;
+        std::vector<int>   gen_id_;
+        std::vector<int>   gen_status_;
+        std::vector<float> gen_energy_;
+        std::vector<float> gen_pt_;
+        std::vector<float> gen_eta_;
+        std::vector<float> gen_phi_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+        HGCalTriggerNtupleGen,
+        "HGCalTriggerNtupleGen" );
+
+
+HGCalTriggerNtupleGen::
+HGCalTriggerNtupleGen(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+HGCalTriggerNtupleGen::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+
+    gen_token_ = collector.consumes<reco::GenParticleCollection>(conf.getParameter<edm::InputTag>("GenParticles"));
+    tree.Branch("gen_n", &gen_n_, "gen_n/I");
+    tree.Branch("gen_id", &gen_id_);
+    tree.Branch("gen_status", &gen_status_);
+    tree.Branch("gen_energy", &gen_energy_);
+    tree.Branch("gen_pt", &gen_pt_);
+    tree.Branch("gen_eta", &gen_eta_);
+    tree.Branch("gen_phi", &gen_phi_);
+
+}
+
+void
+HGCalTriggerNtupleGen::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+    edm::Handle<reco::GenParticleCollection> gen_particles_h;
+    e.getByToken(gen_token_, gen_particles_h);
+    const reco::GenParticleCollection& gen_particles = *gen_particles_h;
+
+    clear();
+    gen_n_ = gen_particles.size();
+    gen_id_.reserve(gen_n_);
+    gen_status_.reserve(gen_n_);
+    gen_energy_.reserve(gen_n_);
+    gen_pt_.reserve(gen_n_);
+    gen_eta_.reserve(gen_n_);
+    gen_phi_.reserve(gen_n_);
+    for(const auto& particle : gen_particles)
+    {
+        gen_id_.emplace_back(particle.pdgId());
+        gen_status_.emplace_back(particle.status());
+        gen_energy_.emplace_back(particle.energy());
+        gen_pt_.emplace_back(particle.pt());
+        gen_eta_.emplace_back(particle.eta());
+        gen_phi_.emplace_back(particle.phi());
+    }
+
+}
+
+
+void
+HGCalTriggerNtupleGen::
+clear()
+{
+    gen_n_ = 0;
+    gen_id_.clear();
+    gen_status_.clear();
+    gen_energy_.clear();
+    gen_pt_.clear();
+    gen_eta_.clear();
+    gen_phi_.clear();
+}
+
+
+
+

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -1,0 +1,133 @@
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+
+
+
+class HGCalTriggerNtupleHGCDigis : public HGCalTriggerNtupleBase
+{
+
+    public:
+        HGCalTriggerNtupleHGCDigis(const edm::ParameterSet& conf);
+        ~HGCalTriggerNtupleHGCDigis(){};
+        virtual void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) override final;
+        virtual void fill(const edm::Event& e, const edm::EventSetup& es) override final;
+
+    private:
+        virtual void clear() override final;
+
+        edm::EDGetToken ee_token_, fh_token_, bh_token_;
+
+        int hgcdigi_n_ ;
+        std::vector<int> hgcdigi_id_;
+        std::vector<int> hgcdigi_subdet_;
+        std::vector<int> hgcdigi_side_;
+        std::vector<int> hgcdigi_layer_;
+        std::vector<int> hgcdigi_wafer_;
+        std::vector<int> hgcdigi_wafertype_ ;
+        std::vector<int> hgcdigi_cell_;
+        std::vector<uint32_t> hgcdigi_data_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+        HGCalTriggerNtupleHGCDigis,
+        "HGCalTriggerNtupleHGCDigis" );
+
+
+HGCalTriggerNtupleHGCDigis::
+HGCalTriggerNtupleHGCDigis(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf)
+{
+}
+
+void
+HGCalTriggerNtupleHGCDigis::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+
+    ee_token_ = collector.consumes<HGCEEDigiCollection>(conf.getParameter<edm::InputTag>("HGCDigisEE")); 
+    fh_token_ = collector.consumes<HGCHEDigiCollection>(conf.getParameter<edm::InputTag>("HGCDigisFH"));
+
+    tree.Branch("hgcdigi_n", &hgcdigi_n_, "hgcdigi_n/I");
+    tree.Branch("hgcdigi_id", &hgcdigi_id_);
+    tree.Branch("hgcdigi_subdet", &hgcdigi_subdet_);
+    tree.Branch("hgcdigi_zside", &hgcdigi_side_);
+    tree.Branch("hgcdigi_layer", &hgcdigi_layer_);
+    tree.Branch("hgcdigi_wafer", &hgcdigi_wafer_);
+    tree.Branch("hgcdigi_wafertype", &hgcdigi_wafertype_);
+    tree.Branch("hgcdigi_cell", &hgcdigi_cell_);    
+    tree.Branch("hgcdigi_data", &hgcdigi_data_);
+
+}
+
+void
+HGCalTriggerNtupleHGCDigis::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+    edm::Handle<HGCEEDigiCollection> ee_digis_h;
+    edm::Handle<HGCHEDigiCollection> fh_digis_h;
+
+    e.getByToken(ee_token_, ee_digis_h);
+    e.getByToken(fh_token_, fh_digis_h);
+
+    const HGCEEDigiCollection& ee_digis = *ee_digis_h;
+    const HGCHEDigiCollection& fh_digis = *fh_digis_h;
+
+    clear();
+    hgcdigi_n_ = ee_digis.size() + fh_digis.size();
+    hgcdigi_id_.reserve(hgcdigi_n_);
+    hgcdigi_subdet_.reserve(hgcdigi_n_);
+    hgcdigi_side_.reserve(hgcdigi_n_);
+    hgcdigi_layer_.reserve(hgcdigi_n_);
+    hgcdigi_wafer_.reserve(hgcdigi_n_);
+    hgcdigi_wafertype_.reserve(hgcdigi_n_);
+    hgcdigi_cell_.reserve(hgcdigi_n_);
+    hgcdigi_data_.reserve(hgcdigi_n_);
+    for(const auto& digi : ee_digis)
+    {
+        const HGCalDetId id(digi.id());
+
+        hgcdigi_id_.emplace_back(id.rawId());
+        hgcdigi_subdet_.emplace_back(ForwardSubdetector::HGCEE);
+        hgcdigi_side_.emplace_back(id.zside());
+        hgcdigi_layer_.emplace_back(id.layer());
+        hgcdigi_wafer_.emplace_back(id.wafer());
+        hgcdigi_wafertype_.emplace_back(id.waferType());
+        hgcdigi_cell_.emplace_back(id.cell());
+        hgcdigi_data_.emplace_back(digi[2].raw()); // in-time
+    }
+    for(const auto& digi : fh_digis)
+    {
+        const HGCalDetId id(digi.id());
+
+        hgcdigi_id_.emplace_back(id.rawId());
+        hgcdigi_subdet_.emplace_back(ForwardSubdetector::HGCHEF);
+        hgcdigi_side_.emplace_back(id.zside());
+        hgcdigi_layer_.emplace_back(id.layer());
+        hgcdigi_wafer_.emplace_back(id.wafer());
+        hgcdigi_wafertype_.emplace_back(id.waferType());
+        hgcdigi_cell_.emplace_back(id.cell());
+        hgcdigi_data_.emplace_back(digi[2].raw()); // in-time
+    }
+}
+
+
+void
+HGCalTriggerNtupleHGCDigis::
+clear()
+{
+    hgcdigi_n_ = 0;
+    hgcdigi_id_.clear();
+    hgcdigi_subdet_.clear();
+    hgcdigi_side_.clear();
+    hgcdigi_layer_.clear();
+    hgcdigi_wafer_.clear();
+    hgcdigi_wafertype_.clear();
+    hgcdigi_cell_.clear();
+    hgcdigi_data_.clear();
+}
+
+
+
+

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -17,7 +17,7 @@ class HGCalTriggerNtupleHGCDigis : public HGCalTriggerNtupleBase
     private:
         virtual void clear() override final;
 
-        edm::EDGetToken ee_token_, fh_token_, bh_token_;
+        edm::EDGetToken ee_token_, fh_token_;
 
         int hgcdigi_n_ ;
         std::vector<int> hgcdigi_id_;

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleManager.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleManager.cc
@@ -2,18 +2,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
-//#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-//#include "FWCore/Framework/interface/ESTransientHandle.h"
-//#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
-//#include "TTree.h"
-//#include <iostream>
-//#include <string>
-//#include <vector>
 
 class HGCalTriggerNtupleManager : public edm::EDAnalyzer 
 {

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleManager.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleManager.cc
@@ -1,0 +1,63 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+//#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+//#include "FWCore/Framework/interface/ESTransientHandle.h"
+//#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+//#include "TTree.h"
+//#include <iostream>
+//#include <string>
+//#include <vector>
+
+class HGCalTriggerNtupleManager : public edm::EDAnalyzer 
+{
+    public:
+        typedef std::unique_ptr<HGCalTriggerNtupleBase> ntuple_ptr;
+
+    public:
+        explicit HGCalTriggerNtupleManager(const edm::ParameterSet& conf);
+        ~HGCalTriggerNtupleManager(){};
+        virtual void beginRun(const edm::Run&, const edm::EventSetup&) {};
+        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+    private:
+        edm::Service<TFileService> file_service_;
+        std::vector<ntuple_ptr> hgc_ntuples_;
+        TTree* tree_;
+};
+
+
+DEFINE_FWK_MODULE(HGCalTriggerNtupleManager);
+
+
+HGCalTriggerNtupleManager::
+HGCalTriggerNtupleManager(const edm::ParameterSet& conf) 
+{
+    tree_ = file_service_->make<TTree>("HGCalTriggerNtuple","HGCalTriggerNtuple");    
+    const std::vector<edm::ParameterSet> ntuple_cfgs = conf.getParameterSetVector("Ntuples");
+    for(const auto& ntuple_cfg : ntuple_cfgs) 
+    {
+        const std::string& ntuple_name = ntuple_cfg.getParameter<std::string>("NtupleName");
+        hgc_ntuples_.emplace_back( HGCalTriggerNtupleFactory::get()->create(ntuple_name, ntuple_cfg) );
+        hgc_ntuples_.back()->initialize(*tree_, ntuple_cfg , consumesCollector());
+    }
+}
+
+
+void 
+HGCalTriggerNtupleManager::
+analyze(const edm::Event& e, const edm::EventSetup& es) 
+{
+    for(auto& hgc_ntuple : hgc_ntuples_)
+    {
+        hgc_ntuple->fill(e,es);
+    }
+    tree_->Fill();
+}
+

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCal.hgcalTriggerNtuples_cfi import *
+
+hgcalTriggerNtuples = cms.Sequence(hgcalTriggerNtuplizer)

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+
+ntuple_event = cms.PSet(
+    NtupleName = cms.string('HGCalTriggerNtupleEvent')
+)
+
+ntuple_gen = cms.PSet(
+    NtupleName = cms.string('HGCalTriggerNtupleGen'),
+    GenParticles = cms.InputTag('genParticles')
+)
+
+ntuple_digis = cms.PSet(
+    NtupleName = cms.string('HGCalTriggerNtupleHGCDigis'),
+    HGCDigisEE = cms.InputTag('mix:HGCDigisEE'),
+    HGCDigisFH = cms.InputTag('mix:HGCDigisHEfront')
+)
+
+
+hgcalTriggerNtuplizer = cms.EDAnalyzer(
+    "HGCalTriggerNtupleManager",
+    Ntuples = cms.VPSet(
+        ntuple_event,
+        ntuple_gen,
+        ntuple_digis
+    )
+)

--- a/L1Trigger/L1THGCal/src/HGCalTriggerNtupleBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerNtupleBase.cc
@@ -1,0 +1,6 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+
+EDM_REGISTER_PLUGINFACTORY(HGCalTriggerNtupleFactory,
+                           "HGCalTriggerNtupleFactory");
+
+


### PR DESCRIPTION
Related to #47 
Implement the structure of a common and flexible ntuplizer. 

Variables to be stored in the output ntuple are defined in classes inheriting from `HGCalTriggerNtupleBase`. Instances of these classes are created by a `HGCalTriggerNtupleManager`, which manages the ntuple branching and filling.
The choice of variables to be stored in the ntuple is configurable.

Currently only a minimal set of object variables can be stored (event info, gen particles, raw HGC digis info).
