### PR TITLE
Fix implementations configurations

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalMulticlusteringHistoImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalMulticlusteringHistoImpl.h
@@ -71,12 +71,12 @@ private:
     std::vector<unsigned> binsSumsHisto_;
     double histoThreshold_ = 20.;
     std::vector<double> neighbour_weights_;
-    static constexpr unsigned neighbour_weights_size_ = 9;
 
     HGCalShowerShape shape_;
     HGCalTriggerTools triggerTools_;
     std::unique_ptr<HGCalTriggerClusterIdentificationBase> id_;
 
+    static constexpr unsigned neighbour_weights_size_ = 9;
     static constexpr double kROverZMin_ = 0.09;
     static constexpr double kROverZMax_ = 0.52;
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -12,13 +12,20 @@
 class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBase 
 { 
 
+  private:
+    enum SelectionType{
+      thresholdSelect,
+      bestChoiceSelect,
+      superTriggerCellSelect
+    };
+
   public:
     HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf);
   
     void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput, l1t::HGCalTriggerCellBxCollection& triggerCellCollOutput, const edm::EventSetup& es) override;
 
   private:
-    std::string choice_;
+    SelectionType selectionType_;
     
     std::unique_ptr<HGCalConcentratorSelectionImpl> concentratorProcImpl_;
     std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> concentratorSTCImpl_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -20,8 +20,8 @@ class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBas
   private:
     std::string choice_;
     
-    HGCalConcentratorSelectionImpl concentratorProcImpl_;
-    HGCalConcentratorSuperTriggerCellImpl concentratorSTCImpl_;
+    std::unique_ptr<HGCalConcentratorSelectionImpl> concentratorProcImpl_;
+    std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> concentratorSTCImpl_;
      
     HGCalTriggerTools triggerTools_;
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFEProcessorSums.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFEProcessorSums.h
@@ -28,10 +28,10 @@ class HGCalVFEProcessorSums : public HGCalVFEProcessorBase
 	             
   private:
           
-    HGCalVFELinearizationImpl vfeLinearizationImpl_;
-    HGCalVFESummationImpl vfeSummationImpl_; 
-    HGCalVFECompressionImpl vfeCompressionImpl_;
-    HGCalTriggerCellCalibration calibration_;
+    std::unique_ptr<HGCalVFELinearizationImpl> vfeLinearizationImpl_;
+    std::unique_ptr<HGCalVFESummationImpl> vfeSummationImpl_; 
+    std::unique_ptr<HGCalVFECompressionImpl> vfeCompressionImpl_;
+    std::unique_ptr<HGCalTriggerCellCalibration> calibration_;
 
 };    
     

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -16,9 +16,9 @@ class HGCalTowerMapProcessor : public HGCalTowerMapProcessorBase
   public:
 
     HGCalTowerMapProcessor(const edm::ParameterSet& conf) :
-    HGCalTowerMapProcessorBase(conf),
-    towermap2D_( conf.getParameterSet("towermap_parameters") )
+    HGCalTowerMapProcessorBase(conf)
     {
+      towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>( conf.getParameterSet("towermap_parameters") );
     }
                 
     void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
@@ -26,7 +26,7 @@ class HGCalTowerMapProcessor : public HGCalTowerMapProcessorBase
              const edm::EventSetup& es) override
     {
       es.get<CaloGeometryRecord>().get("", triggerGeometry_);
-      towermap2D_.eventSetup(es);
+      towermap2D_->eventSetup(es);
       
       /* create a persistent vector of pointers to the trigger-cells */
       std::vector<edm::Ptr<l1t::HGCalTriggerCell>> triggerCellsPtrs;
@@ -36,7 +36,7 @@ class HGCalTowerMapProcessor : public HGCalTowerMapProcessorBase
       }    
 
       /* call to towerMap2D clustering */
-      towermap2D_.buildTowerMap2D( triggerCellsPtrs, collTowerMap); 
+      towermap2D_->buildTowerMap2D( triggerCellsPtrs, collTowerMap); 
     }               
 
     
@@ -45,7 +45,7 @@ class HGCalTowerMapProcessor : public HGCalTowerMapProcessorBase
     edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
     /* algorithms instances */
-    HGCalTowerMap2DImpl towermap2D_;
+    std::unique_ptr<HGCalTowerMap2DImpl> towermap2D_;
 };
 
 DEFINE_EDM_PLUGIN(HGCalTowerMapFactory, 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -16,9 +16,9 @@ class HGCalTowerProcessor : public HGCalTowerProcessorBase
   public:
 
     HGCalTowerProcessor(const edm::ParameterSet& conf) :
-    HGCalTowerProcessorBase(conf),
-    towermap3D_( )
+    HGCalTowerProcessorBase(conf)
     {
+      towermap3D_ = std::make_unique<HGCalTowerMap3DImpl>( );
     }          
             
     void run(const edm::Handle<l1t::HGCalTowerMapBxCollection>& collHandle,
@@ -35,7 +35,7 @@ class HGCalTowerProcessor : public HGCalTowerProcessorBase
       }
 
       /* call to towerMap3D clustering */
-      towermap3D_.buildTowerMap3D( towerMapsPtrs, collTowers);
+      towermap3D_->buildTowerMap3D( towerMapsPtrs, collTowers);
     }
 
    
@@ -44,7 +44,7 @@ class HGCalTowerProcessor : public HGCalTowerProcessorBase
       edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
       /* algorithms instances */
-      HGCalTowerMap3DImpl towermap3D_;
+      std::unique_ptr<HGCalTowerMap3DImpl> towermap3D_;
 };
 
 DEFINE_EDM_PLUGIN(HGCalTowerFactory, 

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -9,10 +9,10 @@ DEFINE_EDM_PLUGIN(HGCalConcentratorFactory,
 
 HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf)  : 
   HGCalConcentratorProcessorBase(conf),
-  choice_(conf.getParameter<std::string>("Method")),
-  concentratorProcImpl_(conf),
-  concentratorSTCImpl_(conf)
+  choice_(conf.getParameter<std::string>("Method"))
 { 
+  concentratorProcImpl_ = std::make_unique<HGCalConcentratorSelectionImpl>(conf);
+  concentratorSTCImpl_ = std::make_unique<HGCalConcentratorSuperTriggerCellImpl>(conf);
 }
 
 void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput, 
@@ -31,7 +31,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
   {
     for( const auto& module_trigcell : tc_modules ) {
       std::vector<l1t::HGCalTriggerCell> trigCellVecOutput;
-      concentratorProcImpl_.thresholdSelectImpl(module_trigcell.second, trigCellVecOutput);
+      concentratorProcImpl_->thresholdSelectImpl(module_trigcell.second, trigCellVecOutput);
       // Push trigger Cells for each module from std::vector<l1t::HGCalTriggerCell> into the final collection
       for( const auto& trigCell : trigCellVecOutput){
         triggerCellCollOutput.push_back(0, trigCell);     
@@ -41,7 +41,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
   else if (choice_ == "bestChoiceSelect"){
     for( const auto& module_trigcell : tc_modules ) {  
       std::vector<l1t::HGCalTriggerCell> trigCellVecOutput;
-      concentratorProcImpl_.bestChoiceSelectImpl(module_trigcell.second, trigCellVecOutput);     
+      concentratorProcImpl_->bestChoiceSelectImpl(module_trigcell.second, trigCellVecOutput);     
       // Push trigger Cells for each module from std::vector<l1t::HGCalTriggerCell> into the final collection
       for( const auto& trigCell : trigCellVecOutput){
         triggerCellCollOutput.push_back(0, trigCell);       
@@ -51,7 +51,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
   else if (choice_ == "superTriggerCellSelect"){
     for( const auto& module_trigcell : tc_modules ) {  
       std::vector<l1t::HGCalTriggerCell> trigCellVecOutput;
-      concentratorSTCImpl_.superTriggerCellSelectImpl( module_trigcell.second, trigCellVecOutput);
+      concentratorSTCImpl_->superTriggerCellSelectImpl( module_trigcell.second, trigCellVecOutput);
       
       // Push trigger Cells for each module from std::vector<l1t::HGCalTriggerCell> into the final collection
       for( auto trigCell = trigCellVecOutput.begin(); trigCell != trigCellVecOutput.end(); ++trigCell){


### PR DESCRIPTION
* Use `unique_ptr` for implementation instances and construct them only if requested to avoid passing incompatible parameters to the constructor.
* Also use `enum` in the concentrator processor to switch between the different algorithms