### PR TITLE
Thresholds on output collections

### DIFF
--- a/L1Trigger/L1THGCal/plugins/be_algorithms/HGCClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/HGCClusterAlgo.cc
@@ -41,6 +41,7 @@ class HGCClusterAlgo : public Algorithm<FECODEC>
         clustering_( conf.getParameterSet("C2d_parameters") ),
         multiclustering_( conf.getParameterSet("C3d_parameters" ) )
         {
+            clustering_threshold_ = conf.getParameterSet("C2d_parameters").getParameter<double>("clustering_threshold");
             std::string type(conf.getParameterSet("C2d_parameters").getParameter<std::string>("clusterType"));
             if(type=="dRC2d"){
                 clusteringAlgorithmType_ = dRC2d;
@@ -101,6 +102,7 @@ class HGCClusterAlgo : public Algorithm<FECODEC>
 
         /* algorithm type */
         ClusterType clusteringAlgorithmType_;
+        double clustering_threshold_;
 };
 
 
@@ -144,8 +146,8 @@ void HGCClusterAlgo<FECODEC,DATA>::run(const l1t::HGCFETriggerDigiCollection & c
 
                 l1t::HGCalTriggerCell calibratedtriggercell( triggercell );
                 calibration_.calibrateInGeV( calibratedtriggercell, cellThickness ); 
+                if(calibratedtriggercell.mipPt()<clustering_threshold_) continue;
                 trgcell_product_->push_back( 0, calibratedtriggercell );
-
             }           
         
         }

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -48,7 +48,7 @@ C2d_parValues = cms.PSet( seeding_threshold = cms.double(5), # MipT
                           )
 
 C3d_parValues = cms.PSet( dR_multicluster = cms.double(0.01), # dR in normalized plane used to clusterize C2d
-                          minPt_multicluster = cms.double(0.0), # minimum pt of the multicluster
+                          minPt_multicluster = cms.double(0.5), # minimum pt of the multicluster (GeV)
                           calibSF_multicluster = cms.double(1.084)
                           )
 cluster_algo =  cms.PSet( AlgorithmName = cms.string('HGCClusterAlgoThreshold'),

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalTriggerCellCalibration.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalTriggerCellCalibration.cc
@@ -12,8 +12,9 @@ HGCalTriggerCellCalibration::HGCalTriggerCellCalibration(const edm::ParameterSet
 
     for(auto corr : thickCorr_){
         if(corr <= 0){
-            edm::LogWarning("DivisionByZero") << "WARNING: the cell-thickness correction factor is zero";
+            edm::LogWarning("DivisionByZero") << "WARNING: the cell-thickness correction factor is zero or negative. It won't be applied to correct trigger cell energies.";
         }
+
     }
 }
 


### PR DESCRIPTION
* Apply the clustering threshold on trigger cells before filling the trigger cell collections (reduce collection size by a factor ~7)
* Apply a 0.5 GeV threshold on the 3D clusters.