### PR TITLE
Fix the data formats for persistency

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalTowerID.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerID.h
@@ -7,6 +7,8 @@
 namespace l1t {
   class HGCalTowerID {
   public:
+    HGCalTowerID(): HGCalTowerID(0) {}
+
     HGCalTowerID(unsigned short rawId): rawId_(rawId) {}
 
     HGCalTowerID(short zside, unsigned short coord1, unsigned short coord2) {

--- a/DataFormats/L1THGCal/src/classes.h
+++ b/DataFormats/L1THGCal/src/classes.h
@@ -31,6 +31,7 @@ namespace DataFormats {
     l1t::HGCalTriggerCellBxCollection   hgcalTriggerCellBxColl;
     l1t::HGCalClusterBxCollection hgcalClusterBxColl;
     l1t::HGCalMulticlusterBxCollection hgcalMulticlusterBxColl;
+    l1t::HGCalTowerID towerId;
 
     edm::Ptr<l1t::HGCalTriggerCell> hgcalTriggerCellPtr;
     edm::Ptr<l1t::HGCalCluster> hgcalClusterPtr;
@@ -40,6 +41,7 @@ namespace DataFormats {
     std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>  hgcalTriggerCellMap;
     std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>  hgcalClusterMap;
     edm::PtrVector<l1t::HGCalTowerMap>  hgcalTowerMapList;
+    std::unordered_map<unsigned short,l1t::HGCalTower> towermap;
 
     edm::Wrapper<l1t::HGCalTowerBxCollection>   w_hgcalTowerBxColl;
     edm::Wrapper<l1t::HGCalTowerMapBxCollection>   w_hgcalTowerMapBxColl;
@@ -51,7 +53,7 @@ namespace DataFormats {
     edm::Wrapper<edm::PtrVector<l1t::HGCalTriggerCell>> w_hgcalTriggerCellList;
     edm::Wrapper<edm::Ptr<l1t::HGCalCluster>> w_hgcalClusterPtr;
     edm::Wrapper<edm::PtrVector<l1t::HGCalCluster>> w_hgcalClusterList;
-    
+
     l1t::ClusterShapes clusterShapes;
   }
 }

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -3,16 +3,16 @@
     <version ClassVersion="10" checksum="3197268020"/>
   </class>
   <class name="std::vector<l1t::HGCFETriggerDigi>"/>
-  <class name="l1t::HGCFETriggerDigiCollection"/>  
-  <class name="edm::Wrapper<l1t::HGCFETriggerDigiCollection>"/> 
-  
+  <class name="l1t::HGCFETriggerDigiCollection"/>
+  <class name="edm::Wrapper<l1t::HGCFETriggerDigiCollection>"/>
+
   <class name="l1t::HGCFETriggerDigiRef"/>
   <class name="l1t::HGCFETriggerDigiRefVector"/>
   <class name="edm::Wrapper<l1t::HGCFETriggerDigiRefVector>"/>
-  
+
   <class name="l1t::HGCFETriggerDigiPtr"/>
   <class name="l1t::HGCFETriggerDigiPtrVector"/>
-  <class name="edm::Wrapper<l1t::HGCFETriggerDigiPtrVector>"/>  
+  <class name="edm::Wrapper<l1t::HGCFETriggerDigiPtrVector>"/>
 
   <class name="l1t::HGCalTower" />
   <class name="std::vector<l1t::HGCalTower>" />
@@ -20,7 +20,9 @@
   <class name="l1t::HGCalTowerBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTowerBxCollection>"/>
 
+
   <class name="l1t::HGCalTowerMap" />
+  <class name="l1t::HGCalTowerID" />
   <class name="std::vector<l1t::HGCalTowerMap>" />
   <class name="l1t::HGCalTowerMapBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTowerMapBxCollection>"/>
@@ -39,7 +41,7 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
   <class name="l1t::HGCalMulticluster" ClassVersion="14">
-  <version ClassVersion="14" checksum="2315302819"/> 
+  <version ClassVersion="14" checksum="2315302819"/>
   <version ClassVersion="13" checksum="816077951"/>
   <version ClassVersion="12" checksum="4221677522"/>
   <version ClassVersion="11" checksum="1508179045"/>
@@ -61,6 +63,7 @@
   <class name="std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>" />
   <class name="std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>" />
   <class name="std::unordered_map<uint32_t, double>" />
+  <class name="unordered_map<unsigned short,l1t::HGCalTower>" />
   <class name="edm::PtrVector<l1t::HGCalTowerMap>" />
   <class name="edm::Ptr<l1t::HGCalTriggerCell>" />
   <class name="edm::Ptr<l1t::HGCalCluster>" />


### PR DESCRIPTION

While writing the new Tower formats I realized that some hammering of the ClassDef was needed.

