### PR TITLE
Alternative implementation of trigger towers

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalTower.h
+++ b/DataFormats/L1THGCal/interface/HGCalTower.h
@@ -39,8 +39,6 @@ namespace l1t {
     const HGCalTower& operator+=(const HGCalTower& tower);
 
     HGCalTowerID id() const { return id_;}
-    unsigned short iX() const { return id_.iX();}
-    unsigned short iY() const { return id_.iY();}
     short zside() const { return id_.zside(); }
 
   private:

--- a/DataFormats/L1THGCal/interface/HGCalTower.h
+++ b/DataFormats/L1THGCal/interface/HGCalTower.h
@@ -4,59 +4,56 @@
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
 namespace l1t {
-  
+
   class HGCalTower;
   typedef BXVector<HGCalTower> HGCalTowerBxCollection;
-  
+
   class HGCalTower : public L1Candidate {
-    
+
   public:
-    
-  HGCalTower(): etEm_(0.),etHad_(0.),hwEtEm_(0),hwEtHad_(0),hwEtRatio_(0) {}
-    
-    HGCalTower( const LorentzVector& p4,
-	       double etEm=0.,
-	       double etHad=0.,
-	       int pt=0,
-	       int eta=0,
-	       int phi=0,
-	       int qual=0,
-	       int hwEtEm=0,
-	       int hwEtHad=0,
-	       int hwEtRatio=0);
-    
+
+
+    HGCalTower(): etEm_(0.),etHad_(0.),id_(0) {}
+
+    HGCalTower(double etEm,
+               double etHad,
+               double eta,
+               double phi,
+               unsigned short id,
+               int hwpt=0,
+               int hweta=0,
+               int hwphi=0,
+               int qual=0);
+
     ~HGCalTower();
 
-    void setEtEm( double et );
-    void setEtHad( double et );
+    void addEtEm(double et);
+    void addEtHad(double et);
 
-    void setHwEtEm( int et );
-    void setHwEtHad( int et );
-    void setHwEtRatio( int ratio );
+    double etEm()const { return etEm_; };
+    double etHad()const { return etHad_; };
 
-    double etEm()const;
-    double etHad()const;
+    const HGCalTower& operator+=(const HGCalTower& tower);
 
-    int hwEtEm()const;
-    int hwEtHad()const;
-    int hwEtRatio()const;
-
-    HGCalTower& operator+=(const HGCalTower& tower);
+    HGCalTowerID id() const { return id_;}
+    unsigned short iX() const { return id_.iX();}
+    unsigned short iY() const { return id_.iY();}
+    short zside() const { return id_.zside(); }
 
   private:
-    
+
+    void addEt(double et);
+
     // additional hardware quantities
     double etEm_;
     double etHad_;
-    
-    int hwEtEm_;
-    int hwEtHad_;
-    int hwEtRatio_;
-    
+    HGCalTowerID id_;
+
   };
-  
+
 }
 
 #endif

--- a/DataFormats/L1THGCal/interface/HGCalTowerID.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerID.h
@@ -1,0 +1,34 @@
+#ifndef DataFormats_L1TCalorimeter_HGCalTowerID_h
+#define DataFormats_L1TCalorimeter_HGCalTowerID_h
+
+namespace l1t {
+  class HGCalTowerID {
+  public:
+    HGCalTowerID(unsigned short rawId): rawId_(rawId) {}
+
+    HGCalTowerID(short zside, unsigned short iX, unsigned short iY) {
+      rawId_ = ((iX & coordMask) << xShift) | ((iY & coordMask) << yShift) | (((zside > 0) & zsideMask) << zsideShift);
+    }
+
+    short zside() const { return ((rawId_ >> zsideShift) & zsideMask) ? 1 : -1;}
+
+    unsigned short iX() const { return (rawId_ >> xShift) & coordMask; }
+
+    unsigned short iY() const { return (rawId_ >> yShift) & coordMask;}
+
+    unsigned short rawId() const {return rawId_;}
+
+
+  private:
+
+    unsigned short rawId_;
+    static const int zsideMask = 0x1;
+    static const int zsideShift = 15;
+    static const int coordMask = 0x007F;
+    static const int xShift = 7;
+    static const int yShift = 0;
+  };
+}
+
+
+#endif

--- a/DataFormats/L1THGCal/interface/HGCalTowerID.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerID.h
@@ -28,7 +28,24 @@ namespace l1t {
     static const int xShift = 7;
     static const int yShift = 0;
   };
+
+
+  struct HGCalTowerCoord {
+    HGCalTowerCoord(unsigned short rawId, float eta, float phi): rawId(rawId),
+                                                                 eta(eta),
+                                                                 phi(phi) {}
+
+    const unsigned short rawId;
+    const float eta;
+    const float phi;
+
+  };
+
+
 }
+
+
+
 
 
 #endif

--- a/DataFormats/L1THGCal/interface/HGCalTowerID.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerID.h
@@ -1,20 +1,23 @@
 #ifndef DataFormats_L1TCalorimeter_HGCalTowerID_h
 #define DataFormats_L1TCalorimeter_HGCalTowerID_h
 
+// NOTE: in the current implementation HGCalTowerID can only
+// accomodate 127 bins per coordinate x2 zsides
+
 namespace l1t {
   class HGCalTowerID {
   public:
     HGCalTowerID(unsigned short rawId): rawId_(rawId) {}
 
-    HGCalTowerID(short zside, unsigned short iX, unsigned short iY) {
-      rawId_ = ((iX & coordMask) << xShift) | ((iY & coordMask) << yShift) | (((zside > 0) & zsideMask) << zsideShift);
+    HGCalTowerID(short zside, unsigned short coord1, unsigned short coord2) {
+      rawId_ = ((coord1 & coordMask) << coord1Shift) | ((coord2 & coordMask) << coord2Shift) | (((zside > 0) & zsideMask) << zsideShift);
     }
 
     short zside() const { return ((rawId_ >> zsideShift) & zsideMask) ? 1 : -1;}
 
-    unsigned short iX() const { return (rawId_ >> xShift) & coordMask; }
+    unsigned short coord1() const { return (rawId_ >> coord1Shift) & coordMask; }
 
-    unsigned short iY() const { return (rawId_ >> yShift) & coordMask;}
+    unsigned short coord2() const { return (rawId_ >> coord2Shift) & coordMask;}
 
     unsigned short rawId() const {return rawId_;}
 
@@ -25,8 +28,8 @@ namespace l1t {
     static const int zsideMask = 0x1;
     static const int zsideShift = 15;
     static const int coordMask = 0x007F;
-    static const int xShift = 7;
-    static const int yShift = 0;
+    static const int coord1Shift = 7;
+    static const int coord2Shift = 0;
   };
 
 

--- a/DataFormats/L1THGCal/interface/HGCalTowerMap.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerMap.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 
 namespace l1t {
-  
+
   class HGCalTowerMap;
   typedef BXVector<HGCalTowerMap> HGCalTowerMapBxCollection;
 
@@ -15,52 +15,33 @@ namespace l1t {
 
   public:
 
-    HGCalTowerMap(): nEtaBins_(0), nPhiBins_(0), layer_(0) {}
-    
-    HGCalTowerMap( int nEtaBins, int nPhiBins );
+    HGCalTowerMap(): layer_(0) {}
 
-    HGCalTowerMap( const std::vector<double>& etaBins, const std::vector<double>& phiBins );
+    HGCalTowerMap(const std::vector<unsigned short>& tower_ids, const int layer);
 
-    ~HGCalTowerMap();
+    // ~HGCalTowerMap();
 
-    void setLayer( const unsigned layer ) { layer_ = layer; }
+    // const l1t::HGCalTower& tower(int iX, int iY) const;
 
+    int layer() const { return layer_; }
 
-    int nEtaBins() const { return nEtaBins_; }
-    int nPhiBins() const { return nPhiBins_; }
-    const vector<double>& etaBins() const { return etaBins_; }
-    const vector<double>& phiBins() const { return phiBins_; }
-    const l1t::HGCalTower& tower(int iEta, int iPhi) const { return towerMap_.at(bin_id(iEta,iPhi)); }
+    // FIXME: is this the right signature shall I pass a const ref????
+    const HGCalTowerMap& operator+=(HGCalTowerMap map);
 
-    int iEta(const double eta) const;
-    int iPhi(const double phi) const;
-    int layer() const { return layer_;}
+    // bool addEt(short iX, short iY, float etEm, float etHad);
+    bool addEt(short bin_id, float etEm, float etHad);
 
-    HGCalTowerMap& operator+=(const HGCalTowerMap& map);
-    void addTower(int iEta, int iPhi, const l1t::HGCalTower& tower) { towerMap_[bin_id(iEta,iPhi)] += tower; }
+    unsigned nTowers() const { return towerMap_.size(); }
+    const std::map<unsigned short, l1t::HGCalTower>& towers() const { return towerMap_; }
+
 
   private:
 
-    static constexpr double kEtaMin_ = 1.479;
-    static constexpr double kEtaMax_ = 3.;
-    static constexpr double kEtaMinLoose_ = 1.401; //BH has some TC below 1.479
-    static constexpr double kEtaMaxLoose_ = 3.085; //FH has some TC above 3.0
-    static constexpr double kPhiMin_ = -M_PI;
-    static constexpr double kPhiMax_ = +M_PI;  
-    
-    int nEtaBins_;
-    int nPhiBins_;
-    vector<double> etaBins_;
-    vector<double> phiBins_;
-    std::unordered_map<int,l1t::HGCalTower>  towerMap_;
+    std::map<unsigned short, l1t::HGCalTower>  towerMap_;
     unsigned layer_;
-
-    int bin_id(int iEta,int iPhi) const;
 
   };
 
 }
 
 #endif
-
-

--- a/DataFormats/L1THGCal/interface/HGCalTowerMap.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerMap.h
@@ -9,6 +9,7 @@
 namespace l1t {
 
   class HGCalTowerMap;
+  class HGCalTowerCoord;
   typedef BXVector<HGCalTowerMap> HGCalTowerMapBxCollection;
 
   class HGCalTowerMap {
@@ -17,7 +18,7 @@ namespace l1t {
 
     HGCalTowerMap(): layer_(0) {}
 
-    HGCalTowerMap(const std::vector<unsigned short>& tower_ids, const int layer);
+    HGCalTowerMap(const std::vector<l1t::HGCalTowerCoord>& tower_ids, const int layer);
 
     // ~HGCalTowerMap();
 
@@ -25,8 +26,7 @@ namespace l1t {
 
     int layer() const { return layer_; }
 
-    // FIXME: is this the right signature shall I pass a const ref????
-    const HGCalTowerMap& operator+=(HGCalTowerMap map);
+    const HGCalTowerMap& operator+=(const HGCalTowerMap& map);
 
     // bool addEt(short iX, short iY, float etEm, float etHad);
     bool addEt(short bin_id, float etEm, float etHad);

--- a/DataFormats/L1THGCal/src/HGCalTower.cc
+++ b/DataFormats/L1THGCal/src/HGCalTower.cc
@@ -1,100 +1,51 @@
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-using namespace l1t;
+using l1t::L1Candidate;
+using l1t::HGCalTower;
 
-HGCalTower::HGCalTower( const LorentzVector& p4,
-                       double etEm,
+HGCalTower::HGCalTower(double etEm,
                        double etHad,
-                       int pt,
-                       int eta,
-                       int phi,
-                       int qual,
-                       int hwEtEm,
-                       int hwEtHad,
-                       int hwEtRatio)
-  : L1Candidate(p4, pt, eta, phi, qual),
-    etEm_(etEm),
-    etHad_(etHad),
-    hwEtEm_(hwEtEm),
-    hwEtHad_(hwEtHad),
-    hwEtRatio_(hwEtRatio)
-{
-  
+                       double eta,
+                       double phi,
+                       unsigned short id,
+                       int hwpt,
+                       int hweta,
+                       int hwphi,
+                       int qual) : L1Candidate(PolarLorentzVector(etEm+etHad, eta, phi, 0.), hwpt, hweta, hwphi, qual),
+                                   etEm_(etEm),
+                                   etHad_(etHad),
+                                   id_(id) {}
+
+
+HGCalTower::~HGCalTower() {}
+
+
+void HGCalTower::addEtEm(double et) {
+  etEm_+=et;
+  addEt(et);
 }
 
-HGCalTower::~HGCalTower() 
-{
-
+void HGCalTower::addEtHad(double et) {
+  etHad_+=et;
+  addEt(et);
 }
 
-void HGCalTower::setEtEm(double et)
-{
-  etEm_ = et;
-}
-
-void HGCalTower::setEtHad(double et)
-{
-  etHad_ = et;
-}
-
-void HGCalTower::setHwEtEm(int et)
-{
-  hwEtEm_ = et;
-}
-
-void HGCalTower::setHwEtHad(int et)
-{
-  hwEtHad_ = et;
-}
-
-void HGCalTower::setHwEtRatio(int ratio)
-{
-  hwEtRatio_ = ratio;
-}
-
-double HGCalTower::etEm()const
-{
-  return etEm_;
-}
-
-double HGCalTower::etHad()const
-{
-  return etHad_;
-}
-
-int HGCalTower::hwEtEm()const
-{
-  return hwEtEm_;
-}
-
-int HGCalTower::hwEtHad()const
-{
-  return hwEtHad_;
-}
-
-int HGCalTower::hwEtRatio()const
-{
-  return hwEtRatio_;
+void HGCalTower::addEt(double et) {
+  this->setP4(PolarLorentzVector(this->pt()+et, this->eta(), this->phi(), 0.));
 }
 
 
-
-
-HGCalTower& HGCalTower::operator+=(const HGCalTower& tower){
-
-  if(this->hwEta()!= tower.hwEta() || this->hwPhi()!= tower.hwPhi()){
+const HGCalTower& HGCalTower::operator+=(const HGCalTower& tower){
+  // NOTE: assume same eta and phi -> need an explicit check on the ID
+  if(id().rawId() != tower.id().rawId()) {
     throw edm::Exception(edm::errors::StdException, "StdException")
-      << "HGCalTower: Trying to add HGCalTowers with different coordinates"<<endl;
+      << "HGCalTower: adding to this tower with ID: " << id().rawId()
+      << " one with different ID: " << tower.id().rawId()  << std::endl;
   }
-
-  this->setP4(this->p4() + tower.p4());
-  this->setEtEm(this->etEm() + tower.etEm());
-  this->setEtHad(this->etHad() + tower.etHad());
-
-  this->setHwPt(this->hwPt() + tower.hwPt());
-  this->setHwEtEm(this->hwEtEm() + tower.hwEtEm());
-  this->setHwEtHad(this->hwEtHad() + tower.hwEtHad());
+  this->setP4(PolarLorentzVector(this->pt()+tower.pt(), this->eta(), this->phi(), 0.));
+  etEm_+=tower.etEm();
+  etHad_+=tower.etHad();
 
   return *this;
 

--- a/DataFormats/L1THGCal/src/HGCalTowerMap.cc
+++ b/DataFormats/L1THGCal/src/HGCalTowerMap.cc
@@ -5,27 +5,17 @@
 
 using namespace l1t;
 
-HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids, const int layer=0) : layer_(layer)  {
-  // FIXME: these numbers should come from the geometry....
-  GlobalPoint referencePointM(-167.5, -167.5, -320.755);
-  GlobalPoint referencePointP(-167.5, -167.5, 320.755);
-  float bin_size = 5.;
-
+HGCalTowerMap::HGCalTowerMap(const std::vector<HGCalTowerCoord>& tower_ids,
+                             const int layer=0) : layer_(layer)  {
   for(auto tower_id: tower_ids) {
-    l1t::HGCalTowerID towerId(tower_id);
-    GlobalPoint referencePoint = towerId.zside() < 0 ? referencePointM : referencePointP;
-    GlobalPoint surface_center(referencePoint.x()+towerId.iX()*bin_size,
-                               referencePoint.y()+towerId.iY()*bin_size,
-                               referencePoint.z());
-    l1t::HGCalTower tower(0., 0., surface_center.eta(), surface_center.phi(), tower_id);
-    towerMap_[tower_id] = tower;
+    towerMap_[tower_id.rawId] = l1t::HGCalTower(0., 0., tower_id.eta, tower_id.phi, tower_id.rawId);
   }
 }
 
 // HGCalTowerMap::~HGCalTowerMap() {}
 
 
-const HGCalTowerMap& HGCalTowerMap::operator+=(HGCalTowerMap map){
+const HGCalTowerMap& HGCalTowerMap::operator+=(const HGCalTowerMap& map){
   if (nTowers() != map.nTowers()) {
     throw edm::Exception(edm::errors::StdException, "StdException")
       << "HGCalTowerMap: Trying to add HGCalTowerMaps with different bins: " << nTowers() << " and " << map.nTowers() <<endl;

--- a/DataFormats/L1THGCal/src/HGCalTowerMap.cc
+++ b/DataFormats/L1THGCal/src/HGCalTowerMap.cc
@@ -1,153 +1,58 @@
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
-#include "DataFormats/Math/interface/normalizedPhi.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 using namespace l1t;
 
-constexpr double HGCalTowerMap::kEtaMax_;
-constexpr double HGCalTowerMap::kEtaMin_;
-constexpr double HGCalTowerMap::kEtaMaxLoose_;
-constexpr double HGCalTowerMap::kEtaMinLoose_;
-constexpr double HGCalTowerMap::kPhiMax_;
-constexpr double HGCalTowerMap::kPhiMin_;
+HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids, const int layer=0) : layer_(layer)  {
+  // FIXME: these numbers should come from the geometry....
+  GlobalPoint referencePointM(-167.5, -167.5, -320.755);
+  GlobalPoint referencePointP(-167.5, -167.5, 320.755);
+  float bin_size = 5.;
 
-
-HGCalTowerMap::HGCalTowerMap( int nEtaBins, int nPhiBins )
-{
-
-  nEtaBins_ = nEtaBins;
-  nPhiBins_ = nPhiBins;
-
-  double eta_step = (kEtaMax_ - kEtaMin_)/nEtaBins_;
-  for(int i=0; i<nEtaBins_; i++) etaBins_.emplace_back( kEtaMin_ + eta_step*i );
-  etaBins_.emplace_back( kEtaMax_ );
-  
-  double phi_step = (kPhiMax_ - kPhiMin_)/nPhiBins_;
-  for(int i=0; i<nPhiBins_; i++) phiBins_.emplace_back( kPhiMin_ + phi_step*i );
-  phiBins_.emplace_back( kPhiMax_ );
-
-
-  for(int iEta=-nEtaBins_; iEta<=nEtaBins_; iEta++){
-    if(iEta==0) continue;
-    for(int iPhi=0; iPhi<nPhiBins_; iPhi++){
-      l1t::HGCalTower tower;
-      tower.setHwEta(iEta);
-      tower.setHwPhi(iPhi);
-      int bin = bin_id(iEta,iPhi);
-      towerMap_[bin] = tower;
-    }
+  for(auto tower_id: tower_ids) {
+    l1t::HGCalTowerID towerId(tower_id);
+    GlobalPoint referencePoint = towerId.zside() < 0 ? referencePointM : referencePointP;
+    GlobalPoint surface_center(referencePoint.x()+towerId.iX()*bin_size,
+                               referencePoint.y()+towerId.iY()*bin_size,
+                               referencePoint.z());
+    l1t::HGCalTower tower(0., 0., surface_center.eta(), surface_center.phi(), tower_id);
+    towerMap_[tower_id] = tower;
   }
-
-
 }
 
-
-HGCalTowerMap::HGCalTowerMap( const vector<double>& etaBins, const vector<double>& phiBins )
-{
-
-  nEtaBins_ = etaBins.size()-1;
-  nPhiBins_ = phiBins.size()-1;
-  etaBins_ = etaBins;
-  phiBins_ = phiBins;
-
-  for(int iEta=-nEtaBins_; iEta<=nEtaBins_; iEta++){
-    if(iEta==0) continue;
-    for(int iPhi=0; iPhi<nPhiBins_; iPhi++){
-      l1t::HGCalTower tower;
-      tower.setHwEta(iEta);
-      tower.setHwPhi(iPhi);
-      int bin = bin_id(iEta,iPhi);
-      towerMap_[bin] = tower;
-    }
-  }
-
-}
+// HGCalTowerMap::~HGCalTowerMap() {}
 
 
-HGCalTowerMap::~HGCalTowerMap()
-{
-
-}
-
-
-int HGCalTowerMap::iEta(const double eta) const
-{
-
-  double absEta = fabs(eta);
-  int signEta = eta>0 ? 1 : -1;
-  
-  if(absEta<kEtaMin_){
-    absEta = kEtaMin_;
-    if(absEta<kEtaMinLoose_) edm::LogWarning("HGCalTowerMap") << "WARNING: trying to access towers below min eta range of tower maps eta="<<eta;
-    return signEta;
-  }
-  else if(absEta>kEtaMax_){
-    absEta = kEtaMax_;
-    if(absEta>kEtaMaxLoose_) edm::LogWarning("HGCalTowerMap") << "WARNING: trying to access towers above max eta range of tower maps eta="<<eta;
-    return signEta*nEtaBins_;
-  }
-
-  for(int i = 0; i<nEtaBins_; i++){
-    if(absEta>=etaBins_[i] && absEta<etaBins_[i+1]){      
-      return signEta*(i+1);
-    }
-  }
-  
-  return 0;
-
-}
-
-
-int HGCalTowerMap::iPhi(const double phi) const
-{
-
-  double phi_norm = normalizedPhi(phi);
- 
-  for(int i = 0; i<nPhiBins_; i++){
-    if(phi_norm>=phiBins_[i] && phi_norm<phiBins_[i+1]){
-      return i;
-    }
-  }
-  
-  return -1;
-
-}
-
-
-HGCalTowerMap& HGCalTowerMap::operator+=(const HGCalTowerMap& map){
-
-  if(etaBins_!=map.etaBins() || phiBins_!=map.phiBins()){
+const HGCalTowerMap& HGCalTowerMap::operator+=(HGCalTowerMap map){
+  if (nTowers() != map.nTowers()) {
     throw edm::Exception(edm::errors::StdException, "StdException")
-      << "HGCalTowerMap: Trying to add HGCalTowerMaps with different bins"<<endl;
+      << "HGCalTowerMap: Trying to add HGCalTowerMaps with different bins: " << nTowers() << " and " << map.nTowers() <<endl;
   }
 
-  for(int iEta=-nEtaBins_; iEta<=nEtaBins_; iEta++){
-    if(iEta==0) continue;
-    for(int iPhi=0; iPhi<nPhiBins_; iPhi++){
-      towerMap_[bin_id(iEta,iPhi)] += map.tower(iEta,iPhi);
+  for(auto tower: map.towers()) {
+    auto this_tower = towerMap_.find(tower.first);
+    if(this_tower == towerMap_.end()) {
+      throw edm::Exception(edm::errors::StdException, "StdException")
+        << "HGCalTowerMap: Trying to add HGCalTowerMaps but cound not find bin: " << tower.first <<endl;
+    } else {
+      this_tower->second+=tower.second;
     }
-  }
 
+  }
   return *this;
-
 }
 
+// bool HGCalTowerMap::addEt(short iX, short iY, float etEm, float etHad) {
+//   return addEt(pack_tower_ID(iX, iY), etEm, etHad);
+// }
 
+bool HGCalTowerMap::addEt(short bin_id, float etEm, float etHad) {
+  auto this_tower = towerMap_.find(bin_id);
+  if(this_tower == towerMap_.end()) return false;
+  this_tower->second.addEtEm(etEm);
+  this_tower->second.addEtHad(etHad);
 
-int HGCalTowerMap::bin_id(int iEta, int iPhi) const{
-
-  if(iEta==0 || iEta>nEtaBins_ || iEta<-nEtaBins_){
-    throw edm::Exception(edm::errors::StdException, "StdException")
-      << "HGCalTowerMap: Trying to access a bin out of eta range"<<endl;
-  }
-
-  if(iPhi<0 || iPhi>=nPhiBins_){
-    throw edm::Exception(edm::errors::StdException, "StdException")
-      << "HGCalTowerMap: Trying to access a bin out of phi range"<<endl;
-  }
-
-  return iEta*nPhiBins_ + iPhi;
-
+  return true;
 }
-

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -14,8 +14,10 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
-#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
+namespace l1t {
+  class HGCalTowerCoord;
+}
 // Pure virtual trigger geometry class
 // Provides the interface to access trigger cell and module mappings
 class HGCalTriggerGeometryBase
@@ -63,11 +65,8 @@ class HGCalTriggerGeometryBase
         virtual bool disconnectedModule(const unsigned module_id) const = 0;
         virtual unsigned triggerLayer(const unsigned id) const = 0;
 
-        // FIXME: the next two are not pure virtual just to allow me not to implement them in all derived classes...needs to be addressed
-        virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const { return 1; };
-        // FIXME: ideally I would like to return a const ref but this poses problems in all classes actuanlly not
-        // implementing this functionality
-        virtual std::vector<l1t::HGCalTowerCoord> getTriggerTowers() const { return std::vector<l1t::HGCalTowerCoord>(); };
+        virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const = 0;
+        virtual const std::vector<l1t::HGCalTowerCoord>& getTriggerTowers() const = 0;
 
     protected:
         void setCaloGeometry(const edm::ESHandle<CaloGeometry>& geom) {calo_geometry_=geom;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -14,8 +14,7 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
-
-
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
 // Pure virtual trigger geometry class
 // Provides the interface to access trigger cell and module mappings
@@ -68,7 +67,7 @@ class HGCalTriggerGeometryBase
         virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const { return 1; };
         // FIXME: ideally I would like to return a const ref but this poses problems in all classes actuanlly not
         // implementing this functionality
-        virtual std::vector<unsigned short> getTriggerTowers() const { return std::vector<unsigned short>(); };
+        virtual std::vector<l1t::HGCalTowerCoord> getTriggerTowers() const { return std::vector<l1t::HGCalTowerCoord>(); };
 
     protected:
         void setCaloGeometry(const edm::ESHandle<CaloGeometry>& geom) {calo_geometry_=geom;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -19,9 +19,9 @@
 
 // Pure virtual trigger geometry class
 // Provides the interface to access trigger cell and module mappings
-class HGCalTriggerGeometryBase 
-{ 
-    public:  
+class HGCalTriggerGeometryBase
+{
+    public:
         typedef std::unordered_map<unsigned,unsigned> geom_map;
         typedef std::unordered_set<unsigned> geom_set;
         typedef std::set<unsigned> geom_ordered_set;
@@ -29,7 +29,7 @@ class HGCalTriggerGeometryBase
         HGCalTriggerGeometryBase(const edm::ParameterSet& conf);
         virtual ~HGCalTriggerGeometryBase() {}
 
-        const std::string& name() const { return name_; } 
+        const std::string& name() const { return name_; }
 
         const edm::ESHandle<CaloGeometry>& caloGeometry() const {return calo_geometry_;}
         const HGCalGeometry& eeGeometry() const {return *static_cast<const HGCalGeometry*>(calo_geometry_->getSubdetectorGeometry(DetId::Forward,HGCEE));}
@@ -63,6 +63,12 @@ class HGCalTriggerGeometryBase
         virtual bool validTriggerCell( const unsigned trigger_cell_id) const = 0;
         virtual bool disconnectedModule(const unsigned module_id) const = 0;
         virtual unsigned triggerLayer(const unsigned id) const = 0;
+
+        // FIXME: the next two are not pure virtual just to allow me not to implement them in all derived classes...needs to be addressed
+        virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const { return 1; };
+        // FIXME: ideally I would like to return a const ref but this poses problems in all classes actuanlly not
+        // implementing this functionality
+        virtual std::vector<unsigned short> getTriggerTowers() const { return std::vector<unsigned short>(); };
 
     protected:
         void setCaloGeometry(const edm::ESHandle<CaloGeometry>& geom) {calo_geometry_=geom;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryGenericMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryGenericMapping.h
@@ -2,6 +2,7 @@
 #define __L1Trigger_L1THGCal_HGCalTriggerGeometryGenericMapping_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
 /*******
  *
@@ -11,17 +12,17 @@
  *
  * This class is the base class for all HGCal trigger geometry definitions.
  * Typically this is just a ganging of cells and nearest-neighbour relationships.
- * 
+ *
  * Classes for TriggerCells and Modules are defined. They are containers for
  * maps relating modules to modules and trigger cells to trigger cells and
  * raw HGC cells.
- * 
+ *
  * It is up to the user of the class to define what these mappings are through the
  * initialize() function. This function takes the full HGC geometry as input and
- * creates all the necessary maps for navigating the trigger system. All of the 
+ * creates all the necessary maps for navigating the trigger system. All of the
  * containers for parts of the map are available through protected members of the base
  * class.
- * 
+ *
  * All unsigned ints used here are DetIds, or will become them once we sort out the
  * full nature of the trigger detids.
  *******/
@@ -42,11 +43,11 @@ namespace HGCalTriggerGeometry {
       components_(comps)
       {}
     ~TriggerCell() {}
-   
-    
+
+
     unsigned triggerCellId() const { return trigger_cell_id_; }
     unsigned moduleId()      const { return module_id_; }
-    
+
     bool containsCell(const unsigned cell) const {
       return ( components_.find(cell) != components_.end() );
     }
@@ -63,12 +64,12 @@ namespace HGCalTriggerGeometry {
     list_type neighbours_; // neighbouring trigger cells
     list_type components_; // contained HGC cells
   };
-  
+
   class Module {
   public:
     typedef std::unordered_set<unsigned> list_type;
     typedef std::unordered_multimap<unsigned,unsigned> tc_map_type;
-    
+
     Module(unsigned mod_id, const GlobalPoint& pos,
            const list_type& neighbs, const list_type& comps,
            const tc_map_type& tc_comps):
@@ -76,10 +77,10 @@ namespace HGCalTriggerGeometry {
       position_(pos),
       neighbours_(neighbs),
       components_(comps),
-      tc_components_(tc_comps)  
+      tc_components_(tc_comps)
       {}
     ~Module() {}
-    
+
     unsigned moduleId()      const { return module_id_; }
 
     bool containsTriggerCell(const unsigned trig_cell) const {
@@ -100,17 +101,17 @@ namespace HGCalTriggerGeometry {
 
     const tc_map_type& triggerCellComponents() const { return tc_components_; }
 
-  private:    
+  private:
     unsigned module_id_; // module this TC belongs to
     GlobalPoint position_;
     list_type neighbours_; // neighbouring Modules
     list_type components_; // contained HGC trigger cells
     tc_map_type tc_components_; // cells contained by trigger cells
   };
-}  
+}
 
-class HGCalTriggerGeometryGenericMapping : public HGCalTriggerGeometryBase { 
- public:  
+class HGCalTriggerGeometryGenericMapping : public HGCalTriggerGeometryBase {
+ public:
 
   typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::Module> > module_map;
   typedef std::unordered_map<unsigned,std::unique_ptr<const HGCalTriggerGeometry::TriggerCell> > trigger_cell_map;
@@ -120,7 +121,7 @@ class HGCalTriggerGeometryGenericMapping : public HGCalTriggerGeometryBase {
 
   // non-const access to the geometry class
   virtual void reset() override final;
-  
+
   virtual unsigned getTriggerCellFromCell( const unsigned cell_det_id ) const override final;
   virtual unsigned getModuleFromCell( const unsigned cell_det_id ) const override final;
   virtual unsigned getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const override final;
@@ -141,13 +142,16 @@ class HGCalTriggerGeometryGenericMapping : public HGCalTriggerGeometryBase {
   bool disconnectedModule(const unsigned module_id) const final;
   unsigned triggerLayer(const unsigned id) const final;
 
+  virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const override final;
+  virtual const std::vector<l1t::HGCalTowerCoord>& getTriggerTowers() const override final;
+
  protected:
   geom_map cells_to_trigger_cells_;
   geom_map trigger_cells_to_modules_;
-  
+
   module_map modules_;
   trigger_cell_map trigger_cells_;
-  
+  std::vector<l1t::HGCalTowerCoord> towers_;
 };
 
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -1,0 +1,74 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTriggerTowerGeometryHelper_h__
+#define __L1Trigger_L1THGCal_HGCalTriggerTowerGeometryHelper_h__
+
+/** \class HGCalTriggerTowerGeometryHelper
+ *  The trigger tower map is defined esternally to CMSSW
+ *  Assuming a regular binning, to map a given tower to a position we need to know
+ *  - the reference surface,
+ *  - the kind of binning (x-y or eta-phi)
+ *  - the bin pitch
+ *  - the first bin definition
+ *  NOTE: more exotic binnning strategies need a mapping between bin-ids and positions
+ */
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
+
+#include <vector>
+
+enum HGCalTriggerTowerType {
+  regular_xy = 0,
+  regular_etaphi = 1
+};
+
+namespace l1t {
+  class HGCalTowerID;
+  class HGCalTowerCoord;
+}
+
+
+class HGCalTriggerTowerGeometryHelper {
+  public:
+    HGCalTriggerTowerGeometryHelper(const edm::ParameterSet& conf) : HGCalTriggerTowerGeometryHelper(conf.getParameter<double>("refCoord1"),
+                                                                                                     conf.getParameter<double>("refCoord2"),
+                                                                                                     conf.getParameter<double>("refZ"),
+                                                                                                     conf.getParameter<double>("binSizeCoord1"),
+                                                                                                     conf.getParameter<double>("binSizeCoord2"),
+                                                                                                     static_cast<HGCalTriggerTowerType>(conf.getParameter<int>("type"))) {}
+
+
+    HGCalTriggerTowerGeometryHelper(float refCoord1,
+                                    float refCoord2,
+                                    float refZ,
+                                    float binSize1,
+                                    float binSize2,
+                                    HGCalTriggerTowerType type) : refCoord1_(refCoord1),
+                                                                 refCoord2_(refCoord2),
+                                                                 referenceZ_(refZ),
+                                                                 binSizeCoord1_(binSize1),
+                                                                 binSizeCoord2_(binSize2),
+                                                                 type_(type) {}
+    ~HGCalTriggerTowerGeometryHelper() {}
+
+
+    void createTowerCoordinates(const std::vector<unsigned short>& tower_ids);
+
+    GlobalPoint getPositionAtReferenceSurface(const l1t::HGCalTowerID& towerId) const;
+    const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
+
+
+  private:
+
+    const float refCoord1_;
+    const float refCoord2_;
+    const float referenceZ_;
+    const float binSizeCoord1_;
+    const float binSizeCoord2_;
+    const HGCalTriggerTowerType type_;
+    std::vector<l1t::HGCalTowerCoord> coord;
+
+  };
+
+
+#endif

--- a/L1Trigger/L1THGCal/interface/be_algorithms/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/be_algorithms/HGCalTowerMap2DImpl.h
@@ -14,33 +14,26 @@ class HGCalTowerMap2DImpl{
 
  public:
 
-  HGCalTowerMap2DImpl( const edm::ParameterSet &conf); 
-  
-  void resetTowerMaps( );
+  HGCalTowerMap2DImpl( const edm::ParameterSet &conf);
 
-  void buildTowerMap2D( const std::vector<edm::Ptr<l1t::HGCalTriggerCell>> & triggerCellsPtrs,
-			l1t::HGCalTowerMapBxCollection & towermaps
-			);
+  void resetTowerMaps();
+
+  void buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>> & triggerCellsPtrs,
+			                 l1t::HGCalTowerMapBxCollection & towermaps);
 
 
-  void eventSetup(const edm::EventSetup& es) 
-    {
+  void eventSetup(const edm::EventSetup& es) {
         triggerTools_.eventSetup(es);
-    }
+  }
 
-  
+
  private:
 
-  int nEtaBins_;
-  int nPhiBins_;
-  std::vector<double> etaBins_;
-  std::vector<double> phiBins_;
-  
   bool useLayerWeights_;
   std::vector<double> layerWeights_;
   HGCalTriggerTools triggerTools_;
 
-  std::vector<l1t::HGCalTowerMap> newTowerMaps();
+  std::map<int, l1t::HGCalTowerMap> newTowerMaps();
 
 };
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
@@ -3,6 +3,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
 #include <vector>
 #include <iostream>
@@ -38,6 +39,9 @@ class HGCalTriggerGeometryHexImp2 : public HGCalTriggerGeometryBase
         virtual bool disconnectedModule(const unsigned) const override final;
         virtual unsigned triggerLayer(const unsigned) const override final;
 
+        virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const override final;
+        virtual const std::vector<l1t::HGCalTowerCoord>& getTriggerTowers() const override final;
+
     private:
         edm::FileInPath l1tCellsMapping_;
         edm::FileInPath l1tCellNeighborsMapping_;
@@ -60,17 +64,18 @@ class HGCalTriggerGeometryHexImp2 : public HGCalTriggerGeometryBase
         // neighbor related maps
         // trigger cell neighbors:
         // - The key includes the trigger cell id and the wafer configuration.
-        // The wafer configuration is a 7 bits word encoding the type 
+        // The wafer configuration is a 7 bits word encoding the type
         // (small or large cells) of the wafer containing the trigger cell
         // (central wafer) as well as the type of the 6 surrounding wafers
         // - The value is a set of (wafer_idx, trigger_cell_id)
         // wafer_idx is a number between 0 and 7. 0=central wafer, 1..7=surrounding
-        // wafers 
+        // wafers
         std::unordered_map<int, std::set<std::pair<short,short>>> trigger_cell_neighbors_;
         // wafer neighbors:
         // List of the 6 surrounding neighbors around each wafer
         std::unordered_map<short, std::vector<short>> wafer_neighbors_ee_;
         std::unordered_map<short, std::vector<short>> wafer_neighbors_fh_;
+        std::vector<l1t::HGCalTowerCoord> towers_;
 
         void fillMaps();
         void fillNeighborMaps();
@@ -118,7 +123,7 @@ initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
 
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexImp2::
 getTriggerCellFromCell( const unsigned cell_id ) const
 {
@@ -138,7 +143,7 @@ getTriggerCellFromCell( const unsigned cell_id ) const
     return HGCalDetId((ForwardSubdetector)cell_det_id.subdetId(), cell_det_id.zside(), cell_det_id.layer(), cell_det_id.waferType(), cell_det_id.wafer(), trigger_cell).rawId();
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexImp2::
 getModuleFromCell( const unsigned cell_id ) const
 {
@@ -172,7 +177,7 @@ getModuleFromCell( const unsigned cell_id ) const
     return HGCalDetId((ForwardSubdetector)cell_det_id.subdetId(), cell_det_id.zside(), cell_det_id.layer(), cell_det_id.waferType(), module, HGCalDetId::kHGCalCellMask).rawId();
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexImp2::
 getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
 {
@@ -206,7 +211,7 @@ getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
     return HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), trigger_cell_det_id.waferType(), module, HGCalDetId::kHGCalCellMask).rawId();
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexImp2::
 getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
 {
@@ -225,7 +230,7 @@ getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexImp2::
 getCellsFromModule( const unsigned module_id ) const
 {
@@ -263,7 +268,7 @@ getCellsFromModule( const unsigned module_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryHexImp2::
 getOrderedCellsFromModule( const unsigned module_id ) const
 {
@@ -300,7 +305,7 @@ getOrderedCellsFromModule( const unsigned module_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexImp2::
 getTriggerCellsFromModule( const unsigned module_id ) const
 {
@@ -338,7 +343,7 @@ getTriggerCellsFromModule( const unsigned module_id ) const
     return trigger_cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryHexImp2::
 getOrderedTriggerCellsFromModule( const unsigned module_id ) const
 {
@@ -405,7 +410,7 @@ getNeighborsFromTriggerCell( const unsigned trigger_cell_id ) const
         default:
             edm::LogError("HGCalTriggerGeometry") << "Unknown wafer neighbours for subdet "<<subdet<<"\n";
             return geom_set();
-    } 
+    }
     if(out_of_range_error)
     {
         throw cms::Exception("BadGeometry")
@@ -461,7 +466,7 @@ getNeighborsFromTriggerCell( const unsigned trigger_cell_id ) const
 }
 
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryHexImp2::
 getTriggerCellPosition(const unsigned trigger_cell_det_id) const
 {
@@ -478,7 +483,7 @@ getTriggerCellPosition(const unsigned trigger_cell_det_id) const
 
 }
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryHexImp2::
 getModulePosition(const unsigned module_det_id) const
 {
@@ -495,7 +500,7 @@ getModulePosition(const unsigned module_det_id) const
 }
 
 
-void 
+void
 HGCalTriggerGeometryHexImp2::
 fillMaps()
 {
@@ -563,7 +568,7 @@ fillMaps()
     l1tCellsMappingStream.close();
 }
 
-void 
+void
 HGCalTriggerGeometryHexImp2::
 fillNeighborMaps()
 {
@@ -579,7 +584,7 @@ fillNeighborMaps()
         std::string line(&buffer[0]);
         // Extract keys consisting of the wafer configuration
         // and of the trigger cell id
-        // Match patterns (X,Y) 
+        // Match patterns (X,Y)
         // where X is a set of 7 bits
         // and Y is a number with less than 4 digits
         std::regex key_regex("\\(\\s*[01]{7}\\s*,\\s*\\d{1,3}\\s*\\)");
@@ -605,7 +610,7 @@ fillNeighborMaps()
         for(const char c : type_tc[0]) wafer_types.emplace_back( (std::stoi(std::string(&c))?1:-1) );
         unsigned map_key = packTriggerCell(trigger_cell, wafer_types);
         // Extract neighbors
-        // Match patterns (X,Y) 
+        // Match patterns (X,Y)
         // where X is a number with less than 4 digits
         // and Y is one single digit (the neighbor wafer, between 0 and 6)
         std::regex neighbors_regex("\\(\\s*\\d{1,3}\\s*,\\s*\\d\\s*\\)");
@@ -682,7 +687,7 @@ fillNeighborMaps()
 }
 
 
-void 
+void
 HGCalTriggerGeometryHexImp2::
 fillInvalidTriggerCells()
 {
@@ -722,7 +727,7 @@ fillInvalidTriggerCells()
     }
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexImp2::
 packTriggerCell(unsigned trigger_cell, const std::vector<int>& wafer_types) const
 {
@@ -737,7 +742,7 @@ packTriggerCell(unsigned trigger_cell, const std::vector<int>& wafer_types) cons
 }
 
 
-int 
+int
 HGCalTriggerGeometryHexImp2::
 detIdWaferType(unsigned subdet, short wafer) const
 {
@@ -759,7 +764,7 @@ detIdWaferType(unsigned subdet, short wafer) const
     return wafer_type;
 }
 
-bool 
+bool
 HGCalTriggerGeometryHexImp2::
 validTriggerCell(const unsigned trigger_cell_id) const
 {
@@ -767,7 +772,7 @@ validTriggerCell(const unsigned trigger_cell_id) const
 }
 
 
-bool 
+bool
 HGCalTriggerGeometryHexImp2::
 disconnectedModule(const unsigned module_id) const
 {
@@ -775,19 +780,19 @@ disconnectedModule(const unsigned module_id) const
 }
 
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexImp2::
 triggerLayer(const unsigned id) const
 {
     return HGCalDetId(id).layer();
 }
 
-bool 
+bool
 HGCalTriggerGeometryHexImp2::
 validTriggerCellFromCells(const unsigned trigger_cell_id) const
 {
     // Check the validity of a trigger cell with the
-    // validity of the cells. One valid cell in the 
+    // validity of the cells. One valid cell in the
     // trigger cell is enough to make the trigger cell
     // valid.
     HGCalDetId trigger_cell_det_id(trigger_cell_id);
@@ -818,13 +823,22 @@ validCellId(unsigned subdet, unsigned cell_id) const
         default:
             is_valid = false;
             break;
-    } 
+    }
     return is_valid;
 }
 
 
+unsigned short HGCalTriggerGeometryHexImp2::getTriggerTowerFromTriggerCell(const unsigned) const {
+  edm::LogError("HGCalTriggerGeometryHexImp2") << "(getTriggerTowerFromTriggerCell) Trigger Tower mapping is not implemented!\n";
+  return 0;
+}
+
+const std::vector<l1t::HGCalTowerCoord>& HGCalTriggerGeometryHexImp2::getTriggerTowers() const {
+  edm::LogError("HGCalTriggerGeometryHexImp2") << "(getTriggerTowers) Trigger Tower mapping is not implemented!\n";
+  return towers_;
+}
 
 
-DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, 
+DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory,
         HGCalTriggerGeometryHexImp2,
         "HGCalTriggerGeometryHexImp2");

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 
 #include <vector>
 #include <iostream>
@@ -39,12 +40,18 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         virtual bool disconnectedModule(const unsigned) const override final;
         virtual unsigned triggerLayer(const unsigned) const override final;
 
+        virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const override final;
+        virtual std::vector<unsigned short> getTriggerTowers() const override final {
+          return trigger_towers_;
+        }
+
     private:
         edm::FileInPath l1tCellsMapping_;
         edm::FileInPath l1tCellsBHMapping_;
         edm::FileInPath l1tModulesMapping_;
         edm::FileInPath l1tCellNeighborsMapping_;
         edm::FileInPath l1tCellNeighborsBHMapping_;
+        edm::FileInPath l1tTriggerTowerMapping_;
 
         // module related maps
         std::unordered_map<unsigned, unsigned> wafer_to_module_;
@@ -55,9 +62,11 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         std::unordered_multimap<unsigned, unsigned> trigger_cells_to_cells_;
         std::unordered_map<unsigned, unsigned> cells_to_trigger_cells_bh_;
         std::unordered_multimap<unsigned, unsigned> trigger_cells_to_cells_bh_;
-        std::unordered_map<unsigned, unsigned short> number_trigger_cells_in_wafers_; 
-        std::unordered_map<unsigned, unsigned short> number_trigger_cells_in_wafers_bh_; 
+        std::unordered_map<unsigned, unsigned short> number_trigger_cells_in_wafers_;
+        std::unordered_map<unsigned, unsigned short> number_trigger_cells_in_wafers_bh_;
         std::unordered_set<unsigned> invalid_triggercells_;
+        std::map<unsigned, short> cells_to_trigger_towers_;
+        std::vector<unsigned short> trigger_towers_;
 
         // neighbor related maps
         // trigger cell neighbors:
@@ -71,7 +80,7 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         std::unordered_set<unsigned> disconnected_layers_;
         std::vector<unsigned> trigger_layers_;
 
-        // layer offsets 
+        // layer offsets
         unsigned fhOffset_;
         unsigned bhOffset_;
         unsigned totalLayers_;
@@ -101,7 +110,8 @@ HGCalTriggerGeometryHexLayerBasedImp1(const edm::ParameterSet& conf):
     l1tCellsBHMapping_(conf.getParameter<edm::FileInPath>("L1TCellsBHMapping")),
     l1tModulesMapping_(conf.getParameter<edm::FileInPath>("L1TModulesMapping")),
     l1tCellNeighborsMapping_(conf.getParameter<edm::FileInPath>("L1TCellNeighborsMapping")),
-    l1tCellNeighborsBHMapping_(conf.getParameter<edm::FileInPath>("L1TCellNeighborsBHMapping"))
+    l1tCellNeighborsBHMapping_(conf.getParameter<edm::FileInPath>("L1TCellNeighborsBHMapping")),
+    l1tTriggerTowerMapping_(conf.getParameter<edm::FileInPath>("L1TTriggerTowerMapping"))
 {
     std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedModules");
     std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_modules_, disconnected_modules_.end()));
@@ -123,6 +133,7 @@ reset()
     number_trigger_cells_in_wafers_bh_.clear();
     trigger_cell_neighbors_.clear();
     trigger_cell_neighbors_bh_.clear();
+    cells_to_trigger_towers_.clear();
 }
 
 void
@@ -155,7 +166,7 @@ initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
 
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 getTriggerCellFromCell( const unsigned cell_id ) const
 {
@@ -207,14 +218,14 @@ getTriggerCellFromCell( const unsigned cell_id ) const
 
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 getModuleFromCell( const unsigned cell_id ) const
 {
     return getModuleFromTriggerCell(getTriggerCellFromCell(cell_id));
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
 {
@@ -241,7 +252,7 @@ getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
     return HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), trigger_cell_det_id.waferType(), module, HGCalDetId::kHGCalCellMask).rawId();
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexLayerBasedImp1::
 getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
 {
@@ -283,7 +294,7 @@ getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexLayerBasedImp1::
 getCellsFromModule( const unsigned module_id ) const
 {
@@ -297,7 +308,7 @@ getCellsFromModule( const unsigned module_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryHexLayerBasedImp1::
 getOrderedCellsFromModule( const unsigned module_id ) const
 {
@@ -311,7 +322,7 @@ getOrderedCellsFromModule( const unsigned module_id ) const
     return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryHexLayerBasedImp1::
 getTriggerCellsFromModule( const unsigned module_id ) const
 {
@@ -348,7 +359,7 @@ getTriggerCellsFromModule( const unsigned module_id ) const
     return trigger_cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryHexLayerBasedImp1::
 getOrderedTriggerCellsFromModule( const unsigned module_id ) const
 {
@@ -421,7 +432,7 @@ getNeighborsFromTriggerCell( const unsigned trigger_cell_id ) const
 }
 
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryHexLayerBasedImp1::
 getTriggerCellPosition(const unsigned trigger_cell_det_id) const
 {
@@ -451,7 +462,7 @@ getTriggerCellPosition(const unsigned trigger_cell_det_id) const
 
 }
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryHexLayerBasedImp1::
 getModulePosition(const unsigned module_det_id) const
 {
@@ -480,8 +491,7 @@ getModulePosition(const unsigned module_det_id) const
     return GlobalPoint( moduleVector/cell_ids.size() );
 }
 
-
-void 
+void
 HGCalTriggerGeometryHexLayerBasedImp1::
 fillMaps()
 {
@@ -506,7 +516,7 @@ fillMaps()
     l1tModulesMappingStream.close();
     // read trigger cell mapping file
     std::ifstream l1tCellsMappingStream(l1tCellsMapping_.fullPath());
-    if(!l1tCellsMappingStream.is_open()) 
+    if(!l1tCellsMappingStream.is_open())
     {
         throw cms::Exception("MissingDataFile")
             << "Cannot open HGCalTriggerGeometry L1TCellsMapping file\n";
@@ -517,7 +527,7 @@ fillMaps()
     trigger_wafer = 0;
     short trigger_cell = 0;
     for(; l1tCellsMappingStream>>subdet>>wafer>>cell>>trigger_wafer>>trigger_cell; )
-    { 
+    {
         unsigned cell_key = packWaferCellId(subdet,wafer,cell);
         unsigned trigger_cell_key = packWaferCellId(subdet,trigger_wafer,trigger_cell);
         // fill cell <-> trigger cell mappings
@@ -541,7 +551,7 @@ fillMaps()
     trigger_wafer = 0;
     trigger_cell = 0;
     for(; l1tCellsBHMappingStream>>ieta>>iphi>>trigger_wafer>>trigger_cell; )
-    { 
+    {
         unsigned cell_key = packIetaIphi(ieta,iphi);
         unsigned trigger_cell_key = packWaferCellId(ForwardSubdetector::HGCHEB,trigger_wafer,trigger_cell);
         // fill cell <-> trigger cell mappings
@@ -553,16 +563,52 @@ fillMaps()
     }
     if(!l1tCellsBHMappingStream.eof()) edm::LogWarning("HGCalTriggerGeometry") << "Error reading L1TCellsBHMapping '"<<ieta<<" "<<iphi<<" "<<trigger_wafer<<" "<<trigger_cell<<"' \n";
     l1tCellsBHMappingStream.close();
+
+
+    // we read the TC to TriggerTower mapping
+    std::ifstream l1tTriggerTowerMappingStream(l1tTriggerTowerMapping_.fullPath());
+    if(!l1tTriggerTowerMappingStream.is_open()) {
+        throw cms::Exception("MissingDataFile")
+            << "Cannot open HGCalTriggerGeometry L1TTriggerTowerMapping file\n";
+    }
+    std::cout << "cells_to_trigger_cells_ size: " << cells_to_trigger_cells_.size() << std::endl;
+    std::cout << "cells_to_trigger_cells_bh_ size: " << cells_to_trigger_cells_bh_.size() << std::endl;
+
+    std::cout << "About to read " << l1tTriggerTowerMapping_.fullPath() << std::endl;
+    // FIXME: remove the index since it is not used
+    unsigned id = 0;
+    unsigned trigger_cell_id = 0;
+    unsigned short ix = 0;
+    unsigned short iy = 0;
+
+    std::set<unsigned short> tt_ids;
+    for(; l1tTriggerTowerMappingStream >> id >> trigger_cell_id >> ix >> iy;) {
+      // std::cout << trigger_cell_id << " " << ix << " " << iy << std::endl;
+      HGCalDetId detId(trigger_cell_id);
+      int zside = detId.zside();
+      l1t::HGCalTowerID towerId(zside, ix, iy);
+      cells_to_trigger_towers_[trigger_cell_id] = towerId.rawId();
+      tt_ids.insert(std::move(towerId.rawId()));
+    }
+    trigger_towers_.reserve(tt_ids.size());
+    std::copy(tt_ids.begin(), tt_ids.end(), std::back_inserter(trigger_towers_));
+
+    std::cout << "...done" << std::endl;
+    std::cout << "# of trigger cells: " << cells_to_trigger_towers_.size() << std::endl;
+    std::cout << "# of Trigger Towers: " << trigger_towers_.size() << std::endl;
+
+    l1tTriggerTowerMappingStream.close();
 }
 
 
-void 
+
+void
 HGCalTriggerGeometryHexLayerBasedImp1::
 fillNeighborMaps(const edm::FileInPath& file,  std::unordered_map<int, std::set<std::pair<short,short>>>& neighbors_map)
 {
     // Fill trigger neighbor map
     std::ifstream l1tCellNeighborsMappingStream(file.fullPath());
-    if(!l1tCellNeighborsMappingStream.is_open()) 
+    if(!l1tCellNeighborsMappingStream.is_open())
     {
         throw cms::Exception("MissingDataFile")
             << "Cannot open HGCalTriggerGeometry L1TCellNeighborsMapping file\n";
@@ -572,7 +618,7 @@ fillNeighborMaps(const edm::FileInPath& file,  std::unordered_map<int, std::set<
         std::string line(&buffer[0]);
         // Extract keys consisting of the module id
         // and of the trigger cell id
-        // Match patterns (X,Y) 
+        // Match patterns (X,Y)
         // where X is a number with less than 4 digis
         // and Y is a number with less than 4 digits
         std::regex key_regex("\\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*\\)");
@@ -590,12 +636,12 @@ fillNeighborMaps(const edm::FileInPath& file,  std::unordered_map<int, std::set<
         std::vector<std::string>  module_tc {
             std::sregex_token_iterator(key_tokens[0].begin(), key_tokens[0].end(), digits_regex), {}
         };
-        // get module and cell id 
+        // get module and cell id
         int module = std::stoi(module_tc[0]);
         int trigger_cell = std::stoi(module_tc[1]);
         unsigned map_key = packTriggerCell(module, trigger_cell);
         // Extract neighbors
-        // Match patterns (X,Y) 
+        // Match patterns (X,Y)
         // where X is a number with less than 4 digits
         // and Y is a number with less than 4 digits
         std::regex neighbors_regex("\\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*\\)");
@@ -629,7 +675,7 @@ fillNeighborMaps(const edm::FileInPath& file,  std::unordered_map<int, std::set<
 
 
 
-void 
+void
 HGCalTriggerGeometryHexLayerBasedImp1::
 fillInvalidTriggerCells()
 {
@@ -660,7 +706,7 @@ fillInvalidTriggerCells()
     }
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 packWaferCellId(unsigned subdet, unsigned wafer, unsigned cell) const
 {
@@ -673,7 +719,7 @@ packWaferCellId(unsigned subdet, unsigned wafer, unsigned cell) const
 }
 
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 packIetaIphi(unsigned ieta, unsigned iphi) const
 {
@@ -700,14 +746,14 @@ unpackIetaIphi(unsigned ieta_iphi, unsigned& ieta, unsigned& iphi) const
     ieta = (ieta_iphi>>HcalDetId::kHcalEtaOffset2) & HcalDetId::kHcalEtaMask2;
 }
 
-bool 
+bool
 HGCalTriggerGeometryHexLayerBasedImp1::
 validTriggerCell(const unsigned trigger_cell_id) const
 {
     return invalid_triggercells_.find(trigger_cell_id)==invalid_triggercells_.end();
 }
 
-bool 
+bool
 HGCalTriggerGeometryHexLayerBasedImp1::
 disconnectedModule(const unsigned module_id) const
 {
@@ -717,7 +763,7 @@ disconnectedModule(const unsigned module_id) const
     return disconnected;
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 triggerLayer(const unsigned id) const
 {
@@ -726,12 +772,12 @@ triggerLayer(const unsigned id) const
     return trigger_layers_[layer];
 }
 
-bool 
+bool
 HGCalTriggerGeometryHexLayerBasedImp1::
 validTriggerCellFromCells(const unsigned trigger_cell_id) const
 {
     // Check the validity of a trigger cell with the
-    // validity of the cells. One valid cell in the 
+    // validity of the cells. One valid cell in the
     // trigger cell is enough to make the trigger cell
     // valid.
     HGCalDetId trigger_cell_det_id(trigger_cell_id);
@@ -765,12 +811,12 @@ validCellId(unsigned subdet, unsigned cell_id) const
         default:
             is_valid = false;
             break;
-    } 
+    }
     return is_valid;
 }
 
 
-unsigned 
+unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
 packTriggerCell(unsigned module, unsigned trigger_cell) const
 {
@@ -780,7 +826,7 @@ packTriggerCell(unsigned module, unsigned trigger_cell) const
     return packed_value;
 }
 
-int 
+int
 HGCalTriggerGeometryHexLayerBasedImp1::
 detIdWaferType(unsigned subdet, short wafer) const
 {
@@ -801,7 +847,6 @@ detIdWaferType(unsigned subdet, short wafer) const
     };
     return wafer_type;
 }
-
 
 unsigned
 HGCalTriggerGeometryHexLayerBasedImp1::
@@ -825,7 +870,11 @@ layerWithOffset(unsigned id) const
 }
 
 
+unsigned short HGCalTriggerGeometryHexLayerBasedImp1::getTriggerTowerFromTriggerCell(const unsigned trigger_cell_id) const {
+  // FIXME: WE SHOULD IMPLEMENT A CHECK ON END?
+  return cells_to_trigger_towers_.find(trigger_cell_id)->second;
+}
 
-DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, 
+DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory,
         HGCalTriggerGeometryHexLayerBasedImp1,
         "HGCalTriggerGeometryHexLayerBasedImp1");

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -575,14 +575,12 @@ fillMaps()
     std::cout << "cells_to_trigger_cells_bh_ size: " << cells_to_trigger_cells_bh_.size() << std::endl;
 
     std::cout << "About to read " << l1tTriggerTowerMapping_.fullPath() << std::endl;
-    // FIXME: remove the index since it is not used
-    unsigned id = 0;
     unsigned trigger_cell_id = 0;
     unsigned short ix = 0;
     unsigned short iy = 0;
 
     std::set<unsigned short> tt_ids;
-    for(; l1tTriggerTowerMappingStream >> id >> trigger_cell_id >> ix >> iy;) {
+    for(; l1tTriggerTowerMappingStream >> trigger_cell_id >> ix >> iy;) {
       // std::cout << trigger_cell_id << " " << ix << " " << iy << std::endl;
       HGCalDetId detId(trigger_cell_id);
       int zside = detId.zside();

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -42,7 +42,7 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         virtual unsigned triggerLayer(const unsigned) const override final;
 
         virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const override final;
-        virtual std::vector<l1t::HGCalTowerCoord> getTriggerTowers() const override final {
+        virtual const std::vector<l1t::HGCalTowerCoord>& getTriggerTowers() const override final {
           return towerGeometryHelper_.getTowerCoordinates();
         }
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -575,17 +575,13 @@ fillMaps()
         throw cms::Exception("MissingDataFile")
             << "Cannot open HGCalTriggerGeometry L1TTriggerTowerMapping file\n";
     }
-    std::cout << "cells_to_trigger_cells_ size: " << cells_to_trigger_cells_.size() << std::endl;
-    std::cout << "cells_to_trigger_cells_bh_ size: " << cells_to_trigger_cells_bh_.size() << std::endl;
 
-    std::cout << "About to read " << l1tTriggerTowerMapping_.fullPath() << std::endl;
     unsigned trigger_cell_id = 0;
     unsigned short ix = 0;
     unsigned short iy = 0;
 
     std::set<unsigned short> tt_ids;
     for(; l1tTriggerTowerMappingStream >> trigger_cell_id >> ix >> iy;) {
-      // std::cout << trigger_cell_id << " " << ix << " " << iy << std::endl;
       HGCalDetId detId(trigger_cell_id);
       int zside = detId.zside();
       l1t::HGCalTowerID towerId(zside, ix, iy);
@@ -595,10 +591,6 @@ fillMaps()
     trigger_towers_.reserve(tt_ids.size());
     std::copy(tt_ids.begin(), tt_ids.end(), std::back_inserter(trigger_towers_));
     towerGeometryHelper_.createTowerCoordinates(trigger_towers_);
-
-    std::cout << "...done" << std::endl;
-    std::cout << "# of trigger cells: " << cells_to_trigger_towers_.size() << std::endl;
-    std::cout << "# of Trigger Towers: " << trigger_towers_.size() << std::endl;
 
     l1tTriggerTowerMappingStream.close();
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -1,6 +1,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
@@ -41,8 +42,8 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         virtual unsigned triggerLayer(const unsigned) const override final;
 
         virtual unsigned short getTriggerTowerFromTriggerCell(const unsigned) const override final;
-        virtual std::vector<unsigned short> getTriggerTowers() const override final {
-          return trigger_towers_;
+        virtual std::vector<l1t::HGCalTowerCoord> getTriggerTowers() const override final {
+          return towerGeometryHelper_.getTowerCoordinates();
         }
 
     private:
@@ -80,6 +81,8 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase
         std::unordered_set<unsigned> disconnected_layers_;
         std::vector<unsigned> trigger_layers_;
 
+        HGCalTriggerTowerGeometryHelper towerGeometryHelper_;
+
         // layer offsets
         unsigned fhOffset_;
         unsigned bhOffset_;
@@ -111,7 +114,8 @@ HGCalTriggerGeometryHexLayerBasedImp1(const edm::ParameterSet& conf):
     l1tModulesMapping_(conf.getParameter<edm::FileInPath>("L1TModulesMapping")),
     l1tCellNeighborsMapping_(conf.getParameter<edm::FileInPath>("L1TCellNeighborsMapping")),
     l1tCellNeighborsBHMapping_(conf.getParameter<edm::FileInPath>("L1TCellNeighborsBHMapping")),
-    l1tTriggerTowerMapping_(conf.getParameter<edm::FileInPath>("L1TTriggerTowerMapping"))
+    l1tTriggerTowerMapping_(conf.getParameter<edm::ParameterSet>("L1TTriggerTowerConfig").getParameter<edm::FileInPath>("L1TTriggerTowerMapping")),
+    towerGeometryHelper_(conf.getParameter<edm::ParameterSet>("L1TTriggerTowerConfig"))
 {
     std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedModules");
     std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_modules_, disconnected_modules_.end()));
@@ -590,6 +594,7 @@ fillMaps()
     }
     trigger_towers_.reserve(tt_ids.size());
     std::copy(tt_ids.begin(), tt_ids.end(), std::back_inserter(trigger_towers_));
+    towerGeometryHelper_.createTowerCoordinates(trigger_towers_);
 
     std::cout << "...done" << std::endl;
     std::cout << "# of trigger cells: " << cells_to_trigger_towers_.size() << std::endl;

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -20,16 +20,16 @@ class HGCalTriggerNtupleHGCTowers : public HGCalTriggerNtupleBase
 
     edm::EDGetToken towers_token_;
 
-    int tower_n_ ;    
+    int tower_n_ ;
     std::vector<float> tower_pt_;
     std::vector<float> tower_energy_;
     std::vector<float> tower_eta_;
     std::vector<float> tower_phi_;
     std::vector<float> tower_etEm_;
     std::vector<float> tower_etHad_;
-    std::vector<int> tower_hwEta_;
-    std::vector<int> tower_hwPhi_;
-  
+    std::vector<int> tower_iX_;
+    std::vector<int> tower_iY_;
+
 };
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
@@ -48,15 +48,15 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
 {
   towers_token_ = collector.consumes<l1t::HGCalTowerBxCollection>(conf.getParameter<edm::InputTag>("Towers"));
 
-  tree.Branch("tower_n", &tower_n_, "tower_n/I"); 
+  tree.Branch("tower_n", &tower_n_, "tower_n/I");
   tree.Branch("tower_pt", &tower_pt_);
   tree.Branch("tower_energy", &tower_energy_);
   tree.Branch("tower_eta", &tower_eta_);
   tree.Branch("tower_phi", &tower_phi_);
   tree.Branch("tower_etEm", &tower_etEm_);
   tree.Branch("tower_etHad", &tower_etHad_);
-  tree.Branch("tower_hwEta", &tower_hwEta_);
-  tree.Branch("tower_hwPhi", &tower_hwPhi_);
+  tree.Branch("tower_iX", &tower_iX_);
+  tree.Branch("tower_iY", &tower_iY_);
 
 }
 
@@ -80,16 +80,16 @@ fill(const edm::Event& e, const edm::EventSetup& es)
   for(auto tower_itr=towers.begin(0); tower_itr!=towers.end(0); tower_itr++)
   {
     tower_n_++;
-    // physical values 
+    // physical values
     tower_pt_.emplace_back(tower_itr->pt());
     tower_energy_.emplace_back(tower_itr->energy());
     tower_eta_.emplace_back(tower_itr->eta());
     tower_phi_.emplace_back(tower_itr->phi());
     tower_etEm_.emplace_back(tower_itr->etEm());
     tower_etHad_.emplace_back(tower_itr->etHad());
-    
-    tower_hwEta_.emplace_back(tower_itr->hwEta());
-    tower_hwPhi_.emplace_back(tower_itr->hwPhi());
+
+    tower_iX_.emplace_back(tower_itr->iX());
+    tower_iY_.emplace_back(tower_itr->iY());
   }
 }
 
@@ -105,10 +105,6 @@ clear()
   tower_phi_.clear();
   tower_etEm_.clear();
   tower_etHad_.clear();
-  tower_hwEta_.clear();
-  tower_hwPhi_.clear();
+  tower_iX_.clear();
+  tower_iY_.clear();
 }
-
-
-
-

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -88,8 +88,8 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     tower_etEm_.emplace_back(tower_itr->etEm());
     tower_etHad_.emplace_back(tower_itr->etHad());
 
-    tower_iX_.emplace_back(tower_itr->iX());
-    tower_iY_.emplace_back(tower_itr->iY());
+    tower_iX_.emplace_back(tower_itr->id().coord1());
+    tower_iY_.emplace_back(tower_itr->id().coord2());
   }
 }
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
@@ -18,13 +18,30 @@ disconnectedTriggerLayers = [
         ]
 
 
+L1TTriggerTowerConfig_xy = cms.PSet(L1TTriggerTowerMapping=cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_v2.txt"),
+                                    refCoord1=cms.double(-167.5),
+                                    refCoord2=cms.double(-167.5),
+                                    refZ=cms.double(320.755),
+                                    binSizeCoord1=cms.double(5.),
+                                    binSizeCoord2=cms.double(5.),
+                                    type=cms.int32(0))
+
+L1TTriggerTowerConfig_hgcroc_etaphi = cms.PSet(L1TTriggerTowerMapping=cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_hgcroc_eta-phi_v0.txt"),
+                                               refCoord1=cms.double(1.4569),
+                                               refCoord2=cms.double(-3.097959),
+                                               refZ=cms.double(320.755),
+                                               binSizeCoord1=cms.double(0.0938888888889),
+                                               binSizeCoord2=cms.double(0.087266),
+                                               type=cms.int32(1))
+
 geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexLayerBasedImp1'),
                      L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_8inch_aligned_192_432_V8_0.txt"),
                      L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_tdr_0.txt"),
                      L1TCellNeighborsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_8inch_aligned_192_432_0.txt"),
                      L1TCellsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_BH_3x3_30deg_0.txt"),
                      L1TCellNeighborsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_BH_3x3_30deg_0.txt"),
-                     L1TTriggerTowerMapping =  cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_v2.txt"),
+                     L1TTriggerTowerMapping =  cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_hgcroc_eta-phi_v0.txt"),
+                     L1TTriggerTowerConfig = L1TTriggerTowerConfig_hgcroc_etaphi,
                      DisconnectedModules = cms.vuint32(0),
                      DisconnectedLayers = cms.vuint32(disconnectedTriggerLayers)
                    )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
@@ -24,7 +24,7 @@ geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexLa
                      L1TCellNeighborsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_8inch_aligned_192_432_0.txt"),
                      L1TCellsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_BH_3x3_30deg_0.txt"),
                      L1TCellNeighborsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_BH_3x3_30deg_0.txt"),
-                     L1TTriggerTowerMapping =  cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_v1.txt"),
+                     L1TTriggerTowerMapping =  cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_v2.txt"),
                      DisconnectedModules = cms.vuint32(0),
                      DisconnectedLayers = cms.vuint32(disconnectedTriggerLayers)
                    )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerGeometryESProducer_cfi.py
@@ -24,6 +24,7 @@ geometry = cms.PSet( TriggerGeometryName = cms.string('HGCalTriggerGeometryHexLa
                      L1TCellNeighborsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_8inch_aligned_192_432_0.txt"),
                      L1TCellsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_BH_3x3_30deg_0.txt"),
                      L1TCellNeighborsBHMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_BH_3x3_30deg_0.txt"),
+                     L1TTriggerTowerMapping =  cms.FileInPath("L1Trigger/L1THGCal/data/TCmapping_v1.txt"),
                      DisconnectedModules = cms.vuint32(0),
                      DisconnectedLayers = cms.vuint32(disconnectedTriggerLayers)
                    )
@@ -32,5 +33,3 @@ hgcalTriggerGeometryESProducer = cms.ESProducer(
     'HGCalTriggerGeometryESProducer',
     TriggerGeometry = geometry
 )
-
-

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
-import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
+import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam
 import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
 
 
@@ -65,14 +65,14 @@ ntuple_triggercells = cms.PSet(
     keV2fC = keV2fC,
     layerWeights = layerWeights,
     thicknessCorrections = thicknessCorrections,
-    FilterCellsInMulticlusters = cms.bool(True)
+    FilterCellsInMulticlusters = cms.bool(False)
 )
 
 ntuple_clusters = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleHGCClusters'),
     Clusters = cms.InputTag('hgcalTriggerPrimitiveDigiProducer:cluster2D'),
     Multiclusters = cms.InputTag('hgcalTriggerPrimitiveDigiProducer:cluster3D'),
-    FilterClustersInMulticlusters = cms.bool(True)
+    FilterClustersInMulticlusters = cms.bool(False)
 )
 
 from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_cone

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitiveDigiProducer_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
-import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
+import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam
 import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
 
 # Digitization parameters
@@ -91,11 +91,7 @@ cluster_algo =  cms.PSet( AlgorithmName = cms.string('HGCClusterAlgoThreshold'),
                           C3d_parameters = C3d_parValues.clone()
                           )
 
-towerMap2D_parValues = cms.PSet( nEtaBins = cms.int32(18),
-                                 nPhiBins = cms.int32(72),
-                                 etaBins = cms.vdouble(),
-                                 phiBins = cms.vdouble(),
-                                 useLayerWeights = cms.bool(False),
+towerMap2D_parValues = cms.PSet( useLayerWeights = cms.bool(False),
                                  layerWeights = cms.vdouble()
                                  )
 
@@ -111,7 +107,7 @@ hgcalTriggerPrimitiveDigiProducer = cms.EDProducer(
     fhDigis = cms.InputTag('mix:HGCDigisHEfront'),
     bhDigis = cms.InputTag('mix:HGCDigisHEback'),
     FECodec = fe_codec.clone(),
-    BEConfiguration = cms.PSet( 
+    BEConfiguration = cms.PSet(
         algorithms = cms.VPSet( cluster_algo,
                                 tower_algo )
         )
@@ -121,7 +117,7 @@ hgcalTriggerPrimitiveDigiFEReproducer = cms.EDProducer(
     "HGCalTriggerDigiFEReproducer",
     feDigis = cms.InputTag('hgcalTriggerPrimitiveDigiProducer'),
     FECodec = fe_codec.clone(),
-    BEConfiguration = cms.PSet( 
+    BEConfiguration = cms.PSet(
         algorithms = cms.VPSet( cluster_algo,
                                 tower_algo)
         )

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeometryGenericMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeometryGenericMapping.cc
@@ -9,7 +9,7 @@ namespace {
 }
 
 HGCalTriggerGeometryGenericMapping::
-HGCalTriggerGeometryGenericMapping(const edm::ParameterSet& conf) : 
+HGCalTriggerGeometryGenericMapping(const edm::ParameterSet& conf) :
     HGCalTriggerGeometryBase(conf){
 }
 
@@ -20,7 +20,7 @@ void HGCalTriggerGeometryGenericMapping::reset() {
   trigger_cell_map().swap(trigger_cells_);
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryGenericMapping::
 getTriggerCellFromCell( const unsigned cell_det_id ) const {
   auto found_tc = cells_to_trigger_cells_.find(cell_det_id);
@@ -30,7 +30,7 @@ getTriggerCellFromCell( const unsigned cell_det_id ) const {
   return trigger_cells_.find(found_tc->second)->second->triggerCellId();
 }
 
-unsigned 
+unsigned
 HGCalTriggerGeometryGenericMapping::
 getModuleFromCell( const unsigned cell_det_id ) const {
   auto found_tc = cells_to_trigger_cells_.find(cell_det_id);
@@ -54,13 +54,13 @@ getModuleFromTriggerCell( const unsigned trigger_cell_det_id ) const {
   return modules_.find(found_mod->second)->second->moduleId();
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryGenericMapping::
 getCellsFromTriggerCell( const unsigned trigger_cell_det_id ) const {
   return trigger_cells_.find(trigger_cell_det_id)->second->components();
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryGenericMapping::
 getCellsFromModule( const unsigned module_det_id ) const {
   const auto& triggercell_cells = modules_.find(module_det_id)->second->triggerCellComponents();
@@ -68,10 +68,10 @@ getCellsFromModule( const unsigned module_det_id ) const {
   for(const auto& tc_c : triggercell_cells) {
     cells.emplace(tc_c.second);
   }
-  return cells; 
+  return cells;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryGenericMapping::
 getOrderedCellsFromModule( const unsigned module_det_id ) const {
   const auto& triggercell_cells = modules_.find(module_det_id)->second->triggerCellComponents();
@@ -79,16 +79,16 @@ getOrderedCellsFromModule( const unsigned module_det_id ) const {
   for(const auto& tc_c : triggercell_cells) {
     cells.emplace(tc_c.second);
   }
-  return cells; 
+  return cells;
 }
 
-HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryBase::geom_set
 HGCalTriggerGeometryGenericMapping::
 getTriggerCellsFromModule( const unsigned module_det_id ) const {
-  return modules_.find(module_det_id)->second->components(); 
+  return modules_.find(module_det_id)->second->components();
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryBase::geom_ordered_set
 HGCalTriggerGeometryGenericMapping::
 getOrderedTriggerCellsFromModule( const unsigned module_det_id ) const {
   // Build set from unordered_set. Maybe a more efficient to do it
@@ -96,7 +96,7 @@ getOrderedTriggerCellsFromModule( const unsigned module_det_id ) const {
   for(const auto& tc : modules_.find(module_det_id)->second->components()) {
     trigger_cells.emplace(tc);
   }
-  return trigger_cells; 
+  return trigger_cells;
 }
 
 HGCalTriggerGeometryBase::geom_set
@@ -107,35 +107,44 @@ getNeighborsFromTriggerCell( const unsigned trigger_cell_id ) const
   return geom_set();
 }
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryGenericMapping::
 getTriggerCellPosition(const unsigned trigger_cell_det_id) const {
-   return trigger_cells_.find(trigger_cell_det_id)->second->position(); 
+   return trigger_cells_.find(trigger_cell_det_id)->second->position();
 }
 
-GlobalPoint 
+GlobalPoint
 HGCalTriggerGeometryGenericMapping::
 getModulePosition(const unsigned module_det_id) const {
   return modules_.find(module_det_id)->second->position();
 }
 
 
-bool 
+bool
 HGCalTriggerGeometryGenericMapping::
 validTriggerCell(const unsigned trigger_cell_det_id) const {
   return (trigger_cells_.find(trigger_cell_det_id)!=trigger_cells_.end());
 }
 
-bool 
+bool
 HGCalTriggerGeometryGenericMapping::
 disconnectedModule(const unsigned module_id) const {
   return false;
 }
 
 
-unsigned 
+unsigned
 HGCalTriggerGeometryGenericMapping::
 triggerLayer(const unsigned id) const {
   return  HGCalDetId(id).layer();
 }
 
+unsigned short HGCalTriggerGeometryGenericMapping::getTriggerTowerFromTriggerCell(const unsigned) const {
+  edm::LogError("HGCalTriggerGeometryGenericMapping") << "(getTriggerTowerFromTriggerCell) Trigger Tower mapping is not implemented!\n";
+  return 0;
+}
+
+const std::vector<l1t::HGCalTowerCoord>& HGCalTriggerGeometryGenericMapping::getTriggerTowers() const {
+  edm::LogError("HGCalTriggerGeometryGenericMapping") << "(getTriggerTowers) Trigger Tower mapping is not implemented!\n";
+  return towers_;
+}

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -1,0 +1,46 @@
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h"
+#include <cmath>
+#include <iostream>
+
+void HGCalTriggerTowerGeometryHelper::createTowerCoordinates(const std::vector<unsigned short>& tower_ids) {
+  if(coord.size() == 0) {
+    coord.reserve(tower_ids.size());
+    for (auto towerId : tower_ids) {
+      GlobalPoint center = getPositionAtReferenceSurface(l1t::HGCalTowerID(towerId));
+      std::cout << l1t::HGCalTowerID(towerId).zside() << " "
+                << l1t::HGCalTowerID(towerId).iX() << " "
+                << l1t::HGCalTowerID(towerId).iY()
+                << "  eta: " << center.eta()
+                << " phi: " << center.phi() << std::endl;
+      coord.emplace_back(towerId, center.eta(), center.phi());
+    }
+  }
+}
+
+
+const std::vector<l1t::HGCalTowerCoord>& HGCalTriggerTowerGeometryHelper::getTowerCoordinates() const {
+  return coord;
+}
+
+
+
+
+
+GlobalPoint HGCalTriggerTowerGeometryHelper::getPositionAtReferenceSurface(const l1t::HGCalTowerID& towerId) const {
+  GlobalPoint surface_center;
+  if(type_ == HGCalTriggerTowerType::regular_xy) {
+    GlobalPoint referencePoint = towerId.zside() < 0 ?  GlobalPoint(refCoord1_, refCoord2_ , -1*referenceZ_) : GlobalPoint(refCoord1_, refCoord2_ , referenceZ_);
+    surface_center = GlobalPoint(referencePoint.x()+towerId.iX()*binSizeCoord1_,
+                                 referencePoint.y()+towerId.iY()*binSizeCoord2_,
+                                 referencePoint.z());
+
+  } else if(type_ == HGCalTriggerTowerType::regular_etaphi) {
+    float radius = fabs(referenceZ_/sinh(refCoord1_+towerId.iX()*binSizeCoord1_));
+    float phi = refCoord2_+towerId.iY()*binSizeCoord2_;
+    float zcoord = towerId.zside() < 0 ?  -1*referenceZ_ : referenceZ_;
+    surface_center =  GlobalPoint(GlobalPoint::Cylindrical(radius, phi, zcoord));
+  }
+  return surface_center;
+
+}

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -8,11 +8,11 @@ void HGCalTriggerTowerGeometryHelper::createTowerCoordinates(const std::vector<u
     coord.reserve(tower_ids.size());
     for (auto towerId : tower_ids) {
       GlobalPoint center = getPositionAtReferenceSurface(l1t::HGCalTowerID(towerId));
-      std::cout << l1t::HGCalTowerID(towerId).zside() << " "
-                << l1t::HGCalTowerID(towerId).iX() << " "
-                << l1t::HGCalTowerID(towerId).iY()
-                << "  eta: " << center.eta()
-                << " phi: " << center.phi() << std::endl;
+      // std::cout << l1t::HGCalTowerID(towerId).zside() << " "
+      //           << l1t::HGCalTowerID(towerId).coord1() << " "
+      //           << l1t::HGCalTowerID(towerId).coord2()
+      //           << "  eta: " << center.eta()
+      //           << " phi: " << center.phi() << std::endl;
       coord.emplace_back(towerId, center.eta(), center.phi());
     }
   }
@@ -31,13 +31,13 @@ GlobalPoint HGCalTriggerTowerGeometryHelper::getPositionAtReferenceSurface(const
   GlobalPoint surface_center;
   if(type_ == HGCalTriggerTowerType::regular_xy) {
     GlobalPoint referencePoint = towerId.zside() < 0 ?  GlobalPoint(refCoord1_, refCoord2_ , -1*referenceZ_) : GlobalPoint(refCoord1_, refCoord2_ , referenceZ_);
-    surface_center = GlobalPoint(referencePoint.x()+towerId.iX()*binSizeCoord1_,
-                                 referencePoint.y()+towerId.iY()*binSizeCoord2_,
+    surface_center = GlobalPoint(referencePoint.x()+towerId.coord1()*binSizeCoord1_,
+                                 referencePoint.y()+towerId.coord2()*binSizeCoord2_,
                                  referencePoint.z());
 
   } else if(type_ == HGCalTriggerTowerType::regular_etaphi) {
-    float radius = fabs(referenceZ_/sinh(refCoord1_+towerId.iX()*binSizeCoord1_));
-    float phi = refCoord2_+towerId.iY()*binSizeCoord2_;
+    float radius = fabs(referenceZ_/sinh(refCoord1_+towerId.coord1()*binSizeCoord1_));
+    float phi = refCoord2_+towerId.coord2()*binSizeCoord2_;
     float zcoord = towerId.zside() < 0 ?  -1*referenceZ_ : referenceZ_;
     surface_center =  GlobalPoint(GlobalPoint::Cylindrical(radius, phi, zcoord));
   }

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalTowerMap2DImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalTowerMap2DImpl.cc
@@ -33,20 +33,6 @@ std::map<int, l1t::HGCalTowerMap> HGCalTowerMap2DImpl::newTowerMaps() {
 void HGCalTowerMap2DImpl::buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>> & triggerCellsPtrs,
 					                                l1t::HGCalTowerMapBxCollection & towerMaps){
 
-<<<<<<< HEAD
-  for(const auto& tc : triggerCellsPtrs){
-
-    unsigned layer = triggerTools_.layerWithOffset(tc->detId());
-    int iEta = towerMapsTmp[layer-1].iEta(tc->eta());
-    int iPhi = towerMapsTmp[layer-1].iPhi(tc->phi());
-
-    double calibPt = tc->pt();
-    if(useLayerWeights_) calibPt = layerWeights_[layer]*(tc->mipPt());
-    math::PtEtaPhiMLorentzVector p4(calibPt,
-				    tc->eta(),
-				    tc->phi(),
-				    0. );
-=======
   std::map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
 
   for(auto tc:  triggerCellsPtrs) {
@@ -54,7 +40,6 @@ void HGCalTowerMap2DImpl::buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalT
     // FIXME: should actually sum the energy not the Et...
     double calibPt = tc->pt();
     if(useLayerWeights_) calibPt = layerWeights_[layer] * tc->mipPt();
->>>>>>> get the trigger tower grid and mapping from the geometry and switch to iX iY mapping
 
     double etEm = layer<=triggerTools_.lastLayerEE() ? calibPt : 0;
     double etHad = layer>triggerTools_.lastLayerEE() ? calibPt : 0;

--- a/L1Trigger/L1THGCal/src/be_algorithms/HGCalTowerMap3DImpl.cc
+++ b/L1Trigger/L1THGCal/src/be_algorithms/HGCalTowerMap3DImpl.cc
@@ -19,35 +19,18 @@ HGCalTowerMap3DImpl::HGCalTowerMap3DImpl( )
 
 
 void HGCalTowerMap3DImpl::buildTowerMap3D(const std::vector<edm::Ptr<l1t::HGCalTowerMap>> & towerMapsPtrs,
-					  l1t::HGCalTowerBxCollection & towers
-				       ){
+					  															l1t::HGCalTowerBxCollection & towers) {
 
   l1t::HGCalTowerMap towerMap;
 
-  for(const auto& map : towerMapsPtrs){
-    if(towerMap.nEtaBins()==0) towerMap = (*map);
+  for(auto map: towerMapsPtrs) {
+    if(towerMap.layer()==0) towerMap = (*map);
     else towerMap += (*map);
   }
 
-  int nEtaBins = towerMap.nEtaBins();
-  int nPhiBins = towerMap.nPhiBins();
-
-  vector<l1t::HGCalTower> towersTmp;
-
-  for(int iEta=-nEtaBins; iEta<=nEtaBins; iEta++){
-    if(iEta==0) continue;
-    for(int iPhi=0; iPhi<nPhiBins; iPhi++){ 
-      const l1t::HGCalTower& tower = towerMap.tower(iEta,iPhi);
-      if(tower.pt()>0) towersTmp.push_back(tower);
-    }
+	for(auto tower: towerMap.towers()) {
+		// FIXME: make this threshold configurable
+    if(tower.second.pt()>0) towers.push_back(0, tower.second);
   }
-
-  towers.resize(0, towersTmp.size());
-  int i=0;
-  for(auto tower : towersTmp){
-    towers.set( 0, i, tower);
-    i++;
-  }
-
 
 }

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
@@ -26,10 +26,10 @@
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
-#include <stdlib.h> 
+#include <stdlib.h>
 
-namespace 
-{  
+namespace
+{
     template<typename T>
     struct array_deleter
     {
@@ -38,7 +38,7 @@ namespace
 }
 
 
-class HGCalTriggerGeomTester : public edm::EDAnalyzer 
+class HGCalTriggerGeomTester : public edm::EDAnalyzer
 {
     public:
         explicit HGCalTriggerGeomTester(const edm::ParameterSet& );
@@ -80,6 +80,7 @@ class HGCalTriggerGeomTester : public edm::EDAnalyzer
         std::shared_ptr<int>   moduleTC_subdet_;
         std::shared_ptr<int>   moduleTC_layer_ ;
         std::shared_ptr<int>   moduleTC_wafer_;
+        std::shared_ptr<int>   moduleTC_waferType_;
         std::shared_ptr<int>   moduleTC_cell_  ;
         std::shared_ptr<float> moduleTC_x_     ;
         std::shared_ptr<float> moduleTC_y_     ;
@@ -99,6 +100,7 @@ class HGCalTriggerGeomTester : public edm::EDAnalyzer
         int   triggerCellSubdet_ ;
         int   triggerCellLayer_  ;
         int   triggerCellWafer_ ;
+        int   triggerCellWaferType_ ;
         int   triggerCell_       ;
         float triggerCellX_      ;
         float triggerCellY_      ;
@@ -162,7 +164,7 @@ class HGCalTriggerGeomTester : public edm::EDAnalyzer
         float cellBHY3_     ;
         float cellBHX4_     ;
         float cellBHY4_     ;
-        
+
 };
 
 
@@ -189,6 +191,7 @@ HGCalTriggerGeomTester::HGCalTriggerGeomTester(const edm::ParameterSet& conf):
     moduleTC_subdet_.reset(new int[1],   array_deleter<int>());
     moduleTC_layer_ .reset(new int[1],   array_deleter<int>());
     moduleTC_wafer_ .reset(new int[1],   array_deleter<int>());
+    moduleTC_waferType_ .reset(new int[1],   array_deleter<int>());
     moduleTC_cell_  .reset(new int[1],   array_deleter<int>());
     moduleTC_x_     .reset(new float[1], array_deleter<float>());
     moduleTC_y_     .reset(new float[1], array_deleter<float>());
@@ -198,6 +201,7 @@ HGCalTriggerGeomTester::HGCalTriggerGeomTester(const edm::ParameterSet& conf):
     treeModules_->Branch("tc_subdet"      , moduleTC_subdet_.get() , "tc_subdet[tc_n]/I");
     treeModules_->Branch("tc_layer"       , moduleTC_layer_.get()  , "tc_layer[tc_n]/I");
     treeModules_->Branch("tc_wafer"       , moduleTC_wafer_.get()  , "tc_wafer[tc_n]/I");
+    treeModules_->Branch("tc_waferType"       , moduleTC_waferType_.get()  , "tc_waferType[tc_n]/I");
     treeModules_->Branch("tc_cell"        , moduleTC_cell_.get()   , "tc_cell[tc_n]/I");
     treeModules_->Branch("tc_x"           , moduleTC_x_.get()      , "tc_x[tc_n]/F");
     treeModules_->Branch("tc_y"           , moduleTC_y_.get()      , "tc_y[tc_n]/F");
@@ -228,6 +232,8 @@ HGCalTriggerGeomTester::HGCalTriggerGeomTester(const edm::ParameterSet& conf):
     treeTriggerCells_->Branch("subdet"         , &triggerCellSubdet_        , "subdet/I");
     treeTriggerCells_->Branch("layer"          , &triggerCellLayer_         , "layer/I");
     treeTriggerCells_->Branch("wafer"          , &triggerCellWafer_          , "wafer/I");
+    treeTriggerCells_->Branch("wafertype"          , &triggerCellWaferType_          , "wafertype/I");
+
     treeTriggerCells_->Branch("triggercell"    , &triggerCell_              , "triggercell/I");
     treeTriggerCells_->Branch("x"              , &triggerCellX_             , "x/F");
     treeTriggerCells_->Branch("y"              , &triggerCellY_             , "y/F");
@@ -318,13 +324,13 @@ HGCalTriggerGeomTester::HGCalTriggerGeomTester(const edm::ParameterSet& conf):
 
 
 /*****************************************************************/
-HGCalTriggerGeomTester::~HGCalTriggerGeomTester() 
+HGCalTriggerGeomTester::~HGCalTriggerGeomTester()
 /*****************************************************************/
 {
 }
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/, 
+void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/,
                                           const edm::EventSetup& es)
 /*****************************************************************/
 {
@@ -354,7 +360,7 @@ void HGCalTriggerGeomTester::beginRun(const edm::Run& /*run*/,
 
 void HGCalTriggerGeomTester::checkMappingConsistency()
 {
-    
+
 
 
 
@@ -366,7 +372,7 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
     for(const auto& id : triggerGeometry_->eeGeometry().getValidGeomDetIds())
     {
         if(id.rawId()==0) continue;
-        HGCalDetId waferid(id); 
+        HGCalDetId waferid(id);
         int nCells = triggerGeometry_->eeTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
@@ -386,7 +392,7 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
     for(const auto& id : triggerGeometry_->fhGeometry().getValidGeomDetIds())
     {
         if(id.rawId()==0) continue;
-        HGCalDetId waferid(id); 
+        HGCalDetId waferid(id);
         int nCells = triggerGeometry_->fhTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
@@ -515,7 +521,7 @@ void HGCalTriggerGeomTester::checkNeighborConsistency()
     for(const auto& id : triggerGeometry_->eeGeometry().getValidGeomDetIds())
     {
         if(id.rawId()==0) continue;
-        HGCalDetId waferid(id); 
+        HGCalDetId waferid(id);
         int nCells = triggerGeometry_->eeTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
@@ -534,7 +540,7 @@ void HGCalTriggerGeomTester::checkNeighborConsistency()
     for(const auto& id : triggerGeometry_->fhGeometry().getValidGeomDetIds())
     {
         if(id.rawId()==0) continue;
-        HGCalDetId waferid(id); 
+        HGCalDetId waferid(id);
         int nCells = triggerGeometry_->fhTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
@@ -757,6 +763,7 @@ void HGCalTriggerGeomTester::fillTriggerGeometry()
         triggerCellSubdet_ = id.subdetId();
         triggerCellLayer_  = id.layer();
         triggerCellWafer_  = id.wafer();
+        triggerCellWaferType_  = id.waferType();
         triggerCell_       = id.cell();
         triggerCellX_      = position.x();
         triggerCellY_      = position.y();
@@ -856,6 +863,7 @@ void HGCalTriggerGeomTester::fillTriggerGeometry()
             moduleTC_subdet_.get()[itc] = tcId.subdetId();
             moduleTC_layer_ .get()[itc] = tcId.layer();
             moduleTC_wafer_ .get()[itc] = tcId.wafer();
+            moduleTC_waferType_ .get()[itc] = tcId.waferType();
             moduleTC_cell_  .get()[itc] = tcId.cell();
             moduleTC_x_     .get()[itc] = position.x();
             moduleTC_y_     .get()[itc] = position.y();
@@ -890,8 +898,8 @@ void HGCalTriggerGeomTester::fillTriggerGeometry()
 
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::analyze(const edm::Event& e, 
-        const edm::EventSetup& es) 
+void HGCalTriggerGeomTester::analyze(const edm::Event& e,
+        const edm::EventSetup& es)
 /*****************************************************************/
 {
 
@@ -899,7 +907,7 @@ void HGCalTriggerGeomTester::analyze(const edm::Event& e,
 
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::setTreeModuleSize(const size_t n) 
+void HGCalTriggerGeomTester::setTreeModuleSize(const size_t n)
 /*****************************************************************/
 {
     moduleTC_id_    .reset(new int[n],   array_deleter<int>());
@@ -907,6 +915,7 @@ void HGCalTriggerGeomTester::setTreeModuleSize(const size_t n)
     moduleTC_subdet_.reset(new int[n],   array_deleter<int>());
     moduleTC_layer_ .reset(new int[n],   array_deleter<int>());
     moduleTC_wafer_ .reset(new int[n],   array_deleter<int>());
+    moduleTC_waferType_ .reset(new int[n],   array_deleter<int>());
     moduleTC_cell_  .reset(new int[n],   array_deleter<int>());
     moduleTC_x_     .reset(new float[n], array_deleter<float>());
     moduleTC_y_     .reset(new float[n], array_deleter<float>());
@@ -917,6 +926,7 @@ void HGCalTriggerGeomTester::setTreeModuleSize(const size_t n)
     treeModules_->GetBranch("tc_subdet") ->SetAddress(moduleTC_subdet_.get());
     treeModules_->GetBranch("tc_layer")  ->SetAddress(moduleTC_layer_ .get());
     treeModules_->GetBranch("tc_wafer")  ->SetAddress(moduleTC_wafer_ .get());
+    treeModules_->GetBranch("tc_waferType")  ->SetAddress(moduleTC_waferType_ .get());
     treeModules_->GetBranch("tc_cell")   ->SetAddress(moduleTC_cell_  .get());
     treeModules_->GetBranch("tc_x")      ->SetAddress(moduleTC_x_     .get());
     treeModules_->GetBranch("tc_y")      ->SetAddress(moduleTC_y_     .get());
@@ -924,7 +934,7 @@ void HGCalTriggerGeomTester::setTreeModuleSize(const size_t n)
 }
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::setTreeModuleCellSize(const size_t n) 
+void HGCalTriggerGeomTester::setTreeModuleCellSize(const size_t n)
 /*****************************************************************/
 {
     moduleCell_id_    .reset(new int[n],   array_deleter<int>());
@@ -949,7 +959,7 @@ void HGCalTriggerGeomTester::setTreeModuleCellSize(const size_t n)
 }
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::setTreeTriggerCellSize(const size_t n) 
+void HGCalTriggerGeomTester::setTreeTriggerCellSize(const size_t n)
 /*****************************************************************/
 {
     triggerCellCell_id_    .reset(new int[n],   array_deleter<int>());
@@ -980,7 +990,7 @@ void HGCalTriggerGeomTester::setTreeTriggerCellSize(const size_t n)
 
 
 /*****************************************************************/
-void HGCalTriggerGeomTester::setTreeTriggerCellNeighborSize(const size_t n) 
+void HGCalTriggerGeomTester::setTreeTriggerCellNeighborSize(const size_t n)
 /*****************************************************************/
 {
     triggerCellNeighbor_id_.reset(new int[n],array_deleter<int>());


### PR DESCRIPTION
This PR introduces the possibility to feed the trigger geometry with a pre-computed mapping of TCs to TriggerTowers. 
The current mapping:
`L1Trigger/L1THGCal/data/TCmapping_hgcroc_eta-phi_v0.txt`
maps HGCROC in eta phi bins (very crude approx to distinguish wafer cell-size based on radius < 70cm).
The Tower mapping  is served by the TriggerGeometry together with the reference points to establish the eta-phi coordinates of the center of the towers.
The corresponding DataFormats are now simpler.