### PR TITLE
Expand GEN level information and prototype tool to handle TC geometry related info

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -1,6 +1,15 @@
 #ifndef __L1Trigger_L1THGCal_HGCalTriggerTools_h__
 #define __L1Trigger_L1THGCal_HGCalTriggerTools_h__
 
+/** \class HGCalTriggerTools
+ *  Tools for handling HGCal trigger det-ID
+ *  NOTE: this uses the trigger geometry hence would give wrong results 
+ *  when used for offline reco!!!!
+ *
+ *  \author G. Cerminara (CERN), heavily "inspired" by HGCalRechHitTools ;)
+ */
+
+
 #include <array>
 #include <cmath>
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -8,6 +17,10 @@
 
 class HGCalTriggerGeometryBase;
 class DetId;
+
+
+
+
 
 namespace edm {
   class Event;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -2,8 +2,11 @@
 #define __L1Trigger_L1THGCal_HGCalTriggerTools_h__
 
 /** \class HGCalTriggerTools
- *  Tools for handling HGCal trigger det-ID
- *  NOTE: this uses the trigger geometry hence would give wrong results 
+ *  Tools for handling HGCal trigger det-ID: in the current version
+ *  of trhe HGCAL simulation only HGCalDetId for the TriggerCells (TC)
+ *  are used and not HcalDetId as in the offline!
+ *  As a consequence the class assumes that only DetIds of the first kind are used in the getTC* methods
+ *  NOTE: this uses the trigger geometry hence would give wrong results
  *  when used for offline reco!!!!
  *
  *  \author G. Cerminara (CERN), heavily "inspired" by HGCalRechHitTools ;)
@@ -29,11 +32,13 @@ namespace edm {
 
   class HGCalTriggerTools {
   public:
-  HGCalTriggerTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0) {}
+  HGCalTriggerTools() : geom_(nullptr),
+                        fhOffset_(0),
+                        bhOffset_(0) {}
     ~HGCalTriggerTools() {}
 
     void setEventSetup(const edm::EventSetup&);
-    GlobalPoint getPosition(const DetId& id) const;
+    GlobalPoint getTCPosition(const DetId& id) const;
     unsigned int getLayerWithOffset(const DetId&) const;
     // unsigned int getLayer(ForwardSubdetector type) const;
     unsigned int getLayer(const DetId&) const;
@@ -44,13 +49,18 @@ namespace edm {
     float getPt(const GlobalPoint& position, const float& hitEnergy, const float& vertex_z = 0.) const;
 
     // 4-vector helper functions using DetId
-    float getEta(const DetId& id, const float& vertex_z = 0.) const;
-    float getPhi(const DetId& id) const;
-    float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
+    float getTCEta(const DetId& id, const float& vertex_z = 0.) const;
+    float getTCPhi(const DetId& id) const;
+    float getTCPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
 
     inline const HGCalTriggerGeometryBase * getTriggerGeometry() const {return geom_;};
     unsigned int lastLayerEE() const {return fhOffset_;}
     unsigned int lastLayerFH() const {return bhOffset_;}
+
+    float getLayerZ(const unsigned& layerWithOffset) const;
+    float getLayerZ(const int& subdet, const unsigned& layer) const;
+
+
 
   private:
     const HGCalTriggerGeometryBase* geom_;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -1,0 +1,48 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTriggerTools_h__
+#define __L1Trigger_L1THGCal_HGCalTriggerTools_h__
+
+#include <array>
+#include <cmath>
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+
+class HGCalTriggerGeometryBase;
+class DetId;
+
+namespace edm {
+  class Event;
+  class EventSetup;
+}
+
+  class HGCalTriggerTools {
+  public:
+  HGCalTriggerTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0) {}
+    ~HGCalTriggerTools() {}
+
+    void setEventSetup(const edm::EventSetup&);
+    GlobalPoint getPosition(const DetId& id) const;
+    unsigned int getLayerWithOffset(const DetId&) const;
+    // unsigned int getLayer(ForwardSubdetector type) const;
+    unsigned int getLayer(const DetId&) const;
+
+    // 4-vector helper functions using GlobalPoint
+    float getEta(const GlobalPoint& position, const float& vertex_z = 0.) const;
+    float getPhi(const GlobalPoint& position) const;
+    float getPt(const GlobalPoint& position, const float& hitEnergy, const float& vertex_z = 0.) const;
+
+    // 4-vector helper functions using DetId
+    float getEta(const DetId& id, const float& vertex_z = 0.) const;
+    float getPhi(const DetId& id) const;
+    float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
+
+    inline const HGCalTriggerGeometryBase * getTriggerGeometry() const {return geom_;};
+    unsigned int lastLayerEE() const {return fhOffset_;}
+    unsigned int lastLayerFH() const {return bhOffset_;}
+
+  private:
+    const HGCalTriggerGeometryBase* geom_;
+    unsigned int        fhOffset_, bhOffset_;
+  };
+
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCal/plugins/BuildFile.xml
@@ -11,7 +11,7 @@
   <use   name="Geometry/HGCalGeometry"/>
   <use   name="Geometry/CaloTopology"/>
   <use   name="Geometry/HcalTowerAlgo"/>
-  <use   name="L1Trigger/L1THGCal"/>  
+  <use   name="L1Trigger/L1THGCal"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 
@@ -27,11 +27,18 @@
 </library>
 
 <library   name="L1TriggerL1THGCalPlugins_ntuples" file="ntuples/*.cc">
-  <use   name="L1Trigger/L1THGCal"/>  
+  <use   name="L1Trigger/L1THGCal"/>
   <use   name="CommonTools/UtilAlgos"/>
   <use   name="SimDataFormats/CaloTest"/>
   <use   name="DataFormats/JetReco"/>
   <use   name="Geometry/HcalTowerAlgo"/>
   <use   name="SimDataFormats/PileupSummaryInfo"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+  <use   name="TrackPropagation/RungeKutta"/>
+  <use   name="FastSimulation/Event"/>
+  <use   name="FastSimulation/CaloGeometryTools"/>
+  <use   name="MagneticField/Engine"/>
+  <use   name="MagneticField/Records"/>
+  <use name="heppdt"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -1,7 +1,110 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
-#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
+#include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
+#include "FastSimulation/Event/interface/FSimEvent.h"
+#include "FastSimulation/Particle/interface/ParticleTable.h"
+#include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+// NOTE: most of this code is borrowed by https://github.com/CMS-HGCAL/reco-ntuples
+// kudos goes to the original authors. Ideally the 2 repos should be merged since they share part of the use case
+#include <iostream>
+
+namespace HGCal_helpers {
+
+  class coordinates {
+   public:
+    coordinates() : x(0), y(0), z(0), eta(100), phi(0) {}
+    float x, y, z, eta, phi;
+    inline math::XYZTLorentzVectorD toVector() { return math::XYZTLorentzVectorD(x, y, z, 0); }
+  };
+
+
+  class simpleTrackPropagator {
+   public:
+    simpleTrackPropagator(MagneticField const *f)
+        : field_(f), prod_(field_, alongMomentum, 5.e-5), absz_target_(0) {
+      ROOT::Math::SMatrixIdentity id;
+      AlgebraicSymMatrix55 C(id);
+      C *= 0.001;
+      err_ = CurvilinearTrajectoryError(C);
+    }
+    void setPropagationTargetZ(const float &z);
+
+    bool propagate(const double px, const double py, const double pz, const double x, const double y,
+                   const double z, const float charge, coordinates &coords) const;
+
+    bool propagate(const math::XYZTLorentzVectorD &momentum, const math::XYZTLorentzVectorD &position,
+                   const float charge, coordinates &coords) const;
+
+   private:
+    simpleTrackPropagator() : field_(0), prod_(field_, alongMomentum, 5.e-5), absz_target_(0) {}
+    const RKPropagatorInS &RKProp() const { return prod_.propagator; }
+    Plane::PlanePointer targetPlaneForward_, targetPlaneBackward_;
+    MagneticField const *field_;
+    CurvilinearTrajectoryError err_;
+    defaultRKPropagator::Product prod_;
+    float absz_target_;
+  };
+
+  void simpleTrackPropagator::setPropagationTargetZ(const float &z) {
+    targetPlaneForward_ = Plane::build(Plane::PositionType(0, 0, std::abs(z)), Plane::RotationType());
+    targetPlaneBackward_ =
+        Plane::build(Plane::PositionType(0, 0, -std::abs(z)), Plane::RotationType());
+    absz_target_ = std::abs(z);
+  }
+  bool simpleTrackPropagator::propagate(const double px, const double py, const double pz,
+                                        const double x, const double y, const double z,
+                                        const float charge, coordinates &output) const {
+    output = coordinates();
+
+    typedef TrajectoryStateOnSurface TSOS;
+    GlobalPoint startingPosition(x, y, z);
+    GlobalVector startingMomentum(px, py, pz);
+    Plane::PlanePointer startingPlane =
+        Plane::build(Plane::PositionType(x, y, z), Plane::RotationType());
+    TSOS startingStateP(
+        GlobalTrajectoryParameters(startingPosition, startingMomentum, charge, field_), err_,
+        *startingPlane);
+
+    TSOS trackStateP;
+    if (pz > 0) {
+      trackStateP = RKProp().propagate(startingStateP, *targetPlaneForward_);
+    } else {
+      trackStateP = RKProp().propagate(startingStateP, *targetPlaneBackward_);
+    }
+    if (trackStateP.isValid()) {
+      output.x = trackStateP.globalPosition().x();
+      output.y = trackStateP.globalPosition().y();
+      output.z = trackStateP.globalPosition().z();
+      output.phi = trackStateP.globalPosition().phi();
+      output.eta = trackStateP.globalPosition().eta();
+      return true;
+    }
+    return false;
+  }
+
+  bool simpleTrackPropagator::propagate(const math::XYZTLorentzVectorD &momentum,
+                                        const math::XYZTLorentzVectorD &position, const float charge,
+                                        coordinates &output) const {
+    return propagate(momentum.px(), momentum.py(), momentum.pz(), position.x(), position.y(),
+                     position.z(), charge, output);
+  }
+
+}  // HGCal_helpers
 
 
 class HGCalTriggerNtupleGen : public HGCalTriggerNtupleBase
@@ -13,21 +116,83 @@ class HGCalTriggerNtupleGen : public HGCalTriggerNtupleBase
         virtual void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) override final;
         virtual void fill(const edm::Event&, const edm::EventSetup& ) override final;
 
+        typedef ROOT::Math::Transform3DPJ Transform3D;
+        typedef ROOT::Math::Transform3DPJ::Point Point;
+
     private:
         virtual void clear() override final;
+        void retrieveLayerPositions(const edm::EventSetup &es, unsigned layers);
 
         edm::EDGetToken gen_token_;
         edm::EDGetToken gen_PU_token_;
         
         int gen_n_;
-        std::vector<int>   gen_id_;
-        std::vector<int>   gen_status_;
-        std::vector<float> gen_energy_;
-        std::vector<float> gen_pt_;
-        std::vector<float> gen_eta_;
-        std::vector<float> gen_phi_;
         int gen_PUNumInt_;
         float gen_TrueNumInt_;
+
+        float vtx_x_;
+        float vtx_y_;
+        float vtx_z_;
+
+
+        ////////////////////
+        // GenParticles
+        //
+        std::vector<float> genpart_eta_;
+        std::vector<float> genpart_phi_;
+        std::vector<float> genpart_pt_;
+        std::vector<float> genpart_energy_;
+        std::vector<float> genpart_dvx_;
+        std::vector<float> genpart_dvy_;
+        std::vector<float> genpart_dvz_;
+        std::vector<float> genpart_ovx_;
+        std::vector<float> genpart_ovy_;
+        std::vector<float> genpart_ovz_;
+        std::vector<float> genpart_exx_;
+        std::vector<float> genpart_exy_;
+        std::vector<int> genpart_mother_;
+        std::vector<float> genpart_exphi_;
+        std::vector<float> genpart_exeta_;
+        std::vector<float> genpart_fbrem_;
+        std::vector<int> genpart_pid_;
+        std::vector<int> genpart_gen_;
+        std::vector<int> genpart_reachedEE_;
+        std::vector<bool> genpart_fromBeamPipe_;
+        std::vector<std::vector<float>> genpart_posx_;
+        std::vector<std::vector<float>> genpart_posy_;
+        std::vector<std::vector<float>> genpart_posz_;
+
+        ////////////////////
+        // reco::GenParticles
+        //
+        std::vector<float> gen_eta_;
+        std::vector<float> gen_phi_;
+        std::vector<float> gen_pt_;
+        std::vector<float> gen_energy_;
+        std::vector<int> gen_charge_;
+        std::vector<int> gen_pdgid_;
+        std::vector<int> gen_status_;
+        std::vector<std::vector<int>> gen_daughters_;
+
+
+        // -------convenient tool to deal with simulated tracks
+        FSimEvent *mySimEvent_;
+
+        std::vector<float> layerPositions_;
+        //std::vector<double> dEdXWeights_;
+        //std::vector<double> invThicknessCorrection_;
+
+        // and also the magnetic field
+        MagneticField const *aField_;
+
+        HGCalTriggerTools triggerTools_;
+
+        // edm::EDGetTokenT<std::vector<reco::GenParticle> > genParticles_;
+        edm::EDGetToken simTracks_token_;
+        edm::EDGetToken simVertices_token_;
+        edm::EDGetToken hev_token_;
+
+
 };
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
@@ -40,53 +205,243 @@ HGCalTriggerNtupleGen(const edm::ParameterSet& conf):HGCalTriggerNtupleBase(conf
 {
 }
 
+//FIXME: it should be called once per run...
+void HGCalTriggerNtupleGen::retrieveLayerPositions(const edm::EventSetup &es, unsigned layers) {
+  triggerTools_.setEventSetup(es);
+
+  DetId id;
+  for (unsigned ilayer = 1; ilayer <= layers; ++ilayer) {
+    if (ilayer <= triggerTools_.lastLayerEE()) {
+      id = HGCalDetId(ForwardSubdetector::HGCEE, 1, ilayer, 1, 50, 1);
+    } else if (ilayer > triggerTools_.lastLayerEE() && ilayer <= triggerTools_.lastLayerFH()) {
+      id = HGCalDetId(ForwardSubdetector::HGCHEF, 1, ilayer - triggerTools_.lastLayerEE(), 1, 50, 1);
+    } else if (ilayer > triggerTools_.lastLayerFH()) {
+      id = HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, ilayer - triggerTools_.lastLayerFH());
+    }
+    const GlobalPoint pos = triggerTools_.getPosition(id);
+    layerPositions_.push_back(pos.z());
+  }
+}
+
+
 void
 HGCalTriggerNtupleGen::
 initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
 {
 
+    edm::ParameterSet particleFilter_(conf.getParameter<edm::ParameterSet>("TestParticleFilter"));
+    mySimEvent_ = new FSimEvent(particleFilter_);
+
     gen_token_ = collector.consumes<reco::GenParticleCollection>(conf.getParameter<edm::InputTag>("GenParticles"));
+
     gen_PU_token_ = collector.consumes<std::vector<PileupSummaryInfo>>(conf.getParameter<edm::InputTag>("GenPU"));
     tree.Branch("gen_n", &gen_n_, "gen_n/I");
-    tree.Branch("gen_id", &gen_id_);
-    tree.Branch("gen_status", &gen_status_);
-    tree.Branch("gen_energy", &gen_energy_);
-    tree.Branch("gen_pt", &gen_pt_);
-    tree.Branch("gen_eta", &gen_eta_);
-    tree.Branch("gen_phi", &gen_phi_);
     tree.Branch("gen_PUNumInt", &gen_PUNumInt_ ,"gen_PUNumInt/I");
     tree.Branch("gen_TrueNumInt", &gen_TrueNumInt_ ,"gen_TrueNumInt/F");
+
+    hev_token_ = collector.consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
+    simTracks_token_ = collector.consumes<std::vector<SimTrack>>(edm::InputTag("g4SimHits"));
+    simVertices_token_ = collector.consumes<std::vector<SimVertex>>(edm::InputTag("g4SimHits"));
+
+    tree.Branch("vtx_x", &vtx_x_);
+    tree.Branch("vtx_y", &vtx_y_);
+    tree.Branch("vtx_z", &vtx_z_);
+
+
+    tree.Branch("gen_eta", &gen_eta_);
+    tree.Branch("gen_phi", &gen_phi_);
+    tree.Branch("gen_pt", &gen_pt_);
+    tree.Branch("gen_energy", &gen_energy_);
+    tree.Branch("gen_charge", &gen_charge_);
+    tree.Branch("gen_pdgid", &gen_pdgid_);
+    tree.Branch("gen_status", &gen_status_);
+    tree.Branch("gen_daughters", &gen_daughters_);
+
+    tree.Branch("genpart_eta", &genpart_eta_);
+    tree.Branch("genpart_phi", &genpart_phi_);
+    tree.Branch("genpart_pt", &genpart_pt_);
+    tree.Branch("genpart_energy", &genpart_energy_);
+    tree.Branch("genpart_dvx", &genpart_dvx_);
+    tree.Branch("genpart_dvy", &genpart_dvy_);
+    tree.Branch("genpart_dvz", &genpart_dvz_);
+    tree.Branch("genpart_ovx", &genpart_ovx_);
+    tree.Branch("genpart_ovy", &genpart_ovy_);
+    tree.Branch("genpart_ovz", &genpart_ovz_);
+    tree.Branch("genpart_mother", &genpart_mother_);
+    tree.Branch("genpart_exphi", &genpart_exphi_);
+    tree.Branch("genpart_exeta", &genpart_exeta_);
+    tree.Branch("genpart_exx", &genpart_exx_);
+    tree.Branch("genpart_exy", &genpart_exy_);
+    tree.Branch("genpart_fbrem", &genpart_fbrem_);
+    tree.Branch("genpart_pid", &genpart_pid_);
+    tree.Branch("genpart_gen", &genpart_gen_);
+    tree.Branch("genpart_reachedEE", &genpart_reachedEE_);
+    tree.Branch("genpart_fromBeamPipe", &genpart_fromBeamPipe_);
+    tree.Branch("genpart_posx", &genpart_posx_);
+    tree.Branch("genpart_posy", &genpart_posy_);
+    tree.Branch("genpart_posz", &genpart_posz_);
+
 
 }
 
 void
 HGCalTriggerNtupleGen::
-fill(const edm::Event& e, const edm::EventSetup& es)
+fill(const edm::Event& iEvent, const edm::EventSetup& es)
 {
-    edm::Handle<reco::GenParticleCollection> gen_particles_h;
-    e.getByToken(gen_token_, gen_particles_h);
-    const reco::GenParticleCollection& gen_particles = *gen_particles_h;
+    clear();
 
     edm::Handle<std::vector< PileupSummaryInfo > >  PupInfo_h;
     e.getByToken(gen_PU_token_, PupInfo_h);
     const std::vector< PileupSummaryInfo >& PupInfo = *PupInfo_h;
 
-    clear();
-    gen_n_ = gen_particles.size();
-    gen_id_.reserve(gen_n_);
-    gen_status_.reserve(gen_n_);
-    gen_energy_.reserve(gen_n_);
-    gen_pt_.reserve(gen_n_);
-    gen_eta_.reserve(gen_n_);
-    gen_phi_.reserve(gen_n_);
-    for(const auto& particle : gen_particles)
-    {
-        gen_id_.emplace_back(particle.pdgId());
-        gen_status_.emplace_back(particle.status());
-        gen_energy_.emplace_back(particle.energy());
-        gen_pt_.emplace_back(particle.pt());
-        gen_eta_.emplace_back(particle.eta());
-        gen_phi_.emplace_back(particle.phi());
+
+    // FIXME: this part could go in begin run
+    edm::ESHandle<HepPDT::ParticleDataTable> pdt;
+    es.getData(pdt);
+    mySimEvent_->initializePdt(&(*pdt));
+
+    retrieveLayerPositions(es, 52);
+
+    edm::ESHandle<MagneticField> magfield;
+    es.get<IdealMagneticFieldRecord>().get(magfield);
+    aField_ = &(*magfield);
+    // up to here...could go in the beginRun
+
+    // This balck magic is needed to use the mySimEvent_
+    ParticleTable::Sentry ptable(mySimEvent_->theTable());
+    edm::Handle<edm::HepMCProduct> hevH;
+    edm::Handle<std::vector<SimTrack>> simTracksHandle;
+    edm::Handle<std::vector<SimVertex>> simVerticesHandle;
+
+    iEvent.getByToken(hev_token_, hevH);
+    iEvent.getByToken(simTracks_token_, simTracksHandle);
+    iEvent.getByToken(simVertices_token_, simVerticesHandle);
+    mySimEvent_->fill(*simTracksHandle, *simVerticesHandle);
+
+    HepMC::GenVertex *primaryVertex = *(hevH)->GetEvent()->vertices_begin();
+    vtx_x_ = primaryVertex->position().x() / 10.;  // to put in official units
+    vtx_y_ = primaryVertex->position().y() / 10.;
+    vtx_z_ = primaryVertex->position().z() / 10.;
+    Point sim_pv(vtx_x_, vtx_y_, vtx_z_);
+
+
+    HGCal_helpers::simpleTrackPropagator toHGCalPropagator(aField_);
+    toHGCalPropagator.setPropagationTargetZ(layerPositions_[0]);
+    std::vector<FSimTrack *> allselectedgentracks;
+    unsigned int npart = mySimEvent_->nTracks();
+    for (unsigned int i = 0; i < npart; ++i) {
+      std::vector<float> xp, yp, zp;
+      FSimTrack &myTrack(mySimEvent_->track(i));
+      math::XYZTLorentzVectorD vtx(0, 0, 0, 0);
+
+      int reachedEE = 0;  // compute the extrapolations for the particles reaching EE
+                          // and for the gen particles
+      double fbrem = -1;
+
+      if (std::abs(myTrack.vertex().position().z()) >= layerPositions_[0]) continue;
+
+      unsigned nlayers = 40;
+      if (myTrack.noEndVertex())  // || myTrack.genpartIndex()>=0)
+      {
+        HGCal_helpers::coordinates propcoords;
+        bool reachesHGCal = toHGCalPropagator.propagate(
+            myTrack.momentum(), myTrack.vertex().position(), myTrack.charge(), propcoords);
+        vtx = propcoords.toVector();
+
+        if (reachesHGCal && vtx.Rho() < 160 && vtx.Rho() > 25) {
+          reachedEE = 2;
+          double dpt = 0;
+
+          for (int i = 0; i < myTrack.nDaughters(); ++i) dpt += myTrack.daughter(i).momentum().pt();
+          if (abs(myTrack.type()) == 11) fbrem = dpt / myTrack.momentum().pt();
+        } else if (reachesHGCal && vtx.Rho() > 160)
+          reachedEE = 1;
+
+        HGCal_helpers::simpleTrackPropagator indiv_particleProp(aField_);
+        for (unsigned il = 0; il < nlayers; ++il) {
+          const float charge = myTrack.charge();
+          indiv_particleProp.setPropagationTargetZ(layerPositions_[il]);
+          HGCal_helpers::coordinates propCoords;
+          indiv_particleProp.propagate(myTrack.momentum(), myTrack.vertex().position(), charge,
+                                       propCoords);
+
+          xp.push_back(propCoords.x);
+          yp.push_back(propCoords.y);
+          zp.push_back(propCoords.z);
+        }
+      } else {
+        vtx = myTrack.endVertex().position();
+      }
+      auto orig_vtx = myTrack.vertex().position();
+
+      allselectedgentracks.push_back(&mySimEvent_->track(i));
+      // fill branches
+      genpart_eta_.push_back(myTrack.momentum().eta());
+      genpart_phi_.push_back(myTrack.momentum().phi());
+      genpart_pt_.push_back(myTrack.momentum().pt());
+      genpart_energy_.push_back(myTrack.momentum().energy());
+      genpart_dvx_.push_back(vtx.x());
+      genpart_dvy_.push_back(vtx.y());
+      genpart_dvz_.push_back(vtx.z());
+
+      genpart_ovx_.push_back(orig_vtx.x());
+      genpart_ovy_.push_back(orig_vtx.y());
+      genpart_ovz_.push_back(orig_vtx.z());
+
+      HGCal_helpers::coordinates hitsHGCal;
+      toHGCalPropagator.propagate(myTrack.momentum(), orig_vtx, myTrack.charge(), hitsHGCal);
+
+      genpart_exphi_.push_back(hitsHGCal.phi);
+      genpart_exeta_.push_back(hitsHGCal.eta);
+      genpart_exx_.push_back(hitsHGCal.x);
+      genpart_exy_.push_back(hitsHGCal.y);
+
+      genpart_fbrem_.push_back(fbrem);
+      genpart_pid_.push_back(myTrack.type());
+      genpart_gen_.push_back(myTrack.genpartIndex());
+      genpart_reachedEE_.push_back(reachedEE);
+      genpart_fromBeamPipe_.push_back(true);
+
+      genpart_posx_.push_back(xp);
+      genpart_posy_.push_back(yp);
+      genpart_posz_.push_back(zp);
+    }
+
+
+    edm::Handle<std::vector<reco::GenParticle>> genParticlesHandle;
+    iEvent.getByToken(gen_token_, genParticlesHandle);
+    for (std::vector<reco::GenParticle>::const_iterator it_p = genParticlesHandle->begin();
+         it_p != genParticlesHandle->end(); ++it_p) {
+      gen_eta_.push_back(it_p->eta());
+      gen_phi_.push_back(it_p->phi());
+      gen_pt_.push_back(it_p->pt());
+      gen_energy_.push_back(it_p->energy());
+      gen_charge_.push_back(it_p->charge());
+      gen_pdgid_.push_back(it_p->pdgId());
+      gen_status_.push_back(it_p->status());
+      std::vector<int> daughters(it_p->daughterRefVector().size(), 0);
+      for (unsigned j = 0; j < it_p->daughterRefVector().size(); ++j) {
+        daughters[j] = static_cast<int>(it_p->daughterRefVector().at(j).key());
+      }
+      gen_daughters_.push_back(daughters);
+    }
+
+
+    // associate gen particles to mothers
+    genpart_mother_.resize(genpart_posz_.size(), -1);
+    for (size_t i = 0; i < allselectedgentracks.size(); i++) {
+      const auto tracki = allselectedgentracks.at(i);
+
+      for (size_t j = i + 1; j < allselectedgentracks.size(); j++) {
+        const auto trackj = allselectedgentracks.at(j);
+
+        if (!tracki->noMother()) {
+          if (&tracki->mother() == trackj) genpart_mother_.at(i) = j;
+        }
+        if (!trackj->noMother()) {
+          if (&trackj->mother() == tracki) genpart_mother_.at(j) = i;
+        }
+      }
     }
 
     for(const auto& PVI : PupInfo)
@@ -105,17 +460,50 @@ void
 HGCalTriggerNtupleGen::
 clear()
 {
+
     gen_n_ = 0;
-    gen_id_.clear();
-    gen_status_.clear();
-    gen_energy_.clear();
-    gen_pt_.clear();
-    gen_eta_.clear();
-    gen_phi_.clear();
     gen_PUNumInt_ = 0;
     gen_TrueNumInt_ = 0.;
+
+    vtx_x_ = 0;
+    vtx_y_ = 0;
+    vtx_z_ = 0;
+
+
+    //
+    genpart_eta_.clear();
+    genpart_phi_.clear();
+    genpart_pt_.clear();
+    genpart_energy_.clear();
+    genpart_dvx_.clear();
+    genpart_dvy_.clear();
+    genpart_dvz_.clear();
+    genpart_ovx_.clear();
+    genpart_ovy_.clear();
+    genpart_ovz_.clear();
+    genpart_exx_.clear();
+    genpart_exy_.clear();
+    genpart_mother_.clear();
+    genpart_exphi_.clear();
+    genpart_exeta_.clear();
+    genpart_fbrem_.clear();
+    genpart_pid_.clear();
+    genpart_gen_.clear();
+    genpart_reachedEE_.clear();
+    genpart_fromBeamPipe_.clear();
+    genpart_posx_.clear();
+    genpart_posy_.clear();
+    genpart_posz_.clear();
+
+    ////////////////////
+    // reco::GenParticles
+    //
+    gen_eta_.clear();
+    gen_phi_.clear();
+    gen_pt_.clear();
+    gen_energy_.clear();
+    gen_charge_.clear();
+    gen_pdgid_.clear();
+    gen_status_.clear();
+    gen_daughters_.clear();
 }
-
-
-
-

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -291,7 +291,7 @@ fill(const edm::Event& iEvent, const edm::EventSetup& es)
     clear();
 
     edm::Handle<std::vector< PileupSummaryInfo > >  PupInfo_h;
-    e.getByToken(gen_PU_token_, PupInfo_h);
+    iEvent.getByToken(gen_PU_token_, PupInfo_h);
     const std::vector< PileupSummaryInfo >& PupInfo = *PupInfo_h;
 
 
@@ -410,6 +410,8 @@ fill(const edm::Event& iEvent, const edm::EventSetup& es)
 
     edm::Handle<std::vector<reco::GenParticle>> genParticlesHandle;
     iEvent.getByToken(gen_token_, genParticlesHandle);
+    gen_n_ = genParticlesHandle->size();
+
     for (std::vector<reco::GenParticle>::const_iterator it_p = genParticlesHandle->begin();
          it_p != genParticlesHandle->end(); ++it_p) {
       gen_eta_.push_back(it_p->eta());

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -9,7 +9,7 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
-
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 
 
@@ -27,6 +27,7 @@ class HGCalTriggerNtupleHGCTriggerCells : public HGCalTriggerNtupleBase
     void simhits(const edm::Event& e, std::unordered_map<uint32_t, double>& simhits_ee, std::unordered_map<uint32_t, double>& simhits_fh, std::unordered_map<uint32_t, double>& simhits_bh);
     virtual void clear() override final;
 
+    HGCalTriggerTools triggerTools_;
 
     edm::EDGetToken trigger_cells_token_, multiclusters_token_;
     edm::EDGetToken simhits_ee_token_, simhits_fh_token_, simhits_bh_token_;
@@ -100,7 +101,7 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
   tree.Branch("tc_layer", &tc_layer_);
   tree.Branch("tc_wafer", &tc_wafer_);
   tree.Branch("tc_wafertype", &tc_wafertype_);
-  tree.Branch("tc_cell", &tc_cell_);    
+  tree.Branch("tc_cell", &tc_cell_);
   tree.Branch("tc_data", &tc_data_);
   tree.Branch("tc_pt", &tc_pt_);
   tree.Branch("tc_mipPt", &tc_mipPt_);
@@ -158,6 +159,8 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     }
   }
 
+  triggerTools_.setEventSetup(es);
+
   clear();
   for(auto tc_itr=trigger_cells.begin(0); tc_itr!=trigger_cells.end(0); tc_itr++)
   {
@@ -176,7 +179,7 @@ fill(const edm::Event& e, const edm::EventSetup& es)
       tc_id_.emplace_back(tc_itr->detId());
       tc_subdet_.emplace_back(id.subdetId());
       tc_side_.emplace_back(id.zside());
-      tc_layer_.emplace_back(id.layer());
+      tc_layer_.emplace_back(triggerTools_.getLayerWithOffset(id));
       tc_wafer_.emplace_back(id.wafer());
       tc_wafertype_.emplace_back(id.waferType());
       tc_cell_.emplace_back(id.cell());
@@ -335,7 +338,3 @@ clear()
   tc_multicluster_id_.clear();
   tc_multicluster_pt_.clear();
 }
-
-
-
-

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -40,7 +40,7 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(False)
+    isSimhitComp = cms.bool(True)
 )
 
 ntuple_triggercells = cms.PSet(

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -15,10 +15,17 @@ ntuple_event = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleEvent')
 )
 
+
+from FastSimulation.Event.ParticleFilter_cfi import ParticleFilterBlock
+PartFilterConfig = ParticleFilterBlock.ParticleFilter.copy()
+PartFilterConfig.protonEMin = cms.double(100000)
+PartFilterConfig.etaMax = cms.double(3.1)
+
 ntuple_gen = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleGen'),
     GenParticles = cms.InputTag('genParticles'),
     GenPU = cms.InputTag('addPileupInfo')
+    TestParticleFilter = PartFilterConfig
 )
 
 ntuple_gentau = cms.PSet(

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -25,7 +25,7 @@ ntuple_gen = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleGen'),
     GenParticles = cms.InputTag('genParticles'),
     GenPU = cms.InputTag('addPileupInfo'),
-    TestParticleFilter = PartFilterConfig
+    particleFilter = PartFilterConfig
 )
 
 ntuple_gentau = cms.PSet(
@@ -47,7 +47,7 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(True)
+    isSimhitComp = cms.bool(False)
 )
 
 ntuple_triggercells = cms.PSet(

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -24,7 +24,7 @@ PartFilterConfig.etaMax = cms.double(3.1)
 ntuple_gen = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleGen'),
     GenParticles = cms.InputTag('genParticles'),
-    GenPU = cms.InputTag('addPileupInfo')
+    GenPU = cms.InputTag('addPileupInfo'),
     TestParticleFilter = PartFilterConfig
 )
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -9,11 +9,9 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -14,7 +14,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
-#define EDM_ML_DEBUG
+
 namespace {
   constexpr char hgcalee_sens[] = "HGCalEESensitive";
   constexpr char hgcalfh_sens[] = "HGCalHESiliconSensitive";

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -65,91 +65,10 @@ void HGCalTriggerTools::setEventSetup(const edm::EventSetup& es) {
 }
 
 GlobalPoint HGCalTriggerTools::getPosition(const DetId& id) const {
-  auto geom = geom_->caloGeometry()->getSubdetectorGeometry(id);
-  check_geom(geom);
-  GlobalPoint position;
-  if( id.det() == DetId::Hcal ) {
-    position = geom->getGeometry(id)->getPosition();
-  } else {
-    const auto* hg = static_cast<const HGCalGeometry*>(geom);
-    position = hg->getPosition(id);
-  }
+  GlobalPoint position = geom_->getTriggerCellPosition(id);
   return position;
 }
 
-
-// int HGCalTriggerTools::zside(const DetId& id) const {
-//   int zside = 0;
-//   if( id.det() == DetId::Forward) {
-//     const HGCalDetId hid(id);
-//     zside = hid.zside();
-//   } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
-//     const HcalDetId hcid(id);
-//     zside = hcid.zside();
-//   }
-//   return zside;
-// }
-//
-// std::float_t HGCalTriggerTools::getSiThickness(const DetId& id) const {
-//   auto geom = geom_->getSubdetectorGeometry(id);
-//   check_geom(geom);
-//   if( id.det() != DetId::Forward ) {
-//     LogDebug("getSiThickness::InvalidSiliconDetid")
-//       << "det id: " << id.rawId() << " is not HGCal silicon!";
-//   }
-//   const HGCalDetId hid(id);
-//   auto ddd = get_ddd(geom,hid);
-//   unsigned int wafer = hid.wafer();
-//   int tidx = ddd->waferTypeL(wafer);
-//   return idx_to_thickness*tidx;
-// }
-//
-// std::float_t HGCalTriggerTools::getRadiusToSide(const DetId& id) const {
-//   auto geom = geom_->getSubdetectorGeometry(id);
-//   check_geom(geom);
-//   if( id.det() != DetId::Forward ) {
-//     edm::LogError("getRadiusToSide::InvalidSiliconDetid")
-//       << "det id: " << id.rawId() << " is not HGCal silicon!";
-//     return std::numeric_limits<std::float_t>::max();
-//   }
-//   const HGCalDetId hid(id);
-//   auto ddd = get_ddd(geom,hid);
-//   std::float_t size = ddd->cellSizeHex(hid.waferType());
-//   return size;
-// }
-//
-// unsigned int HGCalTriggerTools::getLayer(const ForwardSubdetector type) const {
-//
-//   int layer;
-//   switch (type) {
-//     case(ForwardSubdetector::HGCEE): {
-//       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-//       layer       = (geomEE->topology().dddConstants()).layers(true);
-//       break;
-//     }
-//     case (ForwardSubdetector::HGCHEF): {
-//       auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-//       layer       = (geomFH->topology().dddConstants()).layers(true);
-//       break;
-//     }
-//     case (ForwardSubdetector::HGCHEB): {
-//       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
-//       layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
-//       break;
-//     }
-//     case (ForwardSubdetector::ForwardEmpty): {
-//       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-//       layer       = (geomEE->topology().dddConstants()).layers(true);
-//       auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-//       layer      += (geomFH->topology().dddConstants()).layers(true);
-//       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
-//       layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
-//       break;
-//     }
-//     default: layer = 0;
-//   }
-//   return (unsigned int)(layer);
-// }
 
 unsigned int HGCalTriggerTools::getLayer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
@@ -173,40 +92,6 @@ unsigned int HGCalTriggerTools::getLayerWithOffset(const DetId& id) const {
   }
   return layer;
 }
-
-// unsigned int HGCalTriggerTools::getWafer(const DetId& id) const {
-//   if( id.det() != DetId::Forward ) {
-//     edm::LogError("getWafer::InvalidSiliconDetid")
-//       << "det id: " << id.rawId() << " is not HGCal silicon!";
-//     return std::numeric_limits<unsigned int>::max();
-//   }
-//   const HGCalDetId hid(id);
-//   unsigned int wafer = hid.wafer();
-//   return wafer;
-// }
-//
-// unsigned int HGCalTriggerTools::getCell(const DetId& id) const {
-//   if( id.det() != DetId::Forward ) {
-//     edm::LogError("getCell::InvalidSiliconDetid")
-//       << "det id: " << id.rawId() << " is not HGCal silicon!";
-//     return std::numeric_limits<unsigned int>::max();
-//   }
-//   const HGCalDetId hid(id);
-//   unsigned int cell = hid.cell();
-//   return cell;
-// }
-//
-// bool HGCalTriggerTools::isHalfCell(const DetId& id) const {
-//   if( id.det() != DetId::Forward ) {
-//     return false;
-//   }
-//   auto geom = geom_->getSubdetectorGeometry(id);
-//   check_geom(geom);
-//   const HGCalDetId hid(id);
-//   auto ddd = get_ddd(geom,hid);
-//   const int waferType = ddd->waferTypeT(hid.waferType());
-//   return ddd->isHalfCell(waferType,hid.cell());
-// }
 
 float HGCalTriggerTools::getEta(const GlobalPoint& position, const float& vertex_z) const {
   GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z()-vertex_z);

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -1,0 +1,246 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+
+namespace {
+  constexpr char hgcalee_sens[] = "HGCalEESensitive";
+  constexpr char hgcalfh_sens[] = "HGCalHESiliconSensitive";
+
+  constexpr std::float_t idx_to_thickness = std::float_t(100.0);
+
+  template<typename DDD>
+  inline void check_ddd(const DDD* ddd) {
+    if( nullptr == ddd ) {
+      throw cms::Exception("hgcal::HGCalTriggerTools")
+        << "DDDConstants not accessibl to hgcal::HGCalTriggerTools!";
+    }
+  }
+
+  template<typename GEOM>
+  inline void check_geom(const GEOM* geom) {
+    if( nullptr == geom ) {
+      throw cms::Exception("hgcal::HGCalTriggerTools")
+        << "Geometry not provided yet to hgcal::HGCalTriggerTools!";
+    }
+  }
+
+  inline const HcalDDDRecConstants* get_ddd(const CaloSubdetectorGeometry* geom,
+					    const HcalDetId& detid) {
+    const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
+    const HcalDDDRecConstants* ddd = hc->topology().dddConstants();
+    check_ddd(ddd);
+    return ddd;
+  }
+
+  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
+					  const HGCalDetId& detid) {
+    const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
+    const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
+    check_ddd(ddd);
+    return ddd;
+  }
+
+}
+
+void HGCalTriggerTools::setEventSetup(const edm::EventSetup& es) {
+
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  es.get<CaloGeometryRecord>().get(triggerGeometry_);
+  geom_ = triggerGeometry_.product();
+  fhOffset_ = (geom_->eeTopology().dddConstants()).layers(true);
+  bhOffset_ = fhOffset_ + (geom_->fhTopology().dddConstants()).layers(true);
+}
+
+GlobalPoint HGCalTriggerTools::getPosition(const DetId& id) const {
+  auto geom = geom_->caloGeometry()->getSubdetectorGeometry(id);
+  check_geom(geom);
+  GlobalPoint position;
+  if( id.det() == DetId::Hcal ) {
+    position = geom->getGeometry(id)->getPosition();
+  } else {
+    const auto* hg = static_cast<const HGCalGeometry*>(geom);
+    position = hg->getPosition(id);
+  }
+  return position;
+}
+
+
+// int HGCalTriggerTools::zside(const DetId& id) const {
+//   int zside = 0;
+//   if( id.det() == DetId::Forward) {
+//     const HGCalDetId hid(id);
+//     zside = hid.zside();
+//   } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+//     const HcalDetId hcid(id);
+//     zside = hcid.zside();
+//   }
+//   return zside;
+// }
+//
+// std::float_t HGCalTriggerTools::getSiThickness(const DetId& id) const {
+//   auto geom = geom_->getSubdetectorGeometry(id);
+//   check_geom(geom);
+//   if( id.det() != DetId::Forward ) {
+//     LogDebug("getSiThickness::InvalidSiliconDetid")
+//       << "det id: " << id.rawId() << " is not HGCal silicon!";
+//   }
+//   const HGCalDetId hid(id);
+//   auto ddd = get_ddd(geom,hid);
+//   unsigned int wafer = hid.wafer();
+//   int tidx = ddd->waferTypeL(wafer);
+//   return idx_to_thickness*tidx;
+// }
+//
+// std::float_t HGCalTriggerTools::getRadiusToSide(const DetId& id) const {
+//   auto geom = geom_->getSubdetectorGeometry(id);
+//   check_geom(geom);
+//   if( id.det() != DetId::Forward ) {
+//     edm::LogError("getRadiusToSide::InvalidSiliconDetid")
+//       << "det id: " << id.rawId() << " is not HGCal silicon!";
+//     return std::numeric_limits<std::float_t>::max();
+//   }
+//   const HGCalDetId hid(id);
+//   auto ddd = get_ddd(geom,hid);
+//   std::float_t size = ddd->cellSizeHex(hid.waferType());
+//   return size;
+// }
+//
+// unsigned int HGCalTriggerTools::getLayer(const ForwardSubdetector type) const {
+//
+//   int layer;
+//   switch (type) {
+//     case(ForwardSubdetector::HGCEE): {
+//       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+//       layer       = (geomEE->topology().dddConstants()).layers(true);
+//       break;
+//     }
+//     case (ForwardSubdetector::HGCHEF): {
+//       auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+//       layer       = (geomFH->topology().dddConstants()).layers(true);
+//       break;
+//     }
+//     case (ForwardSubdetector::HGCHEB): {
+//       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+//       layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
+//       break;
+//     }
+//     case (ForwardSubdetector::ForwardEmpty): {
+//       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+//       layer       = (geomEE->topology().dddConstants()).layers(true);
+//       auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+//       layer      += (geomFH->topology().dddConstants()).layers(true);
+//       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+//       layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
+//       break;
+//     }
+//     default: layer = 0;
+//   }
+//   return (unsigned int)(layer);
+// }
+
+unsigned int HGCalTriggerTools::getLayer(const DetId& id) const {
+  unsigned int layer = std::numeric_limits<unsigned int>::max();
+  if( id.det() == DetId::Forward) {
+    const HGCalDetId hid(id);
+    layer = hid.layer();
+  } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+    const HcalDetId hcid(id);
+    layer = hcid.depth();
+  }
+  return layer;
+}
+
+unsigned int HGCalTriggerTools::getLayerWithOffset(const DetId& id) const {
+  unsigned int layer = getLayer(id);
+  if( id.det() == DetId::Forward && id.subdetId() == HGCHEF ) {
+    layer += fhOffset_;
+  } else if( (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) ||
+             (id.det() == DetId::Forward && id.subdetId() == HGCHEB) ) {
+    layer += bhOffset_;
+  }
+  return layer;
+}
+
+// unsigned int HGCalTriggerTools::getWafer(const DetId& id) const {
+//   if( id.det() != DetId::Forward ) {
+//     edm::LogError("getWafer::InvalidSiliconDetid")
+//       << "det id: " << id.rawId() << " is not HGCal silicon!";
+//     return std::numeric_limits<unsigned int>::max();
+//   }
+//   const HGCalDetId hid(id);
+//   unsigned int wafer = hid.wafer();
+//   return wafer;
+// }
+//
+// unsigned int HGCalTriggerTools::getCell(const DetId& id) const {
+//   if( id.det() != DetId::Forward ) {
+//     edm::LogError("getCell::InvalidSiliconDetid")
+//       << "det id: " << id.rawId() << " is not HGCal silicon!";
+//     return std::numeric_limits<unsigned int>::max();
+//   }
+//   const HGCalDetId hid(id);
+//   unsigned int cell = hid.cell();
+//   return cell;
+// }
+//
+// bool HGCalTriggerTools::isHalfCell(const DetId& id) const {
+//   if( id.det() != DetId::Forward ) {
+//     return false;
+//   }
+//   auto geom = geom_->getSubdetectorGeometry(id);
+//   check_geom(geom);
+//   const HGCalDetId hid(id);
+//   auto ddd = get_ddd(geom,hid);
+//   const int waferType = ddd->waferTypeT(hid.waferType());
+//   return ddd->isHalfCell(waferType,hid.cell());
+// }
+
+float HGCalTriggerTools::getEta(const GlobalPoint& position, const float& vertex_z) const {
+  GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z()-vertex_z);
+  return corrected_position.eta();
+}
+
+float HGCalTriggerTools::getEta(const DetId& id, const float& vertex_z) const {
+  GlobalPoint position = getPosition(id);
+  float eta = getEta(position, vertex_z);
+  return eta;
+}
+
+float HGCalTriggerTools::getPhi(const GlobalPoint& position) const {
+  float phi = atan2(position.y(),position.x());
+  return phi;
+}
+
+float HGCalTriggerTools::getPhi(const DetId& id) const {
+  GlobalPoint position = getPosition(id);
+  float phi = atan2(position.y(),position.x());
+  return phi;
+}
+
+float HGCalTriggerTools::getPt(const GlobalPoint& position, const float& hitEnergy, const float& vertex_z) const {
+  float eta = getEta(position, vertex_z);
+  float pt = hitEnergy / cosh(eta);
+  return pt;
+}
+
+float HGCalTriggerTools::getPt(const DetId& id, const float& hitEnergy, const float& vertex_z) const {
+  GlobalPoint position = getPosition(id);
+  float eta = getEta(position, vertex_z);
+  float pt = hitEnergy / cosh(eta);
+  return pt;
+}


### PR DESCRIPTION
Expand GEN level information in the ntuplizer.

NOTE: I had to port the code from the repo: 
https://github.com/CMS-HGCAL/reco-ntuples
unfortunately there is no easy way to merge the 2 ntuplizer at the moment. Apologies to the original authors!

Add the HGCalTriggerTools class, heavily "inspired" to the RecHItTriggerTools one. The current approach is that the class assumes to handle TC DetIDs. However, since there is no clear way to distinguish them from the offline counterpart, some care needs to be used...

 