### PR TITLE
Geometry included in EventSetup

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
@@ -29,13 +29,15 @@
 
 class HGCalTriggerBackendAlgorithmBase { 
  public:    
-  HGCalTriggerBackendAlgorithmBase(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) : 
-    geometry_(geom),
+  HGCalTriggerBackendAlgorithmBase(const edm::ParameterSet& conf) : 
+    geometry_(nullptr),
     name_(conf.getParameter<std::string>("AlgorithmName"))
     {}
   virtual ~HGCalTriggerBackendAlgorithmBase() {}
 
   const std::string& name() const { return name_; } 
+
+  virtual void setGeometry(const HGCalTriggerGeometryBase* const geom) {geometry_ = geom;}
     
   //runs the trigger algorithm, storing internally the results
   virtual void setProduces(edm::EDProducer& prod) const = 0;
@@ -47,7 +49,7 @@ class HGCalTriggerBackendAlgorithmBase {
   virtual void reset() = 0;
 
  protected:
-  const HGCalTriggerGeometryBase* const geometry_;
+  const HGCalTriggerGeometryBase* geometry_;
 
  private:
   const std::string name_;
@@ -59,9 +61,14 @@ namespace HGCalTriggerBackend {
   template<typename FECODEC>
   class Algorithm : public HGCalTriggerBackendAlgorithmBase { 
   public:
-    Algorithm(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) :  
-    HGCalTriggerBackendAlgorithmBase(conf,geom),
-    codec_(conf.getParameterSet("FECodec"),geom){ }
+    Algorithm(const edm::ParameterSet& conf) :  
+    HGCalTriggerBackendAlgorithmBase(conf),
+    codec_(conf.getParameterSet("FECodec")){ }
+
+    virtual void setGeometry(const HGCalTriggerGeometryBase* const geom) override final {
+      HGCalTriggerBackendAlgorithmBase::setGeometry(geom);
+      codec_.setGeometry(geom);
+    }
     
   protected:    
     FECODEC codec_;  
@@ -69,6 +76,6 @@ namespace HGCalTriggerBackend {
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< HGCalTriggerBackendAlgorithmBase* (const edm::ParameterSet&, const HGCalTriggerGeometryBase* const) > HGCalTriggerBackendAlgorithmFactory;
+typedef edmplugin::PluginFactory< HGCalTriggerBackendAlgorithmBase* (const edm::ParameterSet&) > HGCalTriggerBackendAlgorithmFactory;
 
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
@@ -31,7 +31,9 @@ class HGCalTriggerBackendProcessor {
  public:
   typedef std::unique_ptr<HGCalTriggerBackendAlgorithmBase> algo_ptr;
 
-  HGCalTriggerBackendProcessor(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom);
+  HGCalTriggerBackendProcessor(const edm::ParameterSet& conf);
+
+  void setGeometry(const HGCalTriggerGeometryBase* const geom);
 
   void setProduces(edm::EDProducer& prod) const;
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerFECodecBase.h
@@ -25,8 +25,8 @@
 
 class HGCalTriggerFECodecBase { 
  public:  
-  HGCalTriggerFECodecBase(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) : 
-    geometry_(geom),
+  HGCalTriggerFECodecBase(const edm::ParameterSet& conf) : 
+    geometry_(nullptr),
     name_(conf.getParameter<std::string>("CodecName")),
     codec_idx_(static_cast<unsigned char>(conf.getParameter<uint32_t>("CodecIndex")))
     {}
@@ -35,8 +35,9 @@ class HGCalTriggerFECodecBase {
   const std::string& name() const { return name_; } 
   
   const unsigned char getCodecType() const { return codec_idx_; }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { geometry_ = geom;}
   
-  // give the FECodec the trigger geometry + input digis and it sets itself
+  // give the FECodec the input digis and it sets itself
   // with the approprate data
   virtual void setDataPayload(const HGCEEDigiCollection&,
                               const HGCHEDigiCollection&,
@@ -54,7 +55,7 @@ class HGCalTriggerFECodecBase {
                      std::ostream& out = std::cout) const = 0;
 
  protected:
-  const HGCalTriggerGeometryBase* const geometry_;
+  const HGCalTriggerGeometryBase* geometry_;
 
  private:
   const std::string name_;
@@ -67,8 +68,8 @@ namespace HGCalTriggerFE {
   template<typename Impl,typename DATA>
   class Codec : public HGCalTriggerFECodecBase { 
   public:
-    Codec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) :  
-    HGCalTriggerFECodecBase(conf, geom),
+    Codec(const edm::ParameterSet& conf) :  
+    HGCalTriggerFECodecBase(conf),
     dataIsSet_(false) {
     }
     
@@ -143,6 +144,6 @@ namespace HGCalTriggerFE {
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< HGCalTriggerFECodecBase* (const edm::ParameterSet&, const HGCalTriggerGeometryBase* const) > HGCalTriggerFECodecFactory;
+typedef edmplugin::PluginFactory< HGCalTriggerFECodecBase* (const edm::ParameterSet&) > HGCalTriggerFECodecFactory;
 
 #endif

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCal64BitRandomCodec.h
@@ -16,8 +16,8 @@ class HGCal64BitRandomCodec : public HGCalTriggerFE::Codec<HGCal64BitRandomCodec
 public:
   typedef HGCal64BitRandomDataPayload data_type;
   
-  HGCal64BitRandomCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) :
-    Codec(conf,geom),
+  HGCal64BitRandomCodec(const edm::ParameterSet& conf) :
+    Codec(conf),
     codecImpl_(conf) {
     data_.payload = std::numeric_limits<uint64_t>::max();
   }

--- a/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
+++ b/L1Trigger/L1THGCal/interface/fe_codecs/HGCalBestChoiceCodec.h
@@ -21,7 +21,7 @@ class HGCalBestChoiceCodec : public HGCalTriggerFE::Codec<HGCalBestChoiceCodec,H
     public:
         typedef HGCalBestChoiceDataPayload data_type;
 
-        HGCalBestChoiceCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom);
+        HGCalBestChoiceCodec(const edm::ParameterSet& conf);
 
         void setDataPayloadImpl(const HGCEEDigiCollection& ee,
                 const HGCHEDigiCollection& fh,

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -27,8 +27,8 @@ class HGCalTriggerDigiProducer : public edm::EDProducer {
  private:
   // inputs
   edm::EDGetToken inputee_, inputfh_, inputbh_;
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
   // algorithm containers
-  std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_;
   std::unique_ptr<HGCalTriggerFECodecBase> codec_;
   std::unique_ptr<HGCalTriggerBackendProcessor> backEndProcessor_;
 };
@@ -42,14 +42,6 @@ HGCalTriggerDigiProducer(const edm::ParameterSet& conf):
   //inputbh_(consumes<HGCHEDigiCollection>(conf.getParameter<edm::InputTag>("bhDigis"))) 
 {
   
-  //setup geometry configuration
-  const edm::ParameterSet& geometryConfig = 
-    conf.getParameterSet("TriggerGeometry");
-  const std::string& trigGeomName = 
-    geometryConfig.getParameter<std::string>("TriggerGeometryName");
-  HGCalTriggerGeometryBase* geometry = 
-    HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
-  triggerGeometry_.reset(geometry);
   
   //setup FE codec
   const edm::ParameterSet& feCodecConfig = 
@@ -57,31 +49,23 @@ HGCalTriggerDigiProducer(const edm::ParameterSet& conf):
   const std::string& feCodecName = 
     feCodecConfig.getParameter<std::string>("CodecName");
   HGCalTriggerFECodecBase* codec =
-    HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig,triggerGeometry_.get());
+    HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig);
   codec_.reset(codec);
   codec_->unSetDataPayload();
   
   produces<l1t::HGCFETriggerDigiCollection>();
   //setup BE processor
-  backEndProcessor_ = std::make_unique<HGCalTriggerBackendProcessor>(conf.getParameterSet("BEConfiguration"), triggerGeometry_.get());
+  backEndProcessor_ = std::make_unique<HGCalTriggerBackendProcessor>(conf.getParameterSet("BEConfiguration"));
   // register backend processor products
   backEndProcessor_->setProduces(*this);
 }
 
 void HGCalTriggerDigiProducer::beginRun(const edm::Run& /*run*/, 
                                           const edm::EventSetup& es) {
-  triggerGeometry_->reset();
-  HGCalTriggerGeometryBase::es_info info;
-  const std::string& ee_sd_name = triggerGeometry_->eeSDName();
-  const std::string& fh_sd_name = triggerGeometry_->fhSDName();
-  const std::string& bh_sd_name = triggerGeometry_->bhSDName();
-  es.get<IdealGeometryRecord>().get(ee_sd_name,info.geom_ee);
-  es.get<IdealGeometryRecord>().get(fh_sd_name,info.geom_fh);
-  es.get<IdealGeometryRecord>().get(bh_sd_name,info.geom_bh);
-  es.get<IdealGeometryRecord>().get(ee_sd_name,info.topo_ee);
-  es.get<IdealGeometryRecord>().get(fh_sd_name,info.topo_fh);
-  es.get<IdealGeometryRecord>().get(bh_sd_name,info.topo_bh);
-  triggerGeometry_->initialize(info);
+  es.get<IdealGeometryRecord>().get(triggerGeometry_);
+  codec_->setGeometry(triggerGeometry_.product());
+  backEndProcessor_->setGeometry(triggerGeometry_.product());
+
 }
 
 void HGCalTriggerDigiProducer::produce(edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
@@ -1,0 +1,67 @@
+
+#include <memory>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+class HGCalTriggerGeometryESProducer : public edm::ESProducer 
+{
+    public:
+        HGCalTriggerGeometryESProducer(const edm::ParameterSet&);
+        ~HGCalTriggerGeometryESProducer();
+
+        typedef std::unique_ptr<HGCalTriggerGeometryBase> ReturnType;
+
+        ReturnType produce(const IdealGeometryRecord&);
+
+    private:
+        edm::ParameterSet geometry_config_;
+        std::string geometry_name_;
+};
+
+HGCalTriggerGeometryESProducer::
+HGCalTriggerGeometryESProducer(const edm::ParameterSet& iConfig):
+    geometry_config_(iConfig.getParameterSet("TriggerGeometry")),
+    geometry_name_(geometry_config_.getParameter<std::string>("TriggerGeometryName"))
+{
+    setWhatProduced(this);
+}
+
+
+HGCalTriggerGeometryESProducer::
+~HGCalTriggerGeometryESProducer()
+{
+
+    // do anything here that needs to be done at desctruction time
+    // (e.g. close files, deallocate resources etc.)
+
+}
+
+HGCalTriggerGeometryESProducer::ReturnType
+HGCalTriggerGeometryESProducer::
+produce(const IdealGeometryRecord& iRecord)
+{
+    //using namespace edm::es;
+    ReturnType geometry(HGCalTriggerGeometryFactory::get()->create(geometry_name_,geometry_config_));
+    geometry->reset();
+    HGCalTriggerGeometryBase::es_info info;
+    const std::string& ee_sd_name = geometry->eeSDName();
+    const std::string& fh_sd_name = geometry->fhSDName();
+    const std::string& bh_sd_name = geometry->bhSDName();
+    iRecord.get(ee_sd_name, info.geom_ee);
+    iRecord.get(fh_sd_name, info.geom_fh);
+    iRecord.get(bh_sd_name, info.geom_bh);
+    iRecord.get(ee_sd_name, info.topo_ee);
+    iRecord.get(fh_sd_name, info.topo_fh);
+    iRecord.get(bh_sd_name, info.topo_bh);
+    geometry->initialize(info);
+    return geometry;
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(HGCalTriggerGeometryESProducer);

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/FullModuleSumAlgo.cc
@@ -10,8 +10,8 @@ class FullModuleSumAlgo : public Algorithm<HGCalBestChoiceCodec>
 {
     public:
 
-        FullModuleSumAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
-            Algorithm<HGCalBestChoiceCodec>(conf,geom),
+        FullModuleSumAlgo(const edm::ParameterSet& conf):
+            Algorithm<HGCalBestChoiceCodec>(conf),
             cluster_product_( new l1t::HGCalClusterBxCollection ){}
 
         virtual void setProduces(edm::EDProducer& prod) const override final 

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/RandomClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/RandomClusterAlgo.cc
@@ -8,8 +8,8 @@ using namespace HGCalTriggerBackend;
 class RandomClusterAlgo : public Algorithm<HGCal64BitRandomCodec> {
 public:
   
-  RandomClusterAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
-    Algorithm<HGCal64BitRandomCodec>(conf,geom),
+  RandomClusterAlgo(const edm::ParameterSet& conf):
+    Algorithm<HGCal64BitRandomCodec>(conf),
     cluster_product_( new l1t::HGCalClusterBxCollection ){
   }
 

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/SingleCellClusterAlgo.cc
@@ -10,8 +10,8 @@ class SingleCellClusterAlgo : public Algorithm<HGCalBestChoiceCodec>
 {
     public:
 
-        SingleCellClusterAlgo(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom):
-            Algorithm<HGCalBestChoiceCodec>(conf,geom),
+        SingleCellClusterAlgo(const edm::ParameterSet& conf):
+            Algorithm<HGCalBestChoiceCodec>(conf),
             cluster_product_( new l1t::HGCalClusterBxCollection ){}
 
         virtual void setProduces(edm::EDProducer& prod) const override final 

--- a/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
+++ b/L1Trigger/L1THGCal/plugins/fe_codecs/HGCalBestChoiceCodec.cc
@@ -8,7 +8,7 @@ DEFINE_EDM_PLUGIN(HGCalTriggerFECodecFactory,
         "HGCalBestChoiceCodec");
 
 /*****************************************************************/
-HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) : Codec(conf,geom),
+HGCalBestChoiceCodec::HGCalBestChoiceCodec(const edm::ParameterSet& conf) : Codec(conf),
     codecImpl_(conf)
 /*****************************************************************/
 {
@@ -79,7 +79,8 @@ void HGCalBestChoiceCodec::setDataPayloadImpl(const l1t::HGCFETriggerDigi& digi)
     conf.addParameter<uint32_t>   ("tdcnBits",      codecImpl_.tdcnBits());
     conf.addParameter<double>     ("tdcOnsetfC",    codecImpl_.tdcOnsetfC());
     conf.addParameter<uint32_t>   ("triggerCellTruncationBits", codecImpl_.triggerCellTruncationBits());
-    HGCalBestChoiceCodec codecInput(conf, geometry_);
+    HGCalBestChoiceCodec codecInput(conf);
+    codecInput.setGeometry(geometry_);
     digi.decode(codecInput,data_);
     // choose best trigger cells in the module
     codecImpl_.bestChoiceSelect(data_);

--- a/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+
+geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
+                     L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
+                     L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
+                     eeSDName = cms.string('HGCalEESensitive'),
+                     fhSDName = cms.string('HGCalHESiliconSensitive'),
+                     bhSDName = cms.string('HGCalHEScintillatorSensitive'),
+                   )
+
+hgcalTriggerGeometryESProducer = cms.ESProducer(
+    'HGCalTriggerGeometryESProducer',
+    TriggerGeometry = geometry
+)

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -16,24 +16,18 @@ fe_codec = cms.PSet( CodecName  = cms.string('HGCalBestChoiceCodec'),
                      tdcOnsetfC = digiparam.hgceeDigitizer.digiCfg.feCfg.tdcOnset_fC
                    )
 
-geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
-                     L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
-                     L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
-                     eeSDName = cms.string('HGCalEESensitive'),
-                     fhSDName = cms.string('HGCalHESiliconSensitive'),
-                     bhSDName = cms.string('HGCalHEScintillatorSensitive'),
-                   )
+
 
 
 cluster_algo =  cms.PSet( AlgorithmName = cms.string('FullModuleSumAlgo'),
                                  FECodec = fe_codec )
+
 
 hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     "HGCalTriggerDigiProducer",
     eeDigis = cms.InputTag('mix:HGCDigisEE'),
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     #bhDigis = cms.InputTag('mix:HGCDigisHEback'),
-    TriggerGeometry = geometry,
     FECodec = fe_codec.clone(),
     BEConfiguration = cms.PSet( 
         algorithms = cms.VPSet( cluster_algo )
@@ -43,7 +37,6 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
 hgcalTriggerPrimitiveDigiFEReproducer = cms.EDProducer(
     "HGCalTriggerDigiFEReproducer",
     feDigis = cms.InputTag('hgcalTriggerPrimitiveDigiProducer'),
-    TriggerGeometry = geometry,
     FECodec = fe_codec.clone(),
     BEConfiguration = cms.PSet( 
         algorithms = cms.VPSet( cluster_algo )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from L1Trigger.L1THGCal.hgcalTriggerGeometryESProducer_cfi import *
 from L1Trigger.L1THGCal.hgcalTriggerPrimitiveDigiProducer_cfi import *
 
 hgcalTriggerPrimitives = cms.Sequence(hgcalTriggerPrimitiveDigiProducer)

--- a/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
@@ -1,17 +1,24 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h"
 
 HGCalTriggerBackendProcessor::
-HGCalTriggerBackendProcessor(const edm::ParameterSet& conf, const HGCalTriggerGeometryBase* const geom) {
+HGCalTriggerBackendProcessor(const edm::ParameterSet& conf) {
   const std::vector<edm::ParameterSet> be_confs = 
     conf.getParameterSetVector("algorithms");
   for( const auto& algo_cfg : be_confs ) {
     const std::string& algo_name = 
       algo_cfg.getParameter<std::string>("AlgorithmName");
     HGCalTriggerBackendAlgorithmBase* algo = 
-      HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg,geom);
+      HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg);
     algorithms_.emplace_back(algo);
   }
 }
+
+void HGCalTriggerBackendProcessor::setGeometry(const HGCalTriggerGeometryBase* const geom) {
+  for( const auto& algo : algorithms_ ) {
+    algo->setGeometry(geom);
+  }
+}
+
 
 void HGCalTriggerBackendProcessor::setProduces(edm::EDProducer& prod) const {
   for( const auto& algo : algorithms_ ) {

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryBase.cc
@@ -15,6 +15,8 @@ void HGCalTriggerGeometryBase::reset()
 {
 }
 
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(HGCalTriggerGeometryBase);
 
 EDM_REGISTER_PLUGINFACTORY(HGCalTriggerGeometryFactory,
 			   "HGCalTriggerGeometryFactory");

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -57,7 +57,7 @@ class HGCalTriggerBestChoiceTester : public edm::EDAnalyzer
         bool is_Simhit_comp_;
         edm::EDGetToken SimHits_inputee_, SimHits_inputfh_, SimHits_inputbh_;
         //
-        std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_; 
+        edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
         std::unique_ptr<HGCalBestChoiceCodecImpl> codec_;
         edm::Service<TFileService> fs_;
         HGCalTriggerGeometryBase::es_info info_;
@@ -105,12 +105,6 @@ HGCalTriggerBestChoiceTester::HGCalTriggerBestChoiceTester(const edm::ParameterS
   // SimHits_inputbh_(consumes<edm::PCaloHitContainer>(conf.getParameter<edm::InputTag>("bhSimHits")))
 /*****************************************************************/
 {
-    //setup geometry 
-    const edm::ParameterSet& geometryConfig = conf.getParameterSet("TriggerGeometry");
-    const std::string& trigGeomName = geometryConfig.getParameter<std::string>("TriggerGeometryName");
-    HGCalTriggerGeometryBase* geometry = HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
-    triggerGeometry_.reset(geometry);
-
     //setup FE codec
     const edm::ParameterSet& feCodecConfig = conf.getParameterSet("FECodec");
     codec_.reset( new HGCalBestChoiceCodecImpl(feCodecConfig) );
@@ -165,7 +159,8 @@ void HGCalTriggerBestChoiceTester::beginRun(const edm::Run& /*run*/,
                                           const edm::EventSetup& es)
 /*****************************************************************/
 {
-    triggerGeometry_->reset();
+    es.get<IdealGeometryRecord>().get(triggerGeometry_);
+
     const std::string& ee_sd_name = triggerGeometry_->eeSDName();
     const std::string& fh_sd_name = triggerGeometry_->fhSDName();
     const std::string& bh_sd_name = triggerGeometry_->bhSDName();
@@ -175,9 +170,8 @@ void HGCalTriggerBestChoiceTester::beginRun(const edm::Run& /*run*/,
     es.get<IdealGeometryRecord>().get(ee_sd_name,info_.topo_ee);
     es.get<IdealGeometryRecord>().get(fh_sd_name,info_.topo_fh);
     es.get<IdealGeometryRecord>().get(bh_sd_name,info_.topo_bh);
-    triggerGeometry_->initialize(info_);
 
- }
+}
 
 /*****************************************************************/
 void HGCalTriggerBestChoiceTester::analyze(const edm::Event& e, 

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
@@ -51,7 +51,7 @@ class HGCalTriggerGeomTester : public edm::EDAnalyzer
         void setTreeModuleSize(const size_t n);
         void setTreeTriggerCellSize(const size_t n);
 
-        std::unique_ptr<HGCalTriggerGeometryBase> triggerGeometry_; 
+        edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
         edm::Service<TFileService> fs_;
         TTree* treeModules_;
         TTree* treeTriggerCells_;
@@ -120,11 +120,6 @@ class HGCalTriggerGeomTester : public edm::EDAnalyzer
 HGCalTriggerGeomTester::HGCalTriggerGeomTester(const edm::ParameterSet& conf) 
 /*****************************************************************/
 {
-    //setup geometry 
-    const edm::ParameterSet& geometryConfig = conf.getParameterSet("TriggerGeometry");
-    const std::string& trigGeomName = geometryConfig.getParameter<std::string>("TriggerGeometryName");
-    HGCalTriggerGeometryBase* geometry = HGCalTriggerGeometryFactory::get()->create(trigGeomName,geometryConfig);
-    triggerGeometry_.reset(geometry);
 
     // initialize output trees
     treeModules_ = fs_->make<TTree>("TreeModules","Tree of all HGC modules");
@@ -220,7 +215,9 @@ void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/,
                                           const edm::EventSetup& es)
 /*****************************************************************/
 {
-    triggerGeometry_->reset();
+    es.get<IdealGeometryRecord>().get("", triggerGeometry_);
+
+
     HGCalTriggerGeometryBase::es_info info;
     const std::string& ee_sd_name = triggerGeometry_->eeSDName();
     const std::string& fh_sd_name = triggerGeometry_->fhSDName();
@@ -231,7 +228,7 @@ void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/,
     es.get<IdealGeometryRecord>().get(ee_sd_name,info.topo_ee);
     es.get<IdealGeometryRecord>().get(fh_sd_name,info.topo_fh);
     es.get<IdealGeometryRecord>().get(bh_sd_name,info.topo_bh);
-    triggerGeometry_->initialize(info);
+
 
     checkConsistency(info);
     fillTriggerGeometry(info);
@@ -240,6 +237,10 @@ void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/,
 
 void HGCalTriggerGeomTester::checkConsistency(const HGCalTriggerGeometryBase::es_info& info)
 {
+    
+
+
+
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>> modules_to_triggercells;
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>> modules_to_cells;
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>> triggercells_to_cells;

--- a/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TBestChoice_cfg.py
@@ -135,14 +135,6 @@ process.hgcaltriggerbestchoicetester = cms.EDAnalyzer(
     #bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback'),
     beClustersAll = cms.InputTag('hgcalTriggerPrimitiveDigiProducer:SingleCellClusterAlgo'),
     beClustersSelect = cms.InputTag('hgcalTriggerPrimitiveDigiFEReproducer:SingleCellClusterAlgo'),
-    TriggerGeometry = cms.PSet(
-        TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
-        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
-        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
-        eeSDName = cms.string('HGCalEESensitive'),
-        fhSDName = cms.string('HGCalHESiliconSensitive'),
-        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
-        ),
     FECodec = process.hgcalTriggerPrimitiveDigiProducer.FECodec.clone()
     )
 process.test_step = cms.Path(process.hgcaltriggerbestchoicetester)

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometry_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometry_cfg.py
@@ -100,8 +100,8 @@ process.digi2raw_step = cms.Path(process.DigiToRaw)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
-process.hgcaltriggergeomtester = cms.EDAnalyzer(
-    "HGCalTriggerGeomTester",
+process.geometryProducer = cms.ESProducer(
+    'HGCalTriggerGeometryESProducer',
     TriggerGeometry = cms.PSet(
         TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
         L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
@@ -110,6 +110,10 @@ process.hgcaltriggergeomtester = cms.EDAnalyzer(
         fhSDName = cms.string('HGCalHESiliconSensitive'),
         bhSDName = cms.string('HGCalHEScintillatorSensitive'),
         )
+)
+
+process.hgcaltriggergeomtester = cms.EDAnalyzer(
+    "HGCalTriggerGeomTester"
     )
 process.test_step = cms.Path(process.hgcaltriggergeomtester)
 

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -92,18 +92,6 @@ process.generator = cms.EDProducer("FlatRandomPtGunProducer",
 process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 
 
-process.geometryProducer = cms.ESProducer(
-    'HGCalTriggerGeometryESProducer',
-    TriggerGeometry = cms.PSet(
-        TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
-        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
-        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
-        eeSDName = cms.string('HGCalEESensitive'),
-        fhSDName = cms.string('HGCalHESiliconSensitive'),
-        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
-        )
-)
-
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -92,6 +92,19 @@ process.generator = cms.EDProducer("FlatRandomPtGunProducer",
 process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 
 
+process.geometryProducer = cms.ESProducer(
+    'HGCalTriggerGeometryESProducer',
+    TriggerGeometry = cms.PSet(
+        TriggerGeometryName = cms.string('HGCalTriggerGeometryHexImp2'),
+        L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping.txt"),
+        L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/module_mapping.txt"),
+        eeSDName = cms.string('HGCalEESensitive'),
+        fhSDName = cms.string('HGCalHESiliconSensitive'),
+        bhSDName = cms.string('HGCalHEScintillatorSensitive'),
+        )
+)
+
+
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)
 process.simulation_step = cms.Path(process.psim)


### PR DESCRIPTION
See task #56 
The trigger geometry is included in the event setup, to be accessible more easily, for instance in ntuple producers.
- An ESProducer `HGCalTriggerGeometryESProducer` is added
- The accesses to the trigger geometry are updated.
