### PR TITLE
HGC C2D calibration

### DIFF
--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalClusteringImpl.h
@@ -69,6 +69,10 @@ private:
     double scintillatorTriggerCellThreshold_;
     double dr_;
     std::string clusteringAlgorithmType_;
+    double calibSF_;
+    std::vector<double> layerWeights_;
+    bool applyLayerWeights_;
+
     void triggerCellReshuffling( const std::vector<edm::Ptr<l1t::HGCalTriggerCell>> & triggerCellsPtrs, 
                                  std::array<std::array<std::vector<edm::Ptr<l1t::HGCalTriggerCell>>, kLayers_>, kNSides_> & reshuffledTriggerCells );
 
@@ -77,6 +81,8 @@ private:
     void removeUnconnectedTCinCluster( l1t::HGCalCluster & cluster,
                                         const HGCalTriggerGeometryBase & triggerGeometry
         );
+    
+    void calibratePt( l1t::HGCalCluster & cluster );
 
 };
 

--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalMulticlusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalMulticlusteringImpl.h
@@ -39,12 +39,9 @@ private:
     
     double dr_;
     double ptC3dThreshold_;
-    double calibSF_;
     string multiclusterAlgoType_;
     double distDbscan_ = 0.005;
     unsigned minNDbscan_ = 3;
-    std::vector<double> layerWeights_;
-    bool applyLayerWeights_;
 
     HGCalShowerShape shape_;
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -62,17 +62,17 @@ C2d_parValues = cms.PSet( seeding_threshold_silicon = cms.double(5), # MipT
                           clustering_threshold_silicon = cms.double(2), # MipT
                           clustering_threshold_scintillator = cms.double(2), # MipT
                           dR_cluster = cms.double(6.), # in cm
-                          clusterType = cms.string('NNC2d') # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
+                          clusterType = cms.string('NNC2d'), # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
 #                          clusterType = cms.string('dRC2d') # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
 #                          clusterType = cms.string('dRNNC2d') # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
+                          calibSF_multicluster = cms.double(1.084),
+                          applyLayerCalibration = cms.bool(True),
+                          layerWeights = layercalibparam.TrgLayer_weights
                           )
 
 C3d_parValues = cms.PSet( dR_multicluster = cms.double(0.01), # dR in normalized plane used to clusterize C2d
                           minPt_multicluster = cms.double(0.5), # minimum pt of the multicluster (GeV)
-                          calibSF_multicluster = cms.double(1.084),
                           type_multicluster = cms.string('dRC3d'), #'DBSCANC3d' for the DBSCAN algorithm 
-                          applyLayerCalibration = cms.bool(True),
-                          layerWeights = layercalibparam.TrgLayer_weights,
                           dist_dbscan_multicluster = cms.double(0.005),
                           minN_dbscan_multicluster = cms.uint32(3)
                           )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -65,7 +65,7 @@ C2d_parValues = cms.PSet( seeding_threshold_silicon = cms.double(5), # MipT
                           clusterType = cms.string('NNC2d'), # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
 #                          clusterType = cms.string('dRC2d') # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
 #                          clusterType = cms.string('dRNNC2d') # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering; dRNNC2d-->Limited Nearest Neighbors clustering
-                          calibSF_multicluster = cms.double(1.084),
+                          calibSF_cluster = cms.double(1.084),
                           applyLayerCalibration = cms.bool(True),
                           layerWeights = layercalibparam.TrgLayer_weights
                           )

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalClusteringImpl.cc
@@ -11,14 +11,17 @@ HGCalClusteringImpl::HGCalClusteringImpl(const edm::ParameterSet & conf):
     scintillatorSeedThreshold_(conf.getParameter<double>("seeding_threshold_scintillator")),
     scintillatorTriggerCellThreshold_(conf.getParameter<double>("clustering_threshold_scintillator")),
     dr_(conf.getParameter<double>("dR_cluster")),
-    clusteringAlgorithmType_(conf.getParameter<string>("clusterType"))
+    clusteringAlgorithmType_(conf.getParameter<string>("clusterType")),
+    calibSF_(conf.getParameter<double>("calibSF_multicluster")),
+    layerWeights_(conf.getParameter< std::vector<double> >("layerWeights")),
+    applyLayerWeights_(conf.getParameter< bool >("applyLayerCalibration"))
 {    
     edm::LogInfo("HGCalClusterParameters") << "C2d Clustering Algorithm selected : " << clusteringAlgorithmType_ ; 
     edm::LogInfo("HGCalClusterParameters") << "C2d silicon seeding Thr: " << siliconSeedThreshold_ ; 
     edm::LogInfo("HGCalClusterParameters") << "C2d silicon clustering Thr: " << siliconTriggerCellThreshold_ ; 
     edm::LogInfo("HGCalClusterParameters") << "C2d scintillator seeding Thr: " << scintillatorSeedThreshold_ ; 
     edm::LogInfo("HGCalClusterParameters") << "C2d scintillator clustering Thr: " << scintillatorTriggerCellThreshold_ ; 
- 
+    edm::LogInfo("HGCalClusterParameters") << "C2d global calibration factor: " << calibSF_;
 }
 
 
@@ -103,6 +106,7 @@ void HGCalClusteringImpl::clusterizeDR( const std::vector<edm::Ptr<l1t::HGCalTri
     /* store clusters in the persistent collection */
     clusters.resize(0, clustersTmp.size());
     for( unsigned i(0); i<clustersTmp.size(); ++i ){
+        calibratePt(clustersTmp.at(i));
         clusters.set( 0, i, clustersTmp.at(i) );
     }
     
@@ -254,6 +258,7 @@ void HGCalClusteringImpl::NNKernel( const std::vector<edm::Ptr<l1t::HGCalTrigger
             }
         }
         if(saveInCollection){
+            calibratePt(cluster);
             clusters.push_back( 0, cluster );
         }
     }
@@ -369,6 +374,7 @@ void HGCalClusteringImpl::clusterizeDRNN( const std::vector<edm::Ptr<l1t::HGCalT
     clusters.resize(0, clustersTmp.size());
     for( unsigned i(0); i<clustersTmp.size(); ++i ){
         this->removeUnconnectedTCinCluster( clustersTmp.at(i), triggerGeometry );
+        calibratePt( clustersTmp.at(i) );
         clusters.set( 0, i, clustersTmp.at(i) );
     }
 
@@ -434,4 +440,42 @@ void HGCalClusteringImpl::removeUnconnectedTCinCluster( l1t::HGCalCluster & clus
         if( toRemove[i] ) cluster.removeConstituent( distances.at( i ).first );
     }
     
+}
+
+
+
+void HGCalClusteringImpl::calibratePt( l1t::HGCalCluster & cluster ){
+
+  double calibPt=0.;
+
+  if(applyLayerWeights_){
+
+    int layerN = -1;
+    if( cluster.subdetId()==HGCEE ){
+      layerN = cluster.layer();
+    }
+    else if( cluster.subdetId()==HGCHEF ){
+      layerN = cluster.layer()+kLayersEE_;
+    }
+    else if( cluster.subdetId()==HGCHEB ){
+      layerN = cluster.layer()+kLayersFH_+kLayersEE_;
+    }
+
+    calibPt = layerWeights_.at(layerN) * cluster.mipPt();
+
+  }
+
+  else{
+
+    calibPt = cluster.pt() * calibSF_;
+
+  }
+
+  math::PtEtaPhiMLorentzVector calibP4( calibPt,
+                                        cluster.eta(),
+                                        cluster.phi(),
+					0. );
+
+  cluster.setP4( calibP4 );
+
 }

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
@@ -116,14 +116,14 @@ void HGCalMulticlusteringImpl::clusterizeDR( const std::vector<edm::Ptr<l1t::HGC
 
         const std::vector<edm::Ptr<l1t::HGCalCluster>> &pertinentClu = multiclustersTmp.at(i).constituents();
         for( std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator  it_clu=pertinentClu.begin(); it_clu<pertinentClu.end(); it_clu++) sumPt +=(*it_clu)->pt();
-	math::PtEtaPhiMLorentzVector multiclusterP4(  sumPt,
-						      multiclustersTmp.at(i).centre().eta(),
-						      multiclustersTmp.at(i).centre().phi(),
-						      0. );
-	multiclustersTmp.at(i).setP4( multiclusterP4 );
+        math::PtEtaPhiMLorentzVector multiclusterP4(  sumPt,
+                                                      multiclustersTmp.at(i).centre().eta(),
+                                                      multiclustersTmp.at(i).centre().phi(),
+                                                      0. );
+        multiclustersTmp.at(i).setP4( multiclusterP4 );
 
 
-	if( multiclustersTmp.at(i).pt() > ptC3dThreshold_ ){
+        if( multiclustersTmp.at(i).pt() > ptC3dThreshold_ ){
 
             //compute shower shape
             multiclustersTmp.at(i).set_showerLength(shape_.showerLength(multiclustersTmp.at(i)));
@@ -219,9 +219,9 @@ void HGCalMulticlusteringImpl::clusterizeDBSCAN( const std::vector<edm::Ptr<l1t:
     for( std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator  it_clu=pertinentClu.begin(); it_clu<pertinentClu.end(); it_clu++) sumPt +=(*it_clu)->pt();
 
     math::PtEtaPhiMLorentzVector multiclusterP4(  sumPt,
-						  multiclustersTmp.at(i).centre().eta(),
-						  multiclustersTmp.at(i).centre().phi(),
-						  0. );
+                                                  multiclustersTmp.at(i).centre().eta(),
+                                                  multiclustersTmp.at(i).centre().phi(),
+                                                  0. );
     multiclustersTmp.at(i).setP4( multiclusterP4 );
 
     

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalMulticlusteringImpl.cc
@@ -1,3 +1,5 @@
+
+
 #include "L1Trigger/L1THGCal/interface/be_algorithms/HGCalMulticlusteringImpl.h"
 #include "L1Trigger/L1THGCal/interface/be_algorithms/HGCalShowerShape.h"
 #include "DataFormats/Math/interface/deltaR.h"
@@ -6,16 +8,12 @@
 HGCalMulticlusteringImpl::HGCalMulticlusteringImpl( const edm::ParameterSet& conf ) :
     dr_(conf.getParameter<double>("dR_multicluster")),
     ptC3dThreshold_(conf.getParameter<double>("minPt_multicluster")),
-    calibSF_(conf.getParameter<double>("calibSF_multicluster")),
     multiclusterAlgoType_(conf.getParameter<string>("type_multicluster")),
     distDbscan_(conf.getParameter<double>("dist_dbscan_multicluster")),
-    minNDbscan_(conf.getParameter<unsigned>("minN_dbscan_multicluster")),
-    layerWeights_(conf.getParameter< std::vector<double> >("layerWeights")),
-    applyLayerWeights_(conf.getParameter< bool >("applyLayerCalibration"))
+    minNDbscan_(conf.getParameter<unsigned>("minN_dbscan_multicluster"))
 {    
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster dR for Near Neighbour search: " << dr_;  
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster minimum transverse-momentum: " << ptC3dThreshold_;
-    edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster global calibration factor: " << calibSF_;
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster DBSCAN Clustering distance: " << distDbscan_;
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster clustering min number of subclusters: " << minNDbscan_;
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster type of multiclustering algortihm: " << multiclusterAlgoType_;
@@ -112,37 +110,20 @@ void HGCalMulticlusteringImpl::clusterizeDR( const std::vector<edm::Ptr<l1t::HGC
     /* making the collection of multiclusters */
     for( unsigned i(0); i<multiclustersTmp.size(); ++i ){
 
-        double calibPt=0.;
-        if(applyLayerWeights_){
-            const std::vector<edm::Ptr<l1t::HGCalCluster>> &pertinentClu = multiclustersTmp.at(i).constituents();
-            for( std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator  it_clu=pertinentClu.begin(); it_clu<pertinentClu.end(); it_clu++){
-                int layerN = -1; 
-                if( (*it_clu)->subdetId()==HGCEE ){
-                    layerN = (*it_clu)->layer();
-                }
-                else if((*it_clu)->subdetId()==HGCHEF){
-                    layerN = (*it_clu)->layer()+kLayersEE_;
-                }
-                else if((*it_clu)->subdetId()==HGCHEB){
-                    layerN = (*it_clu)->layer()+kLayersFH_+kLayersEE_;
-                }
-                calibPt += layerWeights_.at(layerN) * (*it_clu)->mipPt();
-            }     
-        }
-        else{        
-            calibPt = multiclustersTmp.at(i).pt() * calibSF_; 
-        }
+      // compute the eta, phi observables for multicluster starting from its barycenter x,y,z position + pT as scalar sum of pT of constituents
 
-        // compute the eta, phi observables for multicluster starting from its barycenter x,y,z position 
-        math::PtEtaPhiMLorentzVector calibP4(  calibPt, 
-                                               multiclustersTmp.at(i).centre().eta(), 
-                                               multiclustersTmp.at(i).centre().phi(), 
-                                               0. );
+        double sumPt=0.;
 
-        // overwriting the 4p with the calibrated 4p     
-        multiclustersTmp.at(i).setP4( calibP4 );
-        
-        if( multiclustersTmp.at(i).pt() > ptC3dThreshold_ ){
+        const std::vector<edm::Ptr<l1t::HGCalCluster>> &pertinentClu = multiclustersTmp.at(i).constituents();
+        for( std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator  it_clu=pertinentClu.begin(); it_clu<pertinentClu.end(); it_clu++) sumPt +=(*it_clu)->pt();
+	math::PtEtaPhiMLorentzVector multiclusterP4(  sumPt,
+						      multiclustersTmp.at(i).centre().eta(),
+						      multiclustersTmp.at(i).centre().phi(),
+						      0. );
+	multiclustersTmp.at(i).setP4( multiclusterP4 );
+
+
+	if( multiclustersTmp.at(i).pt() > ptC3dThreshold_ ){
 
             //compute shower shape
             multiclustersTmp.at(i).set_showerLength(shape_.showerLength(multiclustersTmp.at(i)));
@@ -229,12 +210,20 @@ void HGCalMulticlusteringImpl::clusterizeDBSCAN( const std::vector<edm::Ptr<l1t:
   }
   /* making the collection of multiclusters */
   for( unsigned i(0); i<multiclustersTmp.size(); ++i ){
-    math::PtEtaPhiMLorentzVector calibP4( multiclustersTmp.at(i).pt() * calibSF_, 
-                                          multiclustersTmp.at(i).eta(), 
-                                          multiclustersTmp.at(i).phi(), 
-                                          0. );
-    // overwriting the 4p with the calibrated 4p     
-    multiclustersTmp.at(i).setP4( calibP4 );
+
+    // compute the eta, phi observables for multicluster starting from its barycenter x,y,z position + pT as scalar sum of pT of constituents
+
+    double sumPt=0.;
+
+    const std::vector<edm::Ptr<l1t::HGCalCluster>> &pertinentClu = multiclustersTmp.at(i).constituents();
+    for( std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator  it_clu=pertinentClu.begin(); it_clu<pertinentClu.end(); it_clu++) sumPt +=(*it_clu)->pt();
+
+    math::PtEtaPhiMLorentzVector multiclusterP4(  sumPt,
+						  multiclustersTmp.at(i).centre().eta(),
+						  multiclustersTmp.at(i).centre().phi(),
+						  0. );
+    multiclustersTmp.at(i).setP4( multiclusterP4 );
+
     
     if( multiclustersTmp.at(i).pt() > ptC3dThreshold_ ){
       


### PR DESCRIPTION
This PR moves the cluster calibration from the C3D (HGCalMulticlustering) to the C2D (HGCalClustering) step.
This change is transparent for the C3D related quantities, as well as most of C2D quantities.
The physical value of pT of the C2D is modified to be defined as trigger_layer_weight*MIPT (vs pT of the four-momentum sum of its TC constituents previously).