### PR TITLE
Fix wafertype for the cell ids retrieved from trigger cells

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -275,7 +275,7 @@ getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
             unsigned wafer = 0;
             unsigned cell = 0;
             unpackWaferCellId(tc_c_itr->second, wafer, cell);
-            unsigned  wafer_type = (detIdWaferType(subdet, wafer)==1 ? 1 : 0);
+            unsigned wafer_type = (detIdWaferType(subdet, wafer)==1 ? 1 : 0);
             unsigned cell_det_id = HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), wafer_type, wafer, cell).rawId();
             if(validCellId(subdet, cell_det_id)) cell_det_ids.emplace(cell_det_id);
         }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -238,7 +238,7 @@ getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
         }
         module = module_itr->second;
     }
-    return HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), trigger_cell_det_id.waferType(), module, HGCalDetId::kHGCalCellMask).rawId();
+    return HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), (trigger_cell_det_id.waferType()==1 ? 1:0), module, HGCalDetId::kHGCalCellMask).rawId();
 }
 
 HGCalTriggerGeometryBase::geom_set 
@@ -275,7 +275,7 @@ getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
             unsigned wafer = 0;
             unsigned cell = 0;
             unpackWaferCellId(tc_c_itr->second, wafer, cell);
-            unsigned wafer_type = detIdWaferType(subdet, wafer);
+            unsigned  wafer_type = (detIdWaferType(subdet, wafer)==1 ? 1 : 0);
             unsigned cell_det_id = HGCalDetId((ForwardSubdetector)trigger_cell_det_id.subdetId(), trigger_cell_det_id.zside(), trigger_cell_det_id.layer(), wafer_type, wafer, cell).rawId();
             if(validCellId(subdet, cell_det_id)) cell_det_ids.emplace(cell_det_id);
         }

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTester.cc
@@ -17,7 +17,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -373,10 +372,11 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id);
+        unsigned wafer_type = (triggerGeometry_->eeTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->eeTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->eeTopology().valid(id)) continue;
             // fill trigger cells
             uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
@@ -393,10 +393,11 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id);
+        unsigned wafer_type = (triggerGeometry_->fhTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->fhTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->fhTopology().valid(id)) continue;
             // fill trigger cells
             uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
@@ -455,6 +456,7 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
                     output<<cell_geom<<" ";
                 }
                 edm::LogProblem("BadTriggerCell")<<output.str();
+                throw cms::Exception("BadTriggerCell")<<"Trigger cell <-> cell inconsistency";
             }
         }
     }
@@ -479,6 +481,7 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
                     output<<cell_geom<<" ";
                 }
                 edm::LogProblem("BadModule")<<output.str();
+                throw cms::Exception("BadModule")<<"Trigger cell <-> module inconsistency";
             }
         }
     }
@@ -508,6 +511,7 @@ void HGCalTriggerGeomTester::checkMappingConsistency()
                     output<<cell_geom<<" ";
                 }
                 edm::LogProblem("BadModule")<<output.str();
+                throw cms::Exception("BadModule")<<"Cell <-> module inconsistency";
             }
         }
     }
@@ -522,10 +526,11 @@ void HGCalTriggerGeomTester::checkNeighborConsistency()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id);
+        unsigned wafer_type = (triggerGeometry_->eeTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->eeTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->eeTopology().valid(id)) continue;
             // fill trigger cells
             // Skip trigger cells in module 0
@@ -541,10 +546,11 @@ void HGCalTriggerGeomTester::checkNeighborConsistency()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id);
+        unsigned wafer_type = (triggerGeometry_->fhTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->fhTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->fhTopology().valid(id)) continue;
             // fill trigger cells
             // Skip trigger cells in module 0
@@ -590,6 +596,7 @@ void HGCalTriggerGeomTester::checkNeighborConsistency()
                     output<<"  "<< HGCalDetId(neighbor_of_neighbor)<<"\n";
                 }
                 edm::LogProblem("BadNeighbor")<<output.str();
+                throw cms::Exception("BadNeighbor")<<"Neighbor mapping not consistent";
             }
         }
     }
@@ -610,10 +617,11 @@ void HGCalTriggerGeomTester::fillTriggerGeometry()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id); 
+        unsigned wafer_type = (triggerGeometry_->eeTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->eeTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->eeTopology().valid(id)) continue;
             cellId_         = id.rawId();
             cellSide_       = id.zside();
@@ -660,10 +668,11 @@ void HGCalTriggerGeomTester::fillTriggerGeometry()
     {
         if(id.rawId()==0) continue;
         HGCalDetId waferid(id); 
+        unsigned wafer_type = (triggerGeometry_->fhTopology().dddConstants().waferTypeT(waferid.wafer())==2?0:1);
         int nCells = triggerGeometry_->fhTopology().dddConstants().numberCellsHexagon(waferid.wafer());
         for(int i=0;i<nCells;i++)
         {
-            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), waferid.waferType(), waferid.wafer(), i);
+            HGCalDetId id(ForwardSubdetector(waferid.subdetId()), waferid.zside(), waferid.layer(), wafer_type, waferid.wafer(), i);
             if(!triggerGeometry_->fhTopology().valid(id)) continue;
             cellId_         = id.rawId();
             cellSide_       = id.zside();


### PR DESCRIPTION
* The wafer type value used to build cell ids from trigger cells was not correct.
* Fix also the wafer type of the cells used to test the geometry.