### PR TITLE
Better compatibility with V9 detid scheme

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -7,6 +7,8 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/ClusterShapes.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 /* ROOT */
 #include "Math/Vector3D.h"
@@ -62,7 +64,7 @@ namespace l1t
 
         if( constituents_.empty() )
         {
-          detId_ = HGCalDetId( c->detId() );
+          detId_ = DetId( c->detId() );
           seedMipPt_ = cMipt;
           /* if the centre will not be dynamically calculated
              the seed centre is considere as cluster centre */
@@ -122,21 +124,21 @@ namespace l1t
 
         for(const auto& id_constituent : constituents())
         {
+          DetId id(id_constituent.first);
           auto id_fraction = constituentsFraction_.find(id_constituent.first);
           double fraction = (id_fraction!=constituentsFraction_.end() ? id_fraction->second : 1.);
-          switch( id_constituent.second->subdetId() )
-          {
-            case HGCEE:
-              pt_em += id_constituent.second->pt() * fraction;
-              break;
-            case HGCHEF:
-              pt_had += id_constituent.second->pt() * fraction;
-              break;
-            case HGCHEB:
-              pt_had += id_constituent.second->pt() * fraction;
-              break;
-            default:
-              break;
+          if (id.det() == DetId::Forward && id.subdetId()==HGCEE) {
+            pt_em += id_constituent.second->pt() * fraction;
+          } else if (id.det() == DetId::HGCalEE) {
+            pt_em += id_constituent.second->pt() * fraction;
+          } else if(id.det() == DetId::Forward && id.subdetId()==HGCHEF) {
+            pt_had += id_constituent.second->pt() * fraction;
+          } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+            pt_had += id_constituent.second->pt() * fraction;
+          } else if (id.det() == DetId::HGCalHSi) {
+            pt_had += id_constituent.second->pt() * fraction;
+          } else if (id.det() == DetId::HGCalHSc) {
+            pt_had += id_constituent.second->pt() * fraction;
           }
         }
         if(pt_em>0) hOe = pt_had / pt_em ;
@@ -145,8 +147,8 @@ namespace l1t
       }
 
       uint32_t subdetId() const {return detId_.subdetId();} 
-      uint32_t layer() const {return detId_.layer();}
-      int32_t zside() const {return detId_.zside();}
+      // uint32_t layer() const {return detId_.layer();}
+      // int32_t zside() const {return detId_.zside();}
 
 
       //shower shape
@@ -189,7 +191,7 @@ namespace l1t
     private:
 
       bool valid_;
-      HGCalDetId detId_;
+      DetId detId_;
 
       std::unordered_map<uint32_t, edm::Ptr<C>> constituents_;
       std::unordered_map<uint32_t, double> constituentsFraction_;

--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -147,8 +147,6 @@ namespace l1t
       }
 
       uint32_t subdetId() const {return detId_.subdetId();} 
-      // uint32_t layer() const {return detId_.layer();}
-      // int32_t zside() const {return detId_.zside();}
 
 
       //shower shape

--- a/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
@@ -6,7 +6,6 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
-//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 namespace l1t 
 {
@@ -39,12 +38,6 @@ namespace l1t
             int subdetId() const {                
                 return detid_.subdetId();               
             }
-            // int zside() const {                
-                // return detid_.zside();               
-            // }
-            // int layer() const {                
-                // return detid_.layer();               
-            // }
             
             void   setMipPt( double value ) { mipPt_ = value; }
             double mipPt() const            { return mipPt_;  }

--- a/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
@@ -5,7 +5,8 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 namespace l1t 
 {
@@ -29,7 +30,7 @@ namespace l1t
 
             ~HGCalTriggerCell() override;
 
-            void setDetId(uint32_t detid) {detid_ = HGCalDetId(detid);}
+            void setDetId(uint32_t detid) {detid_ = DetId(detid);}
             void setPosition(const GlobalPoint& position) {position_ = position;}
 
             uint32_t detId() const {return detid_.rawId();}
@@ -38,12 +39,12 @@ namespace l1t
             int subdetId() const {                
                 return detid_.subdetId();               
             }
-            int zside() const {                
-                return detid_.zside();               
-            }
-            int layer() const {                
-                return detid_.layer();               
-            }
+            // int zside() const {                
+                // return detid_.zside();               
+            // }
+            // int layer() const {                
+                // return detid_.layer();               
+            // }
             
             void   setMipPt( double value ) { mipPt_ = value; }
             double mipPt() const            { return mipPt_;  }
@@ -56,7 +57,7 @@ namespace l1t
             
         private:
             
-            HGCalDetId detid_;
+            DetId detid_;
             GlobalPoint position_;
             
             double mipPt_{0.};

--- a/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
@@ -5,7 +5,8 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 namespace l1t 
 {
@@ -29,25 +30,25 @@ namespace l1t
 
             ~HGCalTriggerSums() override;
 
-            void setDetId(uint32_t detid) {detid_ = HGCalDetId(detid);}
+            void setDetId(uint32_t detid) {detid_ = DetId(detid);}
             void setPosition(const GlobalPoint& position) {position_ = position;}
 
             uint32_t detId() const {return detid_.rawId();}
             const GlobalPoint& position() const {return position_;}
             
-            int zside() const {                
-                return detid_.zside();               
-            }
-            int layer() const {                
-                return detid_.layer();               
-            }
+            // int zside() const {                
+                // return detid_.zside();               
+            // }
+            // int layer() const {                
+                // return detid_.layer();               
+            // }
             
             void   setMipPt( double value ) { mipPt_ = value; }
             double mipPt() const            { return mipPt_;  }
             
         private:
             
-            HGCalDetId detid_;
+            DetId detid_;
             GlobalPoint position_;
             
             double mipPt_;

--- a/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
@@ -6,7 +6,6 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 namespace l1t 
 {
@@ -36,12 +35,6 @@ namespace l1t
             uint32_t detId() const {return detid_.rawId();}
             const GlobalPoint& position() const {return position_;}
             
-            // int zside() const {                
-                // return detid_.zside();               
-            // }
-            // int layer() const {                
-                // return detid_.layer();               
-            // }
             
             void   setMipPt( double value ) { mipPt_ = value; }
             double mipPt() const            { return mipPt_;  }

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -30,7 +30,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerSums>" />
-  <class name="l1t::HGCalCluster" ClassVersion="14">
+  <class name="l1t::HGCalCluster" ClassVersion="15">
+   <version ClassVersion="15" checksum="2522149132"/>
   <version ClassVersion="14" checksum="3289642235"/>
   <version ClassVersion="13" checksum="3397489079"/>
   <version ClassVersion="12" checksum="623703096"/>
@@ -42,7 +43,8 @@
   <class name="edm::Wrapper<l1t::HGCalClusterBxCollection>"/>
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
-  <class name="l1t::HGCalMulticluster" ClassVersion="14">
+  <class name="l1t::HGCalMulticluster" ClassVersion="15">
+   <version ClassVersion="15" checksum="777879934"/>
   <version ClassVersion="14" checksum="2315302819"/>
   <version ClassVersion="13" checksum="816077951"/>
   <version ClassVersion="12" checksum="4221677522"/>
@@ -53,7 +55,8 @@
   <class name="l1t::HGCalMulticlusterBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalMulticlusterBxCollection>"/>
 
-  <class name="l1t::HGCalTriggerCell" ClassVersion="11">
+  <class name="l1t::HGCalTriggerCell" ClassVersion="12">
+   <version ClassVersion="12" checksum="3538848072"/>
    <version ClassVersion="11" checksum="646735227"/>
     <version ClassVersion="10" checksum="1275348814"/>
   </class>
@@ -61,7 +64,8 @@
   <class name="l1t::HGCalTriggerCellBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTriggerCellBxCollection>"/>
   
-  <class name="l1t::HGCalTriggerSums" ClassVersion="11">
+  <class name="l1t::HGCalTriggerSums" ClassVersion="12">
+   <version ClassVersion="12" checksum="1802885417"/>
     <version ClassVersion="11" checksum="4058188392"/>
   </class>
   <class name="std::vector<l1t::HGCalTriggerSums>" />

--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="Geometry/Records"/>
 <use   name="DataFormats/L1THGCal"/>
 <use   name="CommonTools/Utils"/>
+<use   name="SimDataFormats/CaloTest"/>
 
 <export>
   <lib   name="1"/>

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -41,6 +41,7 @@ class HGCalTriggerTools {
     unsigned layers(ForwardSubdetector type) const;
     unsigned layer(const DetId&) const;
     unsigned layerWithOffset(const DetId&) const;
+    int zside(const DetId&) const;
     int thicknessIndex(const DetId&) const;
 
     unsigned lastLayerEE() const {return eeLayers_;}

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -21,6 +21,8 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 class HGCalTriggerGeometryBase;
 class DetId;
@@ -72,6 +74,9 @@ class HGCalTriggerTools {
       outputVector.insert(outputVector.end(), inputBXVector.begin(0), inputBXVector.end(0));
       return outputVector;
     }
+
+    DetId simToReco(const DetId&, const HGCalTopology&) const ;
+    DetId simToReco(const DetId&, const HcalTopology&) const ;
 
   private:
     const HGCalTriggerGeometryBase* geom_;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
@@ -39,6 +40,7 @@ class HGCalTriggerTools {
     void eventSetup(const edm::EventSetup&);
     GlobalPoint getTCPosition(const DetId& id) const;
     unsigned layers(ForwardSubdetector type) const;
+    unsigned layers(DetId::Detector type) const ;
     unsigned layer(const DetId&) const;
     unsigned layerWithOffset(const DetId&) const;
     int zside(const DetId&) const;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -12,6 +12,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 #include <vector>
 #include <unordered_map>
@@ -27,6 +28,11 @@ class HGCalTriggerTowerGeometryHelper {
     HGCalTriggerTowerGeometryHelper(const edm::ParameterSet& conf);
 
     ~HGCalTriggerTowerGeometryHelper() {}
+
+    void eventSetup(const edm::EventSetup& es) 
+    {
+        triggerTools_.eventSetup(es);
+    }
 
     const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 
@@ -46,6 +52,8 @@ class HGCalTriggerTowerGeometryHelper {
 
     std::vector<double> binsEta_;
     std::vector<double> binsPhi_;
+
+    HGCalTriggerTools triggerTools_;
 
   };
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
@@ -6,7 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
@@ -6,7 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+//#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
@@ -25,6 +25,7 @@ class HGCalTowerMap2DImpl{
 
   void eventSetup(const edm::EventSetup& es) {
         triggerTools_.eventSetup(es);
+        towerGeometryHelper_.eventSetup(es);
   }
 
  private:

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
@@ -9,7 +9,6 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
@@ -9,7 +9,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
@@ -4,7 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 class HGCalVFECompressionImpl
 {

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
@@ -4,7 +4,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 class HGCalVFECompressionImpl
 {

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -137,8 +137,9 @@ initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
     bhOffset_ = fhOffset_ + fhTopology().dddConstants().layers(true);
     totalLayers_ =  bhOffset_ + bhTopology().dddConstants()->getMaxDepth(1);
     trigger_layers_.resize(totalLayers_+1);
-    unsigned trigger_layer = 0;
-    for(unsigned layer=0; layer<trigger_layers_.size(); layer++)
+    trigger_layers_[0] = 0; // layer number 0 doesn't exist
+    unsigned trigger_layer = 1;
+    for(unsigned layer=1; layer<trigger_layers_.size(); layer++)
     {
         if(disconnected_layers_.find(layer)==disconnected_layers_.end())
         {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
@@ -160,8 +160,9 @@ initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
     heOffset_ = eeTopology().dddConstants().layers(true);
     totalLayers_ = heOffset_ + hsiTopology().dddConstants().layers(true);
     trigger_layers_.resize(totalLayers_+1);
-    unsigned trigger_layer = 0;
-    for(unsigned layer=0; layer<totalLayers_; layer++)
+    trigger_layers_[0] = 0; // layer number 0 doesn't exist
+    unsigned trigger_layer = 1;
+    for(unsigned layer=1; layer<trigger_layers_.size(); layer++)
     {
         if(disconnected_layers_.find(layer)==disconnected_layers_.end())
         {

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-// #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCPanels.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCPanels.cc
@@ -1,6 +1,6 @@
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCPanels.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCPanels.cc
@@ -1,6 +1,6 @@
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -5,7 +5,7 @@
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -5,7 +5,7 @@
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -271,39 +271,28 @@ simhits(const edm::Event& e, std::unordered_map<uint32_t, double>& simhits_ee, s
   const edm::PCaloHitContainer& bh_simhits = *bh_simhits_h;
 
   //EE
-  int layer=0,cell=0, sec=0, subsec=0, zp=0,subdet=0;
-  ForwardSubdetector mysubdet;
   for( const auto& simhit : ee_simhits )
   { 
-    HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell); 
-    mysubdet = (ForwardSubdetector)subdet;
-    std::pair<int,int> recoLayerCell = geometry_->eeTopology().dddConstants().simToReco(cell,layer,sec,geometry_->eeTopology().detectorType());
-    cell  = recoLayerCell.first;
-    layer = recoLayerCell.second;
-    if (layer<0 || cell<0) continue;
-    auto itr_insert = simhits_ee.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->eeTopology());
+    if(id.rawId()==0) continue;
+    auto itr_insert = simhits_ee.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }
-
   //  FH
-  layer=0; cell=0; sec=0; subsec=0; zp=0; subdet=0;
   for( const auto& simhit : fh_simhits ) 
   { 
-    HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell); 
-    mysubdet = (ForwardSubdetector)(subdet);
-    std::pair<int,int> recoLayerCell = geometry_->fhTopology().dddConstants().simToReco(cell,layer,sec,geometry_->fhTopology().detectorType());
-    cell  = recoLayerCell.first;
-    layer = recoLayerCell.second;
-    if (layer<0 || cell<0) continue;
-    auto itr_insert = simhits_fh.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->fhTopology());
+    if(id.rawId()==0) continue;
+    auto itr_insert = simhits_fh.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }      
-
   //  BH
   for( const auto& simhit : bh_simhits ) 
   { 
-    HcalDetId id = HcalHitRelabeller::relabel(simhit.id(), geometry_->bhTopology().dddConstants());
-    if (id.subdetId()!=HcalEndcap) continue;
+    DetId id = (geometry_->isV9Geometry() ?
+        triggerTools_.simToReco(simhit.id(), geometry_->hscTopology()) :
+        triggerTools_.simToReco(simhit.id(), geometry_->bhTopology()) );
+    if(id.rawId()==0) continue;
     auto itr_insert = simhits_bh.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }      

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 DEFINE_EDM_PLUGIN(HGCalVFEProcessorBaseFactory, 
         HGCalVFEProcessorSums,

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 DEFINE_EDM_PLUGIN(HGCalVFEProcessorBaseFactory, 
         HGCalVFEProcessorSums,

--- a/L1Trigger/L1THGCal/python/customNtuples.py
+++ b/L1Trigger/L1THGCal/python/customNtuples.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+def custom_ntuples_V9(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCDigis' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells':
+            ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
+    return process

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
@@ -4,5 +4,8 @@ from L1Trigger.L1THGCal.hgcalTriggerNtuples_cfi import *
 
 hgcalTriggerNtuples = cms.Sequence(hgcalTriggerNtuplizer)
 
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+from L1Trigger.L1THGCal.customNtuples import custom_ntuples_V9
+modifyHgcalTriggerNtuplesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_ntuples_V9)
 
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -49,7 +49,7 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(False)
+    isSimhitComp = cms.bool(True)
 )
 
 ntuple_triggercells = cms.PSet(
@@ -59,7 +59,7 @@ ntuple_triggercells = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    FillSimEnergy = cms.bool(False),
+    FillSimEnergy = cms.bool(True),
     fcPerMip = fcPerMip,
     keV2fC = keV2fC,
     layerWeights = layerWeights,

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cfi.py
@@ -49,7 +49,7 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(True)
+    isSimhitComp = cms.bool(False)
 )
 
 ntuple_triggercells = cms.PSet(
@@ -59,7 +59,7 @@ ntuple_triggercells = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    FillSimEnergy = cms.bool(True),
+    FillSimEnergy = cms.bool(False),
     fcPerMip = fcPerMip,
     keV2fC = keV2fC,
     layerWeights = layerWeights,

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -5,10 +5,10 @@
 
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
+#include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -278,4 +278,49 @@ float HGCalTriggerTools::getLayerZ(const int& subdet, const unsigned& layer) con
     }
   }
   return layerGlobalZ;
+}
+
+
+DetId
+HGCalTriggerTools::
+simToReco(const DetId& simid, const HGCalTopology& topo) const 
+{
+    DetId recoid(0);
+    const auto& dddConst = topo.dddConstants();
+    // V9
+    if (dddConst.geomMode() == HGCalGeometryMode::Hexagon8 ||
+        dddConst.geomMode() == HGCalGeometryMode::Hexagon8Full ||
+        dddConst.geomMode() == HGCalGeometryMode::Trapezoid)
+    {
+        recoid = simid;
+    }
+    // V8
+    else
+    {
+        int subdet(simid.subdetId());
+        int layer=0, cell=0, sec=0, subsec=0, zp=0;
+        HGCalTestNumbering::unpackHexagonIndex(simid, subdet, zp, layer, sec, subsec, cell);
+        //sec is wafer and subsec is celltype
+        //skip this hit if after ganging it is not valid
+        auto recoLayerCell = dddConst.simToReco(cell,layer,sec,topo.detectorType());
+        cell  = recoLayerCell.first;
+        layer = recoLayerCell.second;
+        if (layer>=0 && cell>=0) 
+        {
+            recoid = HGCalDetId((ForwardSubdetector)subdet,zp,layer,subsec,sec,cell);
+        }
+    }
+    return recoid;
+}
+
+
+DetId
+HGCalTriggerTools::
+simToReco(const DetId& simid, const HcalTopology& topo) const 
+{
+    DetId recoid(0);
+    const auto& dddConst = topo.dddConstants();
+    HcalDetId id = HcalHitRelabeller::relabel(simid,dddConst);
+    if (id.subdet()==int(HcalEndcap)) recoid = id;
+    return recoid;
 }

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -116,6 +116,33 @@ layers(ForwardSubdetector type) const
 
 unsigned
 HGCalTriggerTools::
+layers(DetId::Detector type) const
+{
+
+  unsigned layers = 0;
+  switch (type)
+  {
+    case DetId::HGCalEE:
+      layers = eeLayers_;
+      break;
+    case DetId::HGCalHSi:
+      layers = fhLayers_;
+      break;
+    case DetId::HGCalHSc:
+      layers = bhLayers_;
+      break;
+    case DetId::Forward:
+      layers = totalLayers_;
+      break;
+    default:
+      break;
+  }
+  return layers;
+}
+
+
+unsigned
+HGCalTriggerTools::
 layer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
   if (id.det() == DetId::Forward) {

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -285,32 +285,32 @@ DetId
 HGCalTriggerTools::
 simToReco(const DetId& simid, const HGCalTopology& topo) const 
 {
-    DetId recoid(0);
-    const auto& dddConst = topo.dddConstants();
-    // V9
-    if (dddConst.geomMode() == HGCalGeometryMode::Hexagon8 ||
-        dddConst.geomMode() == HGCalGeometryMode::Hexagon8Full ||
-        dddConst.geomMode() == HGCalGeometryMode::Trapezoid)
+  DetId recoid(0);
+  const auto& dddConst = topo.dddConstants();
+  // V9
+  if (dddConst.geomMode() == HGCalGeometryMode::Hexagon8 ||
+      dddConst.geomMode() == HGCalGeometryMode::Hexagon8Full ||
+      dddConst.geomMode() == HGCalGeometryMode::Trapezoid)
+  {
+    recoid = simid;
+  }
+  // V8
+  else
+  {
+    int subdet(simid.subdetId());
+    int layer=0, cell=0, sec=0, subsec=0, zp=0;
+    HGCalTestNumbering::unpackHexagonIndex(simid, subdet, zp, layer, sec, subsec, cell);
+    //sec is wafer and subsec is celltype
+    //skip this hit if after ganging it is not valid
+    auto recoLayerCell = dddConst.simToReco(cell,layer,sec,topo.detectorType());
+    cell  = recoLayerCell.first;
+    layer = recoLayerCell.second;
+    if (layer>=0 && cell>=0) 
     {
-        recoid = simid;
+      recoid = HGCalDetId((ForwardSubdetector)subdet,zp,layer,subsec,sec,cell);
     }
-    // V8
-    else
-    {
-        int subdet(simid.subdetId());
-        int layer=0, cell=0, sec=0, subsec=0, zp=0;
-        HGCalTestNumbering::unpackHexagonIndex(simid, subdet, zp, layer, sec, subsec, cell);
-        //sec is wafer and subsec is celltype
-        //skip this hit if after ganging it is not valid
-        auto recoLayerCell = dddConst.simToReco(cell,layer,sec,topo.detectorType());
-        cell  = recoLayerCell.first;
-        layer = recoLayerCell.second;
-        if (layer>=0 && cell>=0) 
-        {
-            recoid = HGCalDetId((ForwardSubdetector)subdet,zp,layer,subsec,sec,cell);
-        }
-    }
-    return recoid;
+  }
+  return recoid;
 }
 
 
@@ -318,9 +318,9 @@ DetId
 HGCalTriggerTools::
 simToReco(const DetId& simid, const HcalTopology& topo) const 
 {
-    DetId recoid(0);
-    const auto& dddConst = topo.dddConstants();
-    HcalDetId id = HcalHitRelabeller::relabel(simid,dddConst);
-    if (id.subdet()==int(HcalEndcap)) recoid = id;
-    return recoid;
+  DetId recoid(0);
+  const auto& dddConst = topo.dddConstants();
+  HcalDetId id = HcalHitRelabeller::relabel(simid,dddConst);
+  if (id.subdet()==int(HcalEndcap)) recoid = id;
+  return recoid;
 }

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -118,12 +118,14 @@ unsigned
 HGCalTriggerTools::
 layer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
-  if( id.det() == DetId::Forward) {
-    const HGCalDetId hid(id);
-    layer = hid.layer();
-  } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
-    const HcalDetId hcid(id);
-    layer = hcid.depth();
+  if (id.det() == DetId::Forward) {
+    layer = HGCalDetId(id).layer();
+  } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+    layer = HcalDetId(id).depth();
+  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+    layer = HGCSiliconDetId(id).layer();
+  } else if (id.det() == DetId::HGCalHSc) {
+    layer = HGCScintillatorDetId(id).layer();
   }
   return layer;
 }
@@ -140,6 +142,22 @@ layerWithOffset(const DetId& id) const {
     else l += eeLayers_ + fhLayers_;
   }
   return l;
+}
+
+int
+HGCalTriggerTools::
+zside(const DetId& id) const {
+  int zside = 0;
+  if (id.det() == DetId::Forward) {
+    zside = HGCalDetId(id).zside();
+  } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+    zside = HcalDetId(id).zside();
+  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+    zside = HGCSiliconDetId(id).zside();
+  } else if (id.det() == DetId::HGCalHSc) {
+    zside = HGCScintillatorDetId(id).zside();
+  }
+  return zside;
 }
 
 int

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -118,7 +118,6 @@ unsigned
 HGCalTriggerTools::
 layers(DetId::Detector type) const
 {
-
   unsigned layers = 0;
   switch (type)
   {

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/DetId/interface/DetId.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cmath>

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -2,7 +2,8 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cmath>
@@ -77,7 +78,7 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
           << " to TT iEta: " << iEta << " iPhi: " << iPhi
           << " when max #bins eta: "  << nBinsEta_ << " phi: " << nBinsPhi_ << std::endl;
       }
-      l1t::HGCalTowerID towerId(HGCalDetId(trigger_cell_id).zside(), iEta, iPhi);
+      l1t::HGCalTowerID towerId(triggerTools_.zside(DetId(trigger_cell_id)), iEta, iPhi);
       cells_to_trigger_towers_[trigger_cell_id] = towerId.rawId();
     }
     l1tTriggerTowerMappingStream.close();

--- a/L1Trigger/L1THGCal/src/backend/HGCalClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalClusteringImpl.cc
@@ -31,11 +31,11 @@ bool HGCalClusteringImpl::isPertinent( const l1t::HGCalTriggerCell & tc,
                                        double distXY ) const 
 {
 
-    HGCalDetId tcDetId( tc.detId() );
-    HGCalDetId cluDetId( clu.detId() );
-    if( (tcDetId.layer() != cluDetId.layer()) ||
+    DetId tcDetId( tc.detId() );
+    DetId cluDetId( clu.detId() );
+    if( (triggerTools_.layer(tcDetId) != triggerTools_.layer(cluDetId)) ||
         (tcDetId.subdetId() != cluDetId.subdetId()) ||
-        (tcDetId.zside() != cluDetId.zside()) ){
+        (triggerTools_.zside(tcDetId) != triggerTools_.zside(cluDetId) )){
         return false;
     }   
     if ( clu.distance((tc)) < distXY ){
@@ -115,8 +115,8 @@ void HGCalClusteringImpl::triggerCellReshuffling( const std::vector<edm::Ptr<l1t
     ){
 
     for( const auto& tc : triggerCellsPtrs ){
-        int endcap = tc->zside() == -1 ? 0 : 1 ;
-        HGCalDetId tcDetId( tc->detId() );
+        DetId tcDetId( tc->detId() );
+        int endcap = triggerTools_.zside(tcDetId) == -1 ? 0 : 1 ;
         unsigned layer = triggerTools_.layerWithOffset(tc->detId());
         
         reshuffledTriggerCells[endcap][layer-1].emplace_back(tc);

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
@@ -81,7 +81,7 @@ HGCalMulticlusteringHistoImpl::Histogram HGCalMulticlusteringHistoImpl::fillHist
         int bin_R = int( (ROverZ-kROverZMin_) * nBinsRHisto_ / (kROverZMax_-kROverZMin_) );
         int bin_phi = int( (reco::reduceRange(clu->phi())+M_PI) * nBinsPhiHisto_ / (2*M_PI) );
 
-        histoClusters[{{clu->zside(), bin_R, bin_phi}}]+=clu->mipPt();
+        histoClusters[{{triggerTools_.zside(clu->detId()), bin_R, bin_phi}}]+=clu->mipPt();
 
     }
 
@@ -328,8 +328,7 @@ std::vector<l1t::HGCalMulticluster> HGCalMulticlusteringHistoImpl::clusterSeedMu
     for(auto & clu : clustersPtrs){
 
 
-        HGCalDetId cluDetId( clu->detId() );
-        int z_side = cluDetId.zside();
+        int z_side = triggerTools_.zside(clu->detId());
 
         double minDist = dr_;
         int targetSeed = -1;

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -1,7 +1,7 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <unordered_map>

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -89,8 +89,9 @@ int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d, const 
   std::vector<bool> layers(nlayers);
   for(const auto& id_cluster : clustersPtrs)
   {
-    int layer = triggerGeometry.triggerLayer(id_cluster.second->detId());
-    layers[layer-1] = true;
+    unsigned layer = triggerGeometry.triggerLayer(id_cluster.second->detId());
+    if(layer==0 || layer>nlayers) continue;
+    layers[layer-1] = true; //layer 0 doesn't exist, so shift by -1
   }
   int length = 0;
   int maxlength = 0;

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -1,7 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
-// #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <unordered_map>


### PR DESCRIPTION
* Make the code compatible with both the V8 and V9 geometries detid schemes.
  - Use generic `DetId` in the algorithms code
  - Encapsulate the choice between V8 and V9 detids in the `HGCalTriggerTools` and in the geometry classes
* Update HGC digis ntuplizer for the V9 geometry
* Fix in the trigger layers numbering