### PR TITLE
Save H/E in the Multicluster to avoid expensive recomputation

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalMulticluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalMulticluster.h
@@ -12,7 +12,7 @@ namespace l1t {
     
     public:
        
-      HGCalMulticluster(){}
+      HGCalMulticluster() : hOverEValid_(false) {}
       HGCalMulticluster( const LorentzVector p4,
           int pt=0,
           int eta=0,
@@ -23,7 +23,21 @@ namespace l1t {
       
       ~HGCalMulticluster() override;
 
+      bool hOverE() const { 
+        // --- this below would be faster when reading old objects, as HoE will only be computed once, 
+        // --- but it may not be allowed by CMS rules because of the const_cast
+        // if (!hOverEValid_) (const_cast<HGCalMulticluster*>(this))->saveHOverE();
+        // --- this below is safe in any case
+        return hOverEValid_ ? hOverE_ : l1t::HGCalClusterT<l1t::HGCalCluster>::hOverE(); 
+      }
 
+      void saveHOverE() { 
+        hOverE_ = l1t::HGCalClusterT<l1t::HGCalCluster>::hOverE(); 
+        hOverEValid_ = true;
+      }
+    private:
+      float hOverE_;
+      bool hOverEValid_;
   };
     
   typedef BXVector<HGCalMulticluster> HGCalMulticlusterBxCollection;  

--- a/DataFormats/L1THGCal/src/HGCalMulticluster.cc
+++ b/DataFormats/L1THGCal/src/HGCalMulticluster.cc
@@ -6,13 +6,17 @@ HGCalMulticluster::HGCalMulticluster( const LorentzVector p4,
                             int pt,
                             int eta,
                             int phi )
-   : HGCalClusterT<l1t::HGCalCluster>(p4, pt, eta, phi)
+   : HGCalClusterT<l1t::HGCalCluster>(p4, pt, eta, phi),
+     hOverE_(-99),
+     hOverEValid_(false)
 {
 }
 
 
 HGCalMulticluster::HGCalMulticluster( const edm::Ptr<l1t::HGCalCluster> &clusterSeed )
-    : HGCalClusterT<l1t::HGCalCluster>(clusterSeed)
+    : HGCalClusterT<l1t::HGCalCluster>(clusterSeed),
+      hOverE_(-99),
+      hOverEValid_(false)
 {
 }
 

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -43,7 +43,8 @@
   <class name="edm::Wrapper<l1t::HGCalClusterBxCollection>"/>
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
-  <class name="l1t::HGCalMulticluster" ClassVersion="15">
+  <class name="l1t::HGCalMulticluster" ClassVersion="16">
+   <version ClassVersion="16" checksum="1276395758"/>
    <version ClassVersion="15" checksum="777879934"/>
   <version ClassVersion="14" checksum="2315302819"/>
   <version ClassVersion="13" checksum="816077951"/>
@@ -51,6 +52,8 @@
   <version ClassVersion="11" checksum="1508179045"/>
   <version ClassVersion="10" checksum="1878482802"/>
   </class>
+  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverE_" source="" embed="false"> <![CDATA[ hOverE_ = -99; ]]> </ioread>
+  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverEValid_" source="" embed="false"> <![CDATA[ hOverEValid_ = false; ]]> </ioread>
   <class name="std::vector<l1t::HGCalMulticluster>" />
   <class name="l1t::HGCalMulticlusterBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalMulticlusterBxCollection>"/>

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
@@ -430,6 +430,8 @@ finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
             multicluster.eMax(shape_.eMax(multicluster));
             // fill quality flag
             multicluster.setHwQual(id_->decision(multicluster));
+            // fill H/E
+            multicluster.saveHOverE();            
 
             multiclusters_out.push_back( 0, multicluster);
         }

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
@@ -205,6 +205,8 @@ finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
             multicluster.eMax(shape_.eMax(multicluster));
             // fill quality flag
             multicluster.setHwQual(id_->decision(multicluster));
+            // fill H/E
+            multicluster.saveHOverE();            
 
             multiclusters_out.push_back( 0, multicluster);
         }


### PR DESCRIPTION
This should address #261 in the development branch.

I tested equivalent code in 10_1_X and was working fine (also uncommenting the option to recompute H/E only once). I can re-do the tests in 10_4_X or 10_3_X, but for that it would be helpful to have some suggestion on input files and cmsDriver command.