### PR TITLE
Add thickness utility in trigger tools

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -41,6 +41,7 @@ class HGCalTriggerTools {
     unsigned layers(ForwardSubdetector type) const;
     unsigned layer(const DetId&) const;
     unsigned layerWithOffset(const DetId&) const;
+    int thicknessIndex(const DetId&) const;
 
     unsigned lastLayerEE() const {return eeLayers_;}
     unsigned lastLayerFH() const {return eeLayers_+fhLayers_;}

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
@@ -16,6 +17,7 @@ class HGCalVFESummationImpl
  public:
   HGCalVFESummationImpl(const edm::ParameterSet& conf);
   
+  void eventSetup(const edm::EventSetup& es) {triggerTools_.eventSetup(es);}
   void triggerCellSums(const HGCalTriggerGeometryBase& ,
                        const std::vector<std::pair<DetId, uint32_t > >&,
                        std::unordered_map<uint32_t, uint32_t>& payload);
@@ -23,6 +25,7 @@ class HGCalVFESummationImpl
    
  private:
   std::vector<double> thickness_corrections_;   
+  HGCalTriggerTools triggerTools_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -25,6 +25,7 @@ HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
                            l1t::HGCalTriggerCellBxCollection& triggerCellColl, 
                            const edm::EventSetup& es) 
 { 
+  vfeSummationImpl_.eventSetup(es);
   calibration_.eventSetup(es);
 
   std::vector<HGCalDataFrame> dataframes;

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -142,6 +142,34 @@ layerWithOffset(const DetId& id) const {
   return l;
 }
 
+int
+HGCalTriggerTools::
+thicknessIndex(const DetId& id) const {
+  unsigned det = id.det();
+  int thickness = 0;
+  // For the v8 geometry
+  if(det==DetId::Forward)
+  {
+    switch(id.subdetId())
+    { 
+      case ForwardSubdetector::HGCEE:
+        thickness = geom_->eeTopology().dddConstants().waferTypeL(HGCalDetId(id).wafer())-1;
+        break;
+      case ForwardSubdetector::HGCHEF:
+        thickness = geom_->fhTopology().dddConstants().waferTypeL(HGCalDetId(id).wafer())-1;
+        break;
+      default:
+        break;
+    };
+  }
+  // For the v9 geometry
+  else if(det==DetId::HGCalEE || det==DetId::HGCalHSi)
+  {
+    thickness = HGCSiliconDetId(id).type();
+  }
+  return thickness;
+}
+
 float HGCalTriggerTools::getEta(const GlobalPoint& position, const float& vertex_z) const {
   GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z()-vertex_z);
   return corrected_position.eta();

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -25,28 +25,7 @@ triggerCellSums(const HGCalTriggerGeometryBase& geometry,
     // equalize value among cell thicknesses for Silicon parts
     if(det==DetId::Forward || det==DetId::HGCalEE || det==DetId::HGCalHSi)
     {
-      int thickness = 0;
-      // For the v8 geometry
-      if(det==DetId::Forward)
-      {
-        switch(cellid.subdetId())
-        { 
-          case ForwardSubdetector::HGCEE:
-            thickness = geometry.eeTopology().dddConstants().waferTypeL(HGCalDetId(cellid).wafer())-1;
-            break;
-          case ForwardSubdetector::HGCHEF:
-            thickness = geometry.fhTopology().dddConstants().waferTypeL(HGCalDetId(cellid).wafer())-1;
-            break;
-          default:
-            break;
-        };
-      }
-      // For the v9 geometry
-      else if(det==DetId::HGCalEE || det==DetId::HGCalHSi)
-      {
-        thickness = HGCSiliconDetId(cellid).type();
-      }
-
+      int thickness = triggerTools_.thicknessIndex(cellid);
       double thickness_correction = thickness_corrections_.at(thickness);
       value = (double)value*thickness_correction;
     }


### PR DESCRIPTION
Can now retrieve silicon thickness index (currently used for calibration) from `HGCalTriggerTools`. Both V8- and V9-geometry ways are implemented.