### PR TITLE
Half layers in the EE by default

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -62,6 +62,7 @@ class HGCalTriggerGeometryBase
 
         virtual bool validTriggerCell( const unsigned trigger_cell_id) const = 0;
         virtual bool disconnectedModule(const unsigned module_id) const = 0;
+        virtual unsigned triggerLayer(const unsigned id) const = 0;
 
     protected:
         void setCaloGeometry(const edm::ESHandle<CaloGeometry>& geom) {calo_geometry_=geom;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryGenericMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryGenericMapping.h
@@ -139,6 +139,7 @@ class HGCalTriggerGeometryGenericMapping : public HGCalTriggerGeometryBase {
 
   virtual bool validTriggerCell( const unsigned trigger_cell_det_id ) const override final;
   virtual bool disconnectedModule(const unsigned module_id) const override final;
+  virtual unsigned triggerLayer(const unsigned id) const override final;
 
  protected:
   geom_map cells_to_trigger_cells_;

--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalMulticlusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalMulticlusteringImpl.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h"
 
 class HGCalMulticlusteringImpl{
@@ -19,10 +20,14 @@ public:
                       double dR ) const;
 
     void clusterizeDR( const edm::PtrVector<l1t::HGCalCluster> & clustersPtr, 
-                     l1t::HGCalMulticlusterBxCollection & multiclusters);
+                     l1t::HGCalMulticlusterBxCollection & multiclusters,
+                     const HGCalTriggerGeometryBase & triggerGeometry
+                     );
 
     void clusterizeDBSCAN( const edm::PtrVector<l1t::HGCalCluster> & clustersPtr, 
-                     l1t::HGCalMulticlusterBxCollection & multiclusters);
+                     l1t::HGCalMulticlusterBxCollection & multiclusters,
+                     const HGCalTriggerGeometryBase & triggerGeometry
+                     );
 
 private:
 

--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
 class HGCalShowerShape{
 
@@ -19,7 +20,7 @@ class HGCalShowerShape{
     int maxLayer(const l1t::HGCalMulticluster& c3d) const;
     int showerLength(const l1t::HGCalMulticluster& c3d) const {return lastLayer(c3d)-firstLayer(c3d)+1; }//in number of layers
     // Maximum number of consecutive layers in the cluster
-    int coreShowerLength(const l1t::HGCalMulticluster& c3d) const;
+    int coreShowerLength(const l1t::HGCalMulticluster& c3d, const HGCalTriggerGeometryBase& triggerGeometry) const;
   
     float eMax(const l1t::HGCalMulticluster& c3d) const;  
   

--- a/L1Trigger/L1THGCal/plugins/be_algorithms/HGCClusterAlgo.cc
+++ b/L1Trigger/L1THGCal/plugins/be_algorithms/HGCClusterAlgo.cc
@@ -187,10 +187,10 @@ void HGCClusterAlgo<FECODEC,DATA>::run(const l1t::HGCFETriggerDigiCollection & c
     /* call to multiclustering and compute shower shape*/
     switch(multiclusteringAlgoType_){
     case dRC3d : 
-      multiclustering_.clusterizeDR( clustersPtrs, *multicluster_product_ );
+      multiclustering_.clusterizeDR( clustersPtrs, *multicluster_product_, *triggerGeometry_);
       break;
     case DBSCANC3d:
-      multiclustering_.clusterizeDBSCAN( clustersPtrs, *multicluster_product_ );
+      multiclustering_.clusterizeDBSCAN( clustersPtrs, *multicluster_product_, *triggerGeometry_);
       break;
     default:
       // Should not happen, clustering type checked in constructor

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
@@ -36,6 +36,7 @@ class HGCalTriggerGeometryHexImp2 : public HGCalTriggerGeometryBase
 
         virtual bool validTriggerCell( const unsigned ) const override final;
         virtual bool disconnectedModule(const unsigned) const override final;
+        virtual unsigned triggerLayer(const unsigned) const override final;
 
     private:
         edm::FileInPath l1tCellsMapping_;
@@ -771,6 +772,14 @@ HGCalTriggerGeometryHexImp2::
 disconnectedModule(const unsigned module_id) const
 {
     return false;
+}
+
+
+unsigned 
+HGCalTriggerGeometryHexImp2::
+triggerLayer(const unsigned id) const
+{
+    return HGCalDetId(id).layer();
 }
 
 bool 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
@@ -1,20 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 
 disconnectedTriggerLayers = [
-        1,
-        3,
-        5,
-        7,
-        9,
-        11,
-        13,
-        15,
-        17,
-        19,
-        21,
-        23,
-        25,
-        27
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        24,
+        26,
+        28
         ]
 
 
@@ -25,7 +25,7 @@ geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexLa
                      L1TCellsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_BH_3x3_30deg_0.txt"),
                      L1TCellNeighborsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_BH_3x3_30deg_0.txt"),
                      DisconnectedModules = cms.vuint32(0),
-                     DisconnectedLayers = cms.vuint32([])
+                     DisconnectedLayers = cms.vuint32(disconnectedTriggerLayers)
                    )
 
 hgcalTriggerGeometryESProducer = cms.ESProducer(

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -70,7 +70,7 @@ C3d_parValues = cms.PSet( dR_multicluster = cms.double(0.01), # dR in normalized
                           calibSF_multicluster = cms.double(1.084),
                           type_multicluster = cms.string('dRC3d'), #'DBSCANC3d' for the DBSCAN algorithm 
                           applyLayerCalibration = cms.bool(True),
-                          layerWeights = layercalibparam.AllLayer_weights,
+                          layerWeights = layercalibparam.TrgLayer_weights,
                           dist_dbscan_multicluster = cms.double(0.005),
                           minN_dbscan_multicluster = cms.uint32(3)
                           )

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryGenericMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryGenericMapping.cc
@@ -1,5 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryGenericMapping.h"
 
+
 using namespace HGCalTriggerGeometry;
 
 namespace {
@@ -129,5 +130,12 @@ bool
 HGCalTriggerGeometryGenericMapping::
 disconnectedModule(const unsigned module_id) const {
   return false;
+}
+
+
+unsigned 
+HGCalTriggerGeometryGenericMapping::
+triggerLayer(const unsigned id) const {
+  return  HGCalDetId(id).layer();
 }
 

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
@@ -73,7 +73,8 @@ void HGCalMulticlusteringImpl::findNeighbor( const std::vector<std::pair<unsigne
 
 
 void HGCalMulticlusteringImpl::clusterizeDR( const edm::PtrVector<l1t::HGCalCluster> & clustersPtrs, 
-                                           l1t::HGCalMulticlusterBxCollection & multiclusters)
+                                           l1t::HGCalMulticlusterBxCollection & multiclusters,
+                                           const HGCalTriggerGeometryBase & triggerGeometry)
 {
 
     std::vector<l1t::HGCalMulticluster> multiclustersTmp;
@@ -145,7 +146,7 @@ void HGCalMulticlusteringImpl::clusterizeDR( const edm::PtrVector<l1t::HGCalClus
 
             //compute shower shape
             multiclustersTmp.at(i).set_showerLength(shape_.showerLength(multiclustersTmp.at(i)));
-            multiclustersTmp.at(i).set_coreShowerLength(shape_.coreShowerLength(multiclustersTmp.at(i)));
+            multiclustersTmp.at(i).set_coreShowerLength(shape_.coreShowerLength(multiclustersTmp.at(i), triggerGeometry));
             multiclustersTmp.at(i).set_firstLayer(shape_.firstLayer(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_maxLayer(shape_.maxLayer(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaEtaEtaTot(shape_.sigmaEtaEtaTot(multiclustersTmp.at(i)));
@@ -157,13 +158,15 @@ void HGCalMulticlusteringImpl::clusterizeDR( const edm::PtrVector<l1t::HGCalClus
             multiclustersTmp.at(i).set_sigmaRRMax(shape_.sigmaRRMax(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_sigmaRRMean(shape_.sigmaRRMean(multiclustersTmp.at(i)));
             multiclustersTmp.at(i).set_eMax(shape_.eMax(multiclustersTmp.at(i)));
+
             multiclusters.push_back( 0, multiclustersTmp.at(i));  
         }
     }
     
 }
 void HGCalMulticlusteringImpl::clusterizeDBSCAN( const edm::PtrVector<l1t::HGCalCluster> & clustersPtrs, 
-                                                 l1t::HGCalMulticlusterBxCollection & multiclusters)
+                                                 l1t::HGCalMulticlusterBxCollection & multiclusters,
+                                                 const HGCalTriggerGeometryBase & triggerGeometry)
 {
 
   std::vector<l1t::HGCalMulticluster> multiclustersTmp;

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalShowerShape.cc
@@ -144,13 +144,13 @@ int HGCalShowerShape::lastLayer(const l1t::HGCalMulticluster& c3d) const {
     
 }
 
-int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d) const
+int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d, const HGCalTriggerGeometryBase& triggerGeometry) const
 {
   const edm::PtrVector<l1t::HGCalCluster>& clustersPtrs = c3d.constituents();
   std::vector<bool> layers(kLayersEE_+kLayersFH_+kLayersBH_);
   for(const auto& cluster_ptr : clustersPtrs)
   {
-    int layer = HGC_layer(cluster_ptr->subdetId(), cluster_ptr->layer());
+    int layer = triggerGeometry.triggerLayer(cluster_ptr->detId());
     layers[layer-1] = true;
   }
   int length = 0;


### PR DESCRIPTION
* Can now retrieve the trigger layer index from the geometry
* Update the shower length computation to use trigger layer index
* Disconnect half the EE layers by default and use the corresponding calibration coeffs