### PR TITLE
Add pointer to the geometry in FE codec and BE algos

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
@@ -29,7 +29,8 @@
 
 class HGCalTriggerBackendAlgorithmBase { 
  public:    
-  HGCalTriggerBackendAlgorithmBase(const edm::ParameterSet& conf) : 
+  HGCalTriggerBackendAlgorithmBase(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) : 
+    geometry_(geom),
     name_(conf.getParameter<std::string>("AlgorithmName"))
     {}
   virtual ~HGCalTriggerBackendAlgorithmBase() {}
@@ -39,13 +40,14 @@ class HGCalTriggerBackendAlgorithmBase {
   //runs the trigger algorithm, storing internally the results
   virtual void setProduces(edm::EDProducer& prod) const = 0;
 
-  virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
-                   const std::unique_ptr<HGCalTriggerGeometryBase>& geom) = 0;
+  virtual void run(const l1t::HGCFETriggerDigiCollection& coll) = 0;
 
   virtual void putInEvent(edm::Event& evt) = 0;
 
   virtual void reset() = 0;
 
+ protected:
+  const HGCalTriggerGeometryBase* const geometry_;
 
  private:
   const std::string name_;
@@ -57,9 +59,9 @@ namespace HGCalTriggerBackend {
   template<typename FECODEC>
   class Algorithm : public HGCalTriggerBackendAlgorithmBase { 
   public:
-    Algorithm(const edm::ParameterSet& conf) :  
-    HGCalTriggerBackendAlgorithmBase(conf),
-    codec_(conf.getParameterSet("FECodec")){ }
+    Algorithm(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) :  
+    HGCalTriggerBackendAlgorithmBase(conf,geom),
+    codec_(conf.getParameterSet("FECodec"),geom){ }
     
   protected:    
     FECODEC codec_;  
@@ -67,6 +69,6 @@ namespace HGCalTriggerBackend {
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< HGCalTriggerBackendAlgorithmBase* (const edm::ParameterSet&) > HGCalTriggerBackendAlgorithmFactory;
+typedef edmplugin::PluginFactory< HGCalTriggerBackendAlgorithmBase* (const edm::ParameterSet&, const HGCalTriggerGeometryBase* const) > HGCalTriggerBackendAlgorithmFactory;
 
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
@@ -31,12 +31,11 @@ class HGCalTriggerBackendProcessor {
  public:
   typedef std::unique_ptr<HGCalTriggerBackendAlgorithmBase> algo_ptr;
 
-  HGCalTriggerBackendProcessor(const edm::ParameterSet& conf);
+  HGCalTriggerBackendProcessor(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom);
 
   void setProduces(edm::EDProducer& prod) const;
 
-  void run(const l1t::HGCFETriggerDigiCollection& coll,
-           const std::unique_ptr<HGCalTriggerGeometryBase>& geom);
+  void run(const l1t::HGCFETriggerDigiCollection& coll);
 
   void putInEvent(edm::Event& evt);
 

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -16,19 +16,17 @@ class HGCal64BitRandomCodec : public HGCalTriggerFE::Codec<HGCal64BitRandomCodec
 public:
   typedef HGCal64BitRandomDataPayload data_type;
   
-  HGCal64BitRandomCodec(const edm::ParameterSet& conf) :
-    Codec(conf),
+  HGCal64BitRandomCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) :
+    Codec(conf,geom),
     codecImpl_(conf) {
     data_.payload = std::numeric_limits<uint64_t>::max();
   }
 
-  void setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-                          const HGCEEDigiCollection& ee,
+  void setDataPayloadImpl(const HGCEEDigiCollection& ee,
                           const HGCHEDigiCollection& fh,
                           const HGCHEDigiCollection& bh );
 
-  void setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-                          const l1t::HGCFETriggerDigi& digi);
+  void setDataPayloadImpl(const l1t::HGCFETriggerDigi& digi);
   
   std::vector<bool> encodeImpl(const data_type&) const ;
   data_type         decodeImpl(const std::vector<bool>&) const;  

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -21,15 +21,13 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
     public:
         typedef HGCalBestChoiceDataPayload data_type;
 
-        HGCalBestChoiceCodec(const edm::ParameterSet& conf);
+        HGCalBestChoiceCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom);
 
-        void setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-                const HGCEEDigiCollection& ee,
+        void setDataPayloadImpl(const HGCEEDigiCollection& ee,
                 const HGCHEDigiCollection& fh,
                 const HGCHEDigiCollection& bh );
 
-        void setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-                const l1t::HGCFETriggerDigi& digi);
+        void setDataPayloadImpl(const l1t::HGCFETriggerDigi& digi);
 
         std::vector<bool> encodeImpl(const data_type&) const ;
         data_type         decodeImpl(const std::vector<bool>&) const;  

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
@@ -10,8 +10,8 @@ class FullModuleSumAlgo : public Algorithm<HGCalBestChoiceCodec>
 {
     public:
 
-        FullModuleSumAlgo(const edm::ParameterSet& conf):
-            Algorithm<HGCalBestChoiceCodec>(conf),
+        FullModuleSumAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
+            Algorithm<HGCalBestChoiceCodec>(conf,geom),
             cluster_product_( new l1t::HGCalClusterBxCollection ){}
 
         virtual void setProduces(edm::EDProducer& prod) const override final 
@@ -19,8 +19,7 @@ class FullModuleSumAlgo : public Algorithm<HGCalBestChoiceCodec>
             prod.produces<l1t::HGCalClusterBxCollection>(name());
         }
 
-        virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
-                const std::unique_ptr<HGCalTriggerGeometryBase>& geom) override final;
+        virtual void run(const l1t::HGCFETriggerDigiCollection& coll) override final;
 
         virtual void putInEvent(edm::Event& evt) override final 
         {
@@ -38,8 +37,7 @@ class FullModuleSumAlgo : public Algorithm<HGCalBestChoiceCodec>
 };
 
 /*****************************************************************/
-void FullModuleSumAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
-        const std::unique_ptr<HGCalTriggerGeometryBase>& geom) 
+void FullModuleSumAlgo::run(const l1t::HGCFETriggerDigiCollection& coll) 
 /*****************************************************************/
 {
     for( const auto& digi : coll ) 

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/RandomClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/RandomClusterAlgo.cc
@@ -8,8 +8,8 @@ using namespace HGCalTriggerBackend;
 class RandomClusterAlgo : public Algorithm<HGCal64BitRandomCodec> {
 public:
   
-  RandomClusterAlgo(const edm::ParameterSet& conf):
-    Algorithm<HGCal64BitRandomCodec>(conf),
+  RandomClusterAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
+    Algorithm<HGCal64BitRandomCodec>(conf,geom),
     cluster_product_( new l1t::HGCalClusterBxCollection ){
   }
 
@@ -17,8 +17,7 @@ public:
     prod.produces<l1t::HGCalClusterBxCollection>(name());
   }
 
-  virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
-                   const std::unique_ptr<HGCalTriggerGeometryBase>& geom) override final;
+  virtual void run(const l1t::HGCFETriggerDigiCollection& coll) override final;
 
   virtual void putInEvent(edm::Event& evt) override final {
     evt.put(std::move(cluster_product_),name());
@@ -33,8 +32,7 @@ private:
 
 };
 
-void RandomClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
-                            const std::unique_ptr<HGCalTriggerGeometryBase>& geom) {
+void RandomClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll) {
   for( const auto& digi : coll ) {
     HGCal64BitRandomCodec::data_type my_data;
     digi.decode(codec_,my_data);

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
@@ -10,8 +10,8 @@ class SingleCellClusterAlgo : public Algorithm<HGCalBestChoiceCodec>
 {
     public:
 
-        SingleCellClusterAlgo(const edm::ParameterSet& conf):
-            Algorithm<HGCalBestChoiceCodec>(conf),
+        SingleCellClusterAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
+            Algorithm<HGCalBestChoiceCodec>(conf,geom),
             cluster_product_( new l1t::HGCalClusterBxCollection ){}
 
         virtual void setProduces(edm::EDProducer& prod) const override final 
@@ -19,8 +19,7 @@ class SingleCellClusterAlgo : public Algorithm<HGCalBestChoiceCodec>
             prod.produces<l1t::HGCalClusterBxCollection>(name());
         }
 
-        virtual void run(const l1t::HGCFETriggerDigiCollection& coll,
-                const std::unique_ptr<HGCalTriggerGeometryBase>& geom) override final;
+        virtual void run(const l1t::HGCFETriggerDigiCollection& coll) override final;
 
         virtual void putInEvent(edm::Event& evt) override final 
         {
@@ -38,8 +37,7 @@ class SingleCellClusterAlgo : public Algorithm<HGCalBestChoiceCodec>
 };
 
 /*****************************************************************/
-void SingleCellClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
-        const std::unique_ptr<HGCalTriggerGeometryBase>& geom) 
+void SingleCellClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll) 
 /*****************************************************************/
 {
     for( const auto& digi : coll ) 
@@ -53,7 +51,7 @@ void SingleCellClusterAlgo::run(const l1t::HGCFETriggerDigiCollection& coll,
         {
             if(value>0)
             {
-                GlobalPoint point = geom->getModulePosition(moduleId);
+                GlobalPoint point = geometry_->getModulePosition(moduleId);
                 math::PtEtaPhiMLorentzVector p4((double)value/cosh(point.eta()), point.eta(), point.phi(), 0.);
                 // index in module stored as hwEta
                 l1t::HGCalCluster cluster( 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCal64BitRandomCodec.cc
@@ -7,16 +7,14 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
                   "HGCal64BitRandomCodec");
 
 void HGCal64BitRandomCodec::
-setDataPayloadImpl(const HGCalTriggerGeometryBase& , 
-                   const HGCEEDigiCollection&,
+setDataPayloadImpl(const HGCEEDigiCollection&,
                    const HGCHEDigiCollection&,
                    const HGCHEDigiCollection& ) {
   codecImpl_.setDataPayload(data_);
 }
 
 void HGCal64BitRandomCodec::
-setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-                   const l1t::HGCFETriggerDigi& digi) {
+setDataPayloadImpl(const l1t::HGCFETriggerDigi& digi) {
   codecImpl_.setDataPayload(data_);
 }
 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -9,7 +9,7 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
         "HGCalBestChoiceCodec");
 
 /*****************************************************************/
-HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Codec(conf),
+HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) : Codec(conf,geom),
     codecImpl_(conf)
 /*****************************************************************/
 {
@@ -17,8 +17,7 @@ HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Code
 
 
 /*****************************************************************/
-void HGCalBestChoiceCodec::setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-        const HGCEEDigiCollection& ee,
+void HGCalBestChoiceCodec::setDataPayloadImpl(const HGCEEDigiCollection& ee,
         const HGCHEDigiCollection& fh,
         const HGCHEDigiCollection& ) 
 /*****************************************************************/
@@ -52,14 +51,13 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const HGCalTriggerGeometryBase& ge
     // linearize input energy on 16 bits
     codecImpl_.linearize(dataframes, linearized_dataframes);
     // sum energy in trigger cells
-    codecImpl_.triggerCellSums(geom, linearized_dataframes, data_);
+    codecImpl_.triggerCellSums(*geometry_, linearized_dataframes, data_);
     // choose best trigger cells in the module
     codecImpl_.bestChoiceSelect(data_);
 }
 
 /*****************************************************************/
-void HGCalBestChoiceCodec::setDataPayloadImpl(const HGCalTriggerGeometryBase& geom, 
-        const l1t::HGCFETriggerDigi& digi)
+void HGCalBestChoiceCodec::setDataPayloadImpl(const l1t::HGCFETriggerDigi& digi)
 /*****************************************************************/
 {
     data_.reset();
@@ -82,7 +80,7 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const HGCalTriggerGeometryBase& ge
     conf.addParameter<uint32_t>   ("tdcnBits",      codecImpl_.tdcnBits());
     conf.addParameter<double>     ("tdcOnsetfC",    codecImpl_.tdcOnsetfC());
     conf.addParameter<uint32_t>   ("triggerCellTruncationBits", codecImpl_.triggerCellTruncationBits());
-    HGCalBestChoiceCodec codecInput(conf);
+    HGCalBestChoiceCodec codecInput(conf, geometry_);
     digi.decode(codecInput,data_);
     // choose best trigger cells in the module
     codecImpl_.bestChoiceSelect(data_);

--- a/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
@@ -1,14 +1,14 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h"
 
 HGCalTriggerBackendProcessor::
-HGCalTriggerBackendProcessor(const edm::ParameterSet& conf) {
+HGCalTriggerBackendProcessor(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) {
   const std::vector<edm::ParameterSet> be_confs = 
     conf.getParameterSetVector("algorithms");
   for( const auto& algo_cfg : be_confs ) {
     const std::string& algo_name = 
       algo_cfg.getParameter<std::string>("AlgorithmName");
     HGCalTriggerBackendAlgorithmBase* algo = 
-      HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg);
+      HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg,geom);
     algorithms_.emplace_back(algo);
   }
 }
@@ -20,10 +20,9 @@ void HGCalTriggerBackendProcessor::setProduces(edm::EDProducer& prod) const {
 }
 
 void HGCalTriggerBackendProcessor::
-run(const l1t::HGCFETriggerDigiCollection& coll,
-    const std::unique_ptr<HGCalTriggerGeometryBase>& geom) {
+run(const l1t::HGCFETriggerDigiCollection& coll) {
   for( auto& algo : algorithms_ ) {
-    algo->run(coll,geom);
+    algo->run(coll);
   }
 }
 


### PR DESCRIPTION
Pass pointers to the trigger geometry in the FE codec and in the BE algo constructor, instead of passing them to the setDataPayload() or run() methods.
Access to the geometry will be needed for instance in the decode() method in the future. Having a pointer to the geometry in the class will facilitate this access.

See #46 
