### PR TITLE
Add new cluster shape variables for e/g id

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -145,7 +145,9 @@ namespace l1t
       //shower shape
 
       int showerLength() const { return showerLength_; }
+      int coreShowerLength() const { return coreShowerLength_; }
       int firstLayer() const { return firstLayer_; }
+      int maxLayer() const { return maxLayer_; }
       float eMax() const { return eMax_; }
       float sigmaEtaEtaMax() const { return sigmaEtaEtaMax_; }
       float sigmaPhiPhiMax() const { return sigmaPhiPhiMax_; }
@@ -154,9 +156,12 @@ namespace l1t
       float sigmaZZ() const { return sigmaZZ_; }
       float sigmaRRTot() const { return sigmaRRTot_; }
       float sigmaRRMax() const { return sigmaRRMax_; }
+      float sigmaRRMean() const { return sigmaRRMean_; }
 
       void set_showerLength(int showerLength) { showerLength_ = showerLength;}
+      void set_coreShowerLength(int coreShowerLength) { coreShowerLength_ = coreShowerLength;}
       void set_firstLayer(int firstLayer) { firstLayer_ = firstLayer;}
+      void set_maxLayer(int maxLayer) { maxLayer_ = maxLayer;}
       void set_eMax(float eMax) { eMax_ = eMax;}
       void set_sigmaEtaEtaMax(float sigmaEtaEtaMax) { sigmaEtaEtaMax_ = sigmaEtaEtaMax;}
       void set_sigmaEtaEtaTot(float sigmaEtaEtaTot) { sigmaEtaEtaTot_ = sigmaEtaEtaTot;}
@@ -164,6 +169,7 @@ namespace l1t
       void set_sigmaPhiPhiTot(float sigmaPhiPhiTot) { sigmaPhiPhiTot_ = sigmaPhiPhiTot;}
       void set_sigmaRRMax(float sigmaRRMax) { sigmaRRMax_ = sigmaRRMax;}
       void set_sigmaRRTot(float sigmaRRTot) { sigmaRRTot_ = sigmaRRTot;}
+      void set_sigmaRRMean(float sigmaRRMean) { sigmaRRMean_ = sigmaRRMean;}
       void set_sigmaZZ(float sigmaZZ) { sigmaZZ_ = sigmaZZ;}
       
       /* operators */
@@ -186,7 +192,9 @@ namespace l1t
       //shower shape
 
       int showerLength_;
+      int coreShowerLength_;
       int firstLayer_;
+      int maxLayer_;
       float eMax_;
       float sigmaEtaEtaMax_;
       float sigmaPhiPhiMax_;
@@ -194,6 +202,7 @@ namespace l1t
       float sigmaEtaEtaTot_;
       float sigmaPhiPhiTot_;
       float sigmaRRTot_;
+      float sigmaRRMean_;
       float sigmaZZ_;
 
       ClusterShapes shapes_;

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -20,7 +20,8 @@
   <class name="edm::Wrapper<l1t::HGCalTowerBxCollection>"/>
 
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerCell>" />
-  <class name="l1t::HGCalCluster" ClassVersion="12">
+  <class name="l1t::HGCalCluster" ClassVersion="13">
+  <version ClassVersion="13" checksum="3397489079"/>
   <version ClassVersion="12" checksum="623703096"/>
   <version ClassVersion="11" checksum="354623225"/>
   <version ClassVersion="10" checksum="607544984"/>
@@ -30,7 +31,8 @@
   <class name="edm::Wrapper<l1t::HGCalClusterBxCollection>"/>
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
-  <class name="l1t::HGCalMulticluster" ClassVersion="12">
+  <class name="l1t::HGCalMulticluster" ClassVersion="13">
+  <version ClassVersion="13" checksum="816077951"/>
   <version ClassVersion="12" checksum="4221677522"/>
   <version ClassVersion="11" checksum="1508179045"/>
   <version ClassVersion="10" checksum="1878482802"/>

--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h
@@ -16,7 +16,10 @@ class HGCalShowerShape{
 
     int firstLayer(const l1t::HGCalMulticluster& c3d) const;
     int lastLayer(const l1t::HGCalMulticluster& c3d) const;
+    int maxLayer(const l1t::HGCalMulticluster& c3d) const;
     int showerLength(const l1t::HGCalMulticluster& c3d) const {return lastLayer(c3d)-firstLayer(c3d)+1; }//in number of layers
+    // Maximum number of consecutive layers in the cluster
+    int coreShowerLength(const l1t::HGCalMulticluster& c3d) const;
   
     float eMax(const l1t::HGCalMulticluster& c3d) const;  
   
@@ -33,6 +36,7 @@ class HGCalShowerShape{
     float sigmaRRTot(const l1t::HGCalMulticluster& c3d) const;
     float sigmaRRTot(const l1t::HGCalCluster& c2d) const;       
     float sigmaRRMax(const l1t::HGCalMulticluster& c3d) const;  
+    float sigmaRRMean(const l1t::HGCalMulticluster& c3d, float radius=5.) const;
 
     private: 
     

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -30,7 +30,9 @@ class HGCalTriggerNtupleHGCMulticlusters : public HGCalTriggerNtupleBase
     std::vector<std::vector<uint32_t>> cl3d_clusters_id_;
     // cluster shower shapes
     std::vector<int> cl3d_showerlength_;
+    std::vector<int> cl3d_coreshowerlength_;
     std::vector<int> cl3d_firstlayer_;
+    std::vector<int> cl3d_maxlayer_;
     std::vector<float> cl3d_seetot_;
     std::vector<float> cl3d_seemax_;
     std::vector<float> cl3d_spptot_;
@@ -38,6 +40,7 @@ class HGCalTriggerNtupleHGCMulticlusters : public HGCalTriggerNtupleBase
     std::vector<float> cl3d_szz_;
     std::vector<float> cl3d_srrtot_;
     std::vector<float> cl3d_srrmax_;
+    std::vector<float> cl3d_srrmean_;
     std::vector<float> cl3d_emaxe_;
 };
 
@@ -66,7 +69,9 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
   tree.Branch("cl3d_clusters_n", &cl3d_clusters_n_);
   tree.Branch("cl3d_clusters_id", &cl3d_clusters_id_);
   tree.Branch("cl3d_showerlength", &cl3d_showerlength_);
+  tree.Branch("cl3d_coreshowerlength", &cl3d_coreshowerlength_);
   tree.Branch("cl3d_firstlayer", &cl3d_firstlayer_);
+  tree.Branch("cl3d_maxlayer", &cl3d_maxlayer_);
   tree.Branch("cl3d_seetot", &cl3d_seetot_);
   tree.Branch("cl3d_seemax", &cl3d_seemax_);
   tree.Branch("cl3d_spptot", &cl3d_spptot_);
@@ -74,6 +79,7 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
   tree.Branch("cl3d_szz", &cl3d_szz_);
   tree.Branch("cl3d_srrtot", &cl3d_srrtot_);
   tree.Branch("cl3d_srrmax", &cl3d_srrmax_);
+  tree.Branch("cl3d_srrmean", &cl3d_srrmean_);
   tree.Branch("cl3d_emaxe", &cl3d_emaxe_);
 
 }
@@ -104,7 +110,9 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     cl3d_phi_.emplace_back(cl3d_itr->phi());
     cl3d_clusters_n_.emplace_back(cl3d_itr->constituents().size());
     cl3d_showerlength_.emplace_back(cl3d_itr->showerLength());
+    cl3d_coreshowerlength_.emplace_back(cl3d_itr->coreShowerLength());
     cl3d_firstlayer_.emplace_back(cl3d_itr->firstLayer());
+    cl3d_maxlayer_.emplace_back(cl3d_itr->maxLayer());
     cl3d_seetot_.emplace_back(cl3d_itr->sigmaEtaEtaTot());
     cl3d_seemax_.emplace_back(cl3d_itr->sigmaEtaEtaMax());
     cl3d_spptot_.emplace_back(cl3d_itr->sigmaPhiPhiTot());
@@ -112,6 +120,7 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     cl3d_szz_.emplace_back(cl3d_itr->sigmaZZ());
     cl3d_srrtot_.emplace_back(cl3d_itr->sigmaRRTot());
     cl3d_srrmax_.emplace_back(cl3d_itr->sigmaRRMax());
+    cl3d_srrmean_.emplace_back(cl3d_itr->sigmaRRMean());
     cl3d_emaxe_.emplace_back(cl3d_itr->eMax()/cl3d_itr->energy());
 
     // Retrieve indices of trigger cells inside cluster
@@ -136,7 +145,9 @@ clear()
   cl3d_clusters_n_.clear();
   cl3d_clusters_id_.clear();
   cl3d_showerlength_.clear();
+  cl3d_coreshowerlength_.clear();
   cl3d_firstlayer_.clear();
+  cl3d_maxlayer_.clear();
   cl3d_seetot_.clear();
   cl3d_seemax_.clear();
   cl3d_spptot_.clear();
@@ -144,6 +155,7 @@ clear()
   cl3d_szz_.clear();
   cl3d_srrtot_.clear();
   cl3d_srrmax_.clear();
+  cl3d_srrmean_.clear();
   cl3d_emaxe_.clear();
 }
 

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
@@ -145,7 +145,9 @@ void HGCalMulticlusteringImpl::clusterizeDR( const edm::PtrVector<l1t::HGCalClus
 
             //compute shower shape
             multiclustersTmp.at(i).set_showerLength(shape_.showerLength(multiclustersTmp.at(i)));
+            multiclustersTmp.at(i).set_coreShowerLength(shape_.coreShowerLength(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_firstLayer(shape_.firstLayer(multiclustersTmp.at(i)));
+            multiclustersTmp.at(i).set_maxLayer(shape_.maxLayer(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaEtaEtaTot(shape_.sigmaEtaEtaTot(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaEtaEtaMax(shape_.sigmaEtaEtaMax(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaPhiPhiTot(shape_.sigmaPhiPhiTot(multiclustersTmp.at(i)));
@@ -153,8 +155,8 @@ void HGCalMulticlusteringImpl::clusterizeDR( const edm::PtrVector<l1t::HGCalClus
             multiclustersTmp.at(i).set_sigmaZZ(shape_.sigmaZZ(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaRRTot(shape_.sigmaRRTot(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaRRMax(shape_.sigmaRRMax(multiclustersTmp.at(i)));
+            multiclustersTmp.at(i).set_sigmaRRMean(shape_.sigmaRRMean(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_eMax(shape_.eMax(multiclustersTmp.at(i)));
-
             multiclusters.push_back( 0, multiclustersTmp.at(i));  
         }
     }


### PR DESCRIPTION
Add variables presented in this [presentation](https://indico.cern.ch/event/672827/contributions/2754715/attachments/1542122/2418885/17.10.17_eg.trigger.pdf)
- Layer with max (transverse) energy in the cluster
- Maximum number of consecutive layers in the cluster
- Size-restricted sigmaRR computed layer-by-layer