### PR TITLE
Fix thicknessIndex() for trigger cells

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -46,7 +46,10 @@ class HGCalTriggerTools {
     unsigned layer(const DetId&) const;
     unsigned layerWithOffset(const DetId&) const;
     int zside(const DetId&) const;
-    int thicknessIndex(const DetId&) const;
+    // tc argument is needed because of the impossibility
+    // to know whether the ID is a TC or a sensor cell
+    // in the v8 geometry detid scheme
+    int thicknessIndex(const DetId&, bool tc=false) const;
 
     unsigned lastLayerEE() const {return eeLayers_;}
     unsigned lastLayerFH() const {return eeLayers_+fhLayers_;}
@@ -84,6 +87,8 @@ class HGCalTriggerTools {
     unsigned fhLayers_;
     unsigned bhLayers_;
     unsigned totalLayers_;
+
+    int sensorCellThicknessV8(const DetId& id) const;
 };
 
 

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
-process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
+# For old samples use the digi converter
+#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
+process = cms.Process('DIGI',eras.Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
Implement thicknessIndex in trigger tools for the trigger cell detids with the V8 detid scheme (`HGCalDetId`).
Since sensor cells with different thicknesses can enter a trigger cell in the V8 geometry, a majority logic based on sensor cell thicknesses is used. 