### PR TITLE
Use unordered_map instead of map

### DIFF
--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
@@ -12,8 +12,8 @@ class HGCalVFECompressionImpl
  public:
   HGCalVFECompressionImpl(const edm::ParameterSet& conf);
 
-  void compress(const std::map<HGCalDetId, uint32_t>&,
-                std::map<HGCalDetId, std::array<uint32_t, 2> >&);
+  void compress(const std::unordered_map<uint32_t, uint32_t>&,
+                std::unordered_map<uint32_t, std::array<uint32_t, 2> >&);
 
  private:
   void compressSingle(const uint32_t value,

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
@@ -18,7 +18,7 @@ class HGCalVFESummationImpl
   
   void triggerCellSums(const HGCalTriggerGeometryBase& ,
                        const std::vector<std::pair<DetId, uint32_t > >&,
-                       std::map<HGCalDetId, uint32_t>& payload);
+                       std::unordered_map<uint32_t, uint32_t>& payload);
   const std::vector<double>& thicknessCorrections() const {return thickness_corrections_;} 
    
  private:

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -29,8 +29,8 @@ HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
 
   std::vector<HGCalDataFrame> dataframes;
   std::vector<std::pair<DetId, uint32_t >> linearized_dataframes;
-  std::map<HGCalDetId, uint32_t> payload;
-  std::map<HGCalDetId, std::array<uint32_t, 2> > compressed_payload;
+  std::unordered_map<uint32_t, uint32_t> payload;
+  std::unordered_map<uint32_t, std::array<uint32_t, 2> > compressed_payload;
 
   // convert ee and fh hit collections into the same object  
   for(const auto& digiData : digiColl)
@@ -53,10 +53,10 @@ HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for(const auto& id_value : payload)
   { 
     if (id_value.second>0){
-      l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), compressed_payload[id_value.first][1], 0, 0, 0, id_value.first.rawId());
+      l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), compressed_payload[id_value.first][1], 0, 0, 0, id_value.first);
       triggerCell.setCompressedCharge(compressed_payload[id_value.first][0]);
       triggerCell.setUncompressedCharge(id_value.second);
-      GlobalPoint point = geometry_->getTriggerCellPosition(id_value.first.rawId());
+      GlobalPoint point = geometry_->getTriggerCellPosition(id_value.first);
       
       // 'value' is hardware, so p4 is meaningless, except for eta and phi
       math::PtEtaPhiMLorentzVector p4((double)id_value.second/cosh(point.eta()), point.eta(), point.phi(), 0.);

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFECompressionImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFECompressionImpl.cc
@@ -72,8 +72,8 @@ compressSingle(const uint32_t value,
 
 void
 HGCalVFECompressionImpl::
-compress(const std::map<HGCalDetId, uint32_t>& payload,
-         std::map<HGCalDetId, std::array<uint32_t, 2> >& compressed_payload)
+compress(const std::unordered_map<uint32_t, uint32_t>& payload,
+         std::unordered_map<uint32_t, std::array<uint32_t, 2> >& compressed_payload)
 {
   for (const auto& item : payload) {
     const uint32_t value = item.second;

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -9,7 +9,7 @@ void
 HGCalVFESummationImpl::
 triggerCellSums(const HGCalTriggerGeometryBase& geometry, 
                 const std::vector<std::pair<DetId, uint32_t > >& linearized_dataframes,
-                std::map<HGCalDetId, uint32_t>& payload)
+                std::unordered_map<uint32_t, uint32_t>& payload)
 {
   if(linearized_dataframes.empty()) return;
   // sum energies in trigger cells
@@ -19,8 +19,7 @@ triggerCellSums(const HGCalTriggerGeometryBase& geometry,
 
     // find trigger cell associated to cell
     uint32_t tcid = geometry.getTriggerCellFromCell(cellid);
-    HGCalDetId triggercellid( tcid );
-    payload.emplace(triggercellid, 0); // do nothing if key exists already
+    payload.emplace(tcid, 0); // do nothing if key exists already
     uint32_t value = frame.second;
     unsigned det = cellid.det();
     // equalize value among cell thicknesses for Silicon parts
@@ -52,8 +51,8 @@ triggerCellSums(const HGCalTriggerGeometryBase& geometry,
       value = (double)value*thickness_correction;
     }
 
-    // sums energy for the same triggercellid
-    payload[triggercellid] += value; // 32 bits integer should be largely enough 
+    // sums energy for the same trigger cell id
+    payload[tcid] += value; // 32 bits integer should be largely enough 
   }
 
 }


### PR DESCRIPTION
For optimization purpose (constant time access instead of log). Need to switch from `HGCalDetId` key to raw detid due to the lack of hash function.