### PR TITLE
Check non-zero calibration coefficients

### DIFF
--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalClusteringImpl.cc
@@ -461,6 +461,13 @@ void HGCalClusteringImpl::calibratePt( l1t::HGCalCluster & cluster ){
             layerN = cluster.layer()+kLayersFH_+kLayersEE_;
         }
 
+        if(layerWeights_.at(layerN)==0.){
+            throw cms::Exception("BadConfiguration")
+                <<"2D cluster energy forced to 0 by calibration coefficients.\n"
+                <<"The configuration should be changed. "
+                <<"Discarded layers should be defined in hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedLayers and not with calibration coefficients = 0\n";
+        }
+
         calibPt = layerWeights_.at(layerN) * cluster.mipPt();
 
     }

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalTriggerCellCalibration.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalTriggerCellCalibration.cc
@@ -59,20 +59,27 @@ void HGCalTriggerCellCalibration::calibrateMipTinGeV(l1t::HGCalTriggerCell& trgC
 
 
     if( subdet == HGCHEF ){
-            trgCellLayer = trgCellLayer + kLayersEE_;
+        trgCellLayer = trgCellLayer + kLayersEE_;
     }
     else if( subdet == HGCHEB ){
-            trgCellLayer = trgCellLayer + kLayersEE_ + kLayersFH_;
+        trgCellLayer = trgCellLayer + kLayersEE_ + kLayersFH_;
+    }
+
+    if(dEdX_weights_.at(trgCellLayer)==0.){
+        throw cms::Exception("BadConfiguration")
+            <<"Trigger cell energy forced to 0 by calibration coefficients.\n"
+            <<"The configuration should be changed. "
+            <<"Discarded layers should be defined in hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedLayers and not with calibration coefficients = 0\n";
     }
    
     /* weight the amplitude by the absorber coefficient in MeV/mip + bring it in GeV */
     double trgCellEt = trgCell.mipPt() * dEdX_weights_.at(trgCellLayer) * MevToGeV;
 
+
     /* correct for the cell-thickness */
     if( subdet!=HGCHEB && thickCorr_ > 0 ){
         trgCellEt /= thickCorr_; 
     }
-
     /* assign the new energy to the four-vector of the trigger cell */
     math::PtEtaPhiMLorentzVector calibP4(trgCellEt, 
                                          trgCell.eta(), 


### PR DESCRIPTION
Throw an exception if a layer calibration coefficient = 0 is applied on a trigger cell or cluster. These trigger cells should be disconnected at the level of the geometry.