### PR TITLE
Add multi-algo config utilities

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1THGCal.hgcalTriggerGeometryESProducer_cfi import *
-from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import *
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import *
-from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import *
-from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import *
-from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import *
-from L1Trigger.L1THGCal.hgcalTowerProducer_cfi import *
+from L1Trigger.L1THGCal.hgcalVFE_cff import *
+from L1Trigger.L1THGCal.hgcalConcentrator_cff import *
+from L1Trigger.L1THGCal.hgcalBackEndLayer1_cff import *
+from L1Trigger.L1THGCal.hgcalBackEndLayer2_cff import *
+from L1Trigger.L1THGCal.hgcalTowerMap_cff import *
+from L1Trigger.L1THGCal.hgcalTower_cff import *
 
 
-hgcalTriggerPrimitives = cms.Sequence(hgcalVFEProducer*hgcalConcentratorProducer*hgcalBackEndLayer1Producer*hgcalBackEndLayer2Producer*hgcalTowerMapProducer*hgcalTowerProducer)
+hgcalTriggerPrimitives = cms.Sequence(hgcalVFE*hgcalConcentrator*hgcalBackEndLayer1*hgcalBackEndLayer2*hgcalTowerMap*hgcalTower)
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+
+def create_distance(process, inputs,
+        distance=6.,# cm
+        seed_threshold=5.,# MipT
+        cluster_threshold=2.# MipT
+        ):
+    producer = process.hgcalBackEndLayer1Producer.clone() 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) 
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) 
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) 
+    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) 
+    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRC2d') 
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+    return producer
+
+def create_topological(process, inputs,
+        seed_threshold=5.,# MipT
+        cluster_threshold=2.# MipT
+        ):
+    producer = process.hgcalBackEndLayer1Producer.clone() 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('NNC2d') 
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+    return producer
+
+def create_constrainedtopological(process, inputs,
+        distance=6.,# cm
+        seed_threshold=5.,# MipT
+        cluster_threshold=2.# MipT
+        ):
+    producer = process.hgcalBackEndLayer1Producer.clone() 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
+    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) # cm
+    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRNNC2d') 
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+    return producer
+
+def create_dummy(process, inputs):
+    producer = process.hgcalBackEndLayer1Producer.clone() 
+    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dummyC2d')
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+    return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -8,6 +8,8 @@ def create_distance(process, inputs,
         ):
     producer = process.hgcalBackEndLayer2Producer.clone() 
     producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
+    producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster=cms.double(0.)
+    producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster=cms.uint32(0)
     producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('dRC3d')
     producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
@@ -18,6 +20,7 @@ def create_dbscan(process, inputs,
         min_points=3
         ):
     producer = process.hgcalBackEndLayer2Producer.clone() 
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(0.)
     producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster = cms.double(distance)
     producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster = cms.uint32(min_points)
     producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('DBSCANC3d')
@@ -26,7 +29,7 @@ def create_dbscan(process, inputs,
 
 
 def create_histoMax(process, inputs,
-        distance = 0.01,
+        distance = 0.03,
         nBins_R = 36,
         nBins_Phi = 216,
         binSumsHisto = binSums,                        
@@ -56,7 +59,7 @@ def create_histoMax_variableDr(process, inputs,
 
 
 def create_histoInterpolatedMax(process, inputs,
-        distance = 0.01,
+        distance = 0.03,
         nBins_R = 36,
         nBins_Phi = 216,
         binSumsHisto = binSums,
@@ -87,7 +90,7 @@ def create_histoInterpolatedMax2ndOrder(process, inputs):
 
 def create_histoThreshold(process, inputs,
         threshold = 20.,
-        distance = 0.01,
+        distance = 0.03,
         nBins_R = 36,
         nBins_Phi = 216,
         binSumsHisto = binSums,

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -1,0 +1,110 @@
+import FWCore.ParameterSet.Config as cms
+
+binSums = cms.vuint32(13,               #0
+                      11, 11, 11,       # 1 - 3
+                      9, 9, 9,          # 4 - 6
+                      7, 7, 7, 7, 7, 7, # 7 - 12
+                      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
+                      3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
+                      )
+
+def create_distance(process, inputs,
+        distance=6.,# cm
+        seed_threshold=5.,# MipT
+        cluster_threshold=2.# MipT
+        ):
+    producer = process.hgcalBackEndLayer1Producer.clone() 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) 
+    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) 
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) 
+    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) 
+    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) 
+    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRC2d') 
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+    return producer
+
+
+def create_distance(process, inputs,
+        distance=0.01
+        ):
+    producer = process.hgcalBackEndLayer2Producer.clone() 
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
+    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('dRC3d')
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+    return producer
+
+
+def create_dbscan(process, inputs,
+        distance=0.005,
+        min_points=3
+        ):
+    producer = process.hgcalBackEndLayer2Producer.clone() 
+    producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster = cms.double(distance)
+    producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster = cms.uint32(min_points)
+    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('DBSCANC3d')
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+    return producer
+
+
+def create_histoMax(process, inputs,
+        distance = 0.01,
+        nBins_R = 36,
+        nBins_Phi = 216,
+        binSumsHisto = binSums,                        
+        ):
+    producer = process.hgcalBackEndLayer2Producer.clone() 
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
+    producer.ProcessorParameters.C3d_parameters.nBins_R_histo_multicluster = cms.uint32(nBins_R)
+    producer.ProcessorParameters.C3d_parameters.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
+    producer.ProcessorParameters.C3d_parameters.binSumsHisto = binSumsHisto
+    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoMaxC3d')
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+    return producer
+
+
+def create_histoInterpolatedMax(process, inputs,
+        distance = 0.01,
+        nBins_R = 36,
+        nBins_Phi = 216,
+        binSumsHisto = binSums,
+        ):
+    producer = create_histoMax( process, distance, nBins_R, nBins_Phi, binSumsHisto )    
+    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoInterpolatedMaxC3d')
+    return producer
+
+def create_histoInterpolatedMax1stOrder(process, inputs):
+    producer = custom_3dclustering_histoInterpolatedMax( process )    
+    producer.ProcessorParameters.C3d_parameters.neighbour_weights=cms.vdouble(  0    , 0.25, 0   ,
+                                                   0.25 , 0   , 0.25,
+                                                   0    , 0.25, 0
+                                                )
+    return producer
+
+
+
+def create_histoInterpolatedMax2ndOrder(process, inputs):
+    producer = custom_3dclustering_histoInterpolatedMax( process )    
+    producer.ProcessorParameters.C3d_parameters.neighbour_weights=cms.vdouble( -0.25, 0.5, -0.25,
+                                                   0.5 , 0  ,  0.5 ,
+                                                  -0.25, 0.5, -0.25
+                                                )
+    return producer
+
+
+
+def create_histoThreshold(process, inputs,
+        threshold = 20.,
+        distance = 0.01,
+        nBins_R = 36,
+        nBins_Phi = 216,
+        binSumsHisto = binSums,
+        ):
+    producer = process.hgcalBackEndLayer2Producer.clone() 
+    producer.ProcessorParameters.C3d_parameters.threshold_histo_multicluster = cms.double(threshold)
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
+    producer.ProcessorParameters.C3d_parameters.nBins_R_histo_multicluster = cms.uint32(nBins_R)
+    producer.ProcessorParameters.C3d_parameters.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
+    producer.ProcessorParameters.C3d_parameters.binSumsHisto = binSumsHisto
+    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoThresholdC3d')
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+    return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -8,21 +8,6 @@ binSums = cms.vuint32(13,               #0
                       3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
                       )
 
-def create_distance(process, inputs,
-        distance=6.,# cm
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    producer = process.hgcalBackEndLayer1Producer.clone() 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) 
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) 
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) 
-    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) 
-    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRC2d') 
-    producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
-    return producer
-
 
 def create_distance(process, inputs,
         distance=0.01

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
+
+def create_supertriggercell(process, inputs):
+    producer = process.hgcalConcentratorProducer.clone() 
+    producer.ProcessorParameters.Method = cms.string('superTriggerCellSelect')
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    return producer
+
+
+def create_bestchoice(process, inputs,
+       triggercells=12
+        ):
+    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
+    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
+    producer = process.hgcalConcentratorProducer.clone() 
+    producer.ProcessorParameters.Method = cms.string('bestChoiceSelect')
+    producer.ProcessorParameters.NData = cms.uint32(triggercells)
+    producer.ProcessorParameters.linLSB = cms.double(100./1024.)
+    producer.ProcessorParameters.adcsaturationBH = adcSaturationBH_MIP
+    producer.ProcessorParameters.adcnBitsBH = adcNbitsBH
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -9,6 +9,25 @@ def create_supertriggercell(process, inputs):
     return producer
 
 
+def create_threshold(process, inputs,
+        threshold=2. # in mipT
+        ):
+    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
+    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
+    producer = process.hgcalConcentratorProducer.clone()
+    producer.ProcessorParameters.Method = cms.string('thresholdSelect')
+    producer.ProcessorParameters.linLSB = cms.double(100./1024.)
+    producer.ProcessorParameters.adcsaturationBH = adcSaturationBH_MIP
+    producer.ProcessorParameters.adcnBitsBH = adcNbitsBH
+    producer.ProcessorParameters.TCThreshold_fC = cms.double(0.)
+    producer.ProcessorParameters.TCThresholdBH_MIP = cms.double(0.)
+    producer.ProcessorParameters.triggercell_threshold_silicon = cms.double(threshold) # MipT
+    producer.ProcessorParameters.triggercell_threshold_scintillator = cms.double(threshold) # MipT
+    producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+    return producer
+
+
 def create_bestchoice(process, inputs,
        triggercells=12
         ):

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -7,3 +7,36 @@ def custom_ntuples_V9(process):
            ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells':
             ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
     return process
+
+
+
+def create_ntuple(process, inputs,
+        ntuple_list=[
+            'event',
+            'gen', 'genjet', 'gentau',
+            'digis',
+            'triggercells',
+            'clusters', 'multicluster',
+            'tower'
+            ]
+        ):
+    vpset = []
+    for ntuple in ntuple_list:
+        pset = getattr(process, 'ntuple_'+ntuple).clone()
+        if ntuple=='triggercells':
+            pset.TriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs[0]))
+            pset.Multiclusters = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs[2]))
+        elif ntuple=='clusters':
+            pset.Clusters = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs[1]))
+            pset.Multiclusters = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs[2]))
+        elif ntuple=='multiclusters':
+            pset.Multiclusters = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs[2]))
+        vpset.append(pset)
+    ntuplizer = process.hgcalTriggerNtuplizer.clone()
+    ntuplizer.Ntuples = cms.VPSet(*vpset)
+    print(ntuplizer.Ntuples)
+    return ntuplizer
+
+
+
+

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -16,8 +16,8 @@ def create_ntuple(process, inputs,
             'gen', 'genjet', 'gentau',
             'digis',
             'triggercells',
-            'clusters', 'multicluster',
-            'tower'
+            'clusters', 'multiclusters',
+            'towers'
             ]
         ):
     vpset = []
@@ -33,8 +33,7 @@ def create_ntuple(process, inputs,
             pset.Multiclusters = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs[2]))
         vpset.append(pset)
     ntuplizer = process.hgcalTriggerNtuplizer.clone()
-    ntuplizer.Ntuples = cms.VPSet(*vpset)
-    print(ntuplizer.Ntuples)
+    ntuplizer.Ntuples = cms.VPSet(vpset)
     return ntuplizer
 
 

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -16,8 +16,7 @@ def create_ntuple(process, inputs,
             'gen', 'genjet', 'gentau',
             'digis',
             'triggercells',
-            'clusters', 'multiclusters',
-            'towers'
+            'clusters', 'multiclusters'
             ]
         ):
     vpset = []

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChain.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChain.py
@@ -75,6 +75,5 @@ class HGCalTriggerChain:
         process.globalReplace('hgcalConcentrator', concentrator_sequence)
         process.globalReplace('hgcalBackEndLayer1', backend1_sequence)
         process.globalReplace('hgcalBackEndLayer2', backend2_sequence)
-        if ntuple!='':
-            process.globalReplace('hgcalTriggerNtuples', ntuple_sequence)
+        process.globalReplace('hgcalTriggerNtuples', ntuple_sequence)
         return process

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChain.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChain.py
@@ -1,0 +1,67 @@
+import FWCore.ParameterSet.Config as cms
+
+class HGCalTriggerChain:
+    def __init__(self):
+        self.vfe = {}
+        self.concentrator = {}
+        self.backend1 = {}
+        self.backend2 = {}
+        self.ntuple = {}
+        self.chain = []
+
+    def register_vfe(self, name, generator):
+        self.vfe[name] = generator
+
+    def register_concentrator(self, name, generator):
+        self.concentrator[name] = generator
+
+    def register_backend1(self, name, generator):
+        self.backend1[name] = generator
+
+    def register_backend2(self, name, generator):
+        self.backend2[name] = generator
+
+    def register_chain(self, vfe, concentrator, backend1, backend2, ntuple=None):
+        if not vfe in self.vfe: 
+            raise KeyError('{} not registered as VFE producer'.format(vfe))
+        if not concentrator in self.concentrator: 
+            raise KeyError('{} not registered as concentrator producer'.format(concentrator))
+        if not backend1 in self.backend1: 
+            raise KeyError('{} not registered as backend1 producer'.format(backend1))
+        if not backend2 in self.backend2: 
+            raise KeyError('{} not registered as backend2 producer'.format(backend2))
+        #  if not ntuple in self.ntuple: 
+            #  raise KeyError('{} not registered as ntuplizer'.format(ntuple))
+        self.chain.append( (vfe, concentrator, backend1, backend2) )
+
+    def create_sequences(self, process):
+        tmp = cms.SequencePlaceholder("tmp")
+        vfe_sequence = cms.Sequence(tmp)
+        concentrator_sequence = cms.Sequence(tmp)
+        backend1_sequence = cms.Sequence(tmp)
+        backend2_sequence = cms.Sequence(tmp)
+        for vfe,concentrator,backend1,backend2 in self.chain:
+            concentrator_name = '{0}{1}'.format(vfe, concentrator)
+            backend1_name = '{0}{1}{2}'.format(vfe, concentrator, backend1)
+            backend2_name = '{0}{1}{2}{3}'.format(vfe, concentrator, backend1, backend2)
+            if not hasattr(process, vfe):
+                setattr(process, vfe, self.vfe[vfe](process))
+                vfe_sequence *= getattr(process, vfe)
+            if not hasattr(process, concentrator_name):
+                setattr(process, concentrator_name, self.concentrator[concentrator](process, vfe))
+                concentrator_sequence *= getattr(process, concentrator_name)
+            if not hasattr(process, backend1_name):
+                setattr(process, backend1_name, self.backend1[backend1](process, concentrator_name))
+                backend1_sequence *= getattr(process, backend1_name)
+            if not hasattr(process, backend2_name):
+                setattr(process, backend2_name, self.backend2[backend2](process, backend1_name))
+                backend2_sequence *= getattr(process, backend2_name)
+        vfe_sequence.remove(tmp)
+        concentrator_sequence.remove(tmp)
+        backend1_sequence.remove(tmp)
+        backend2_sequence.remove(tmp)
+        process.globalReplace('hgcalVFE', vfe_sequence)
+        process.globalReplace('hgcalConcentrator', concentrator_sequence)
+        process.globalReplace('hgcalBackEndLayer1', backend1_sequence)
+        process.globalReplace('hgcalBackEndLayer2', backend2_sequence)
+        return process

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-class HGCalTriggerChain:
+class HGCalTriggerChains:
     def __init__(self):
         self.vfe = {}
         self.concentrator = {}

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -75,7 +75,7 @@ ntuple_clusters = cms.PSet(
 )
 
 from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_cone
-ntuple_multicluster = cms.PSet(
+ntuple_multiclusters = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleHGCMulticlusters'),
     Multiclusters = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'),
     EGIdentification = egamma_identification_drnn_cone.clone()
@@ -86,7 +86,7 @@ ntuple_panels = cms.PSet(
     TriggerCells = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection')
 )
 
-ntuple_tower = cms.PSet(
+ntuple_towers = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleHGCTowers'),
     Towers = cms.InputTag('hgcalTowerProducer:HGCalTowerProcessor')
 )
@@ -100,7 +100,7 @@ hgcalTriggerNtuplizer = cms.EDAnalyzer(
         ntuple_gentau,
         ntuple_digis,
         ntuple_triggercells,
-        ntuple_multicluster,
-        ntuple_tower
+        ntuple_multiclusters,
+        ntuple_towers
     )
 )

--- a/L1Trigger/L1THGCalUtilities/python/vfe.py
+++ b/L1Trigger/L1THGCalUtilities/python/vfe.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+
+def create_compression(process,
+       exponent=4,
+       mantissa=4,
+       rounding=True
+        ):
+    producer = process.hgcalVFEProducer.clone() 
+    producer.ProcessorParameters.exponentBits = cms.uint32(exponent)
+    producer.ProcessorParameters.mantissaBits = cms.uint32(mantissa)
+    producer.ProcessorParameters.rounding = cms.bool(rounding)
+    return producer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -75,11 +75,13 @@ import L1Trigger.L1THGCalUtilities.clustering3d as clustering3d
 chain = HGCalTriggerChain()
 chain.register_vfe("Floatingpoint7", lambda p : vfe.create_compression(p, 4, 3, True))
 chain.register_concentrator("Supertriggercell", concentrator.create_supertriggercell)
+chain.register_concentrator("Threshold", concentrator.create_threshold)
 chain.register_concentrator("Bestchoice", lambda p,i : concentrator.create_bestchoice(p,i, triggercells=12))
 chain.register_backend1("Dummy", clustering2d.create_dummy)
 chain.register_backend2("Histothreshold", clustering3d.create_histoThreshold)
 
 chain.register_chain('Floatingpoint7', 'Supertriggercell', 'Dummy', 'Histothreshold')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'Histothreshold')
 chain.register_chain('Floatingpoint7', 'Bestchoice', 'Dummy', 'Histothreshold')
 
 process = chain.create_sequences(process)

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -75,15 +75,18 @@ import L1Trigger.L1THGCalUtilities.clustering3d as clustering3d
 import L1Trigger.L1THGCalUtilities.customNtuples as ntuple
 
 chain = HGCalTriggerChain()
+# Register algorithms
 chain.register_vfe("Floatingpoint7", lambda p : vfe.create_compression(p, 4, 3, True))
 chain.register_concentrator("Supertriggercell", concentrator.create_supertriggercell)
 chain.register_concentrator("Threshold", concentrator.create_threshold)
 chain.register_concentrator("Bestchoice", lambda p,i : concentrator.create_bestchoice(p,i, triggercells=12))
 chain.register_backend1("Dummy", clustering2d.create_dummy)
 chain.register_backend2("Histothreshold", clustering3d.create_histoThreshold)
-ntuple_list = ['event', 'gen', 'multicluster']
+# Register ntuples
+ntuple_list = ['event', 'gen', 'multiclusters']
 chain.register_ntuple("MultiClustersNtuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
 
+# Register trigger chain
 chain.register_chain('Floatingpoint7', 'Supertriggercell', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
 chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
 chain.register_chain('Floatingpoint7', 'Bestchoice', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
@@ -96,26 +99,6 @@ process.hgcalTriggerPrimitives.remove(process.hgcalTower)
 
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
-print(process.hgcl1tpg_step)
-print(process.ntuple_step)
-
-# load ntuplizer
-#process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
-#process.ntuple_multicluster_supertriggercell =  process.ntuple_multicluster.clone()
-#process.ntuple_multicluster_supertriggercell.Multiclusters = cms.InputTag('hgcalStage2SuperTriggerCell:HGCalBackendLayer2Processor3DClustering')
-#process.ntuple_multicluster_bestchoice =  process.ntuple_multicluster.clone()
-#process.ntuple_multicluster_bestchoice.Multiclusters = cms.InputTag('hgcalStage2BestChoice:HGCalBackendLayer2Processor3DClustering')
-#
-#process.hgcalTriggerNtuplizerSuperTriggerCell = process.hgcalTriggerNtuplizer.clone()
-#process.hgcalTriggerNtuplizerSuperTriggerCell.Ntuples = cms.VPSet(process.ntuple_multicluster_supertriggercell)
-#
-#process.hgcalTriggerNtuplizerBestChoice = process.hgcalTriggerNtuplizer.clone()
-#process.hgcalTriggerNtuplizerBestChoice.Ntuples = cms.VPSet(process.ntuple_multicluster_bestchoice)
-#
-#ntuples = cms.Sequence(process.hgcalTriggerNtuplizerSuperTriggerCell*process.hgcalTriggerNtuplizerBestChoice)
-#process.globalReplace("hgcalTriggerNtuples",ntuples)
-#
-#process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
 
 # Schedule definition
 process.schedule = cms.Schedule(process.hgcl1tpg_step, process.ntuple_step)

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -82,6 +82,11 @@ chain.register_concentrator("Threshold", concentrator.create_threshold)
 chain.register_concentrator("Bestchoice", lambda p,i : concentrator.create_bestchoice(p,i, triggercells=12))
 chain.register_backend1("Dummy", clustering2d.create_dummy)
 chain.register_backend2("Histothreshold", clustering3d.create_histoThreshold)
+chain.register_backend2("HistoMax", clustering3d.create_histoMax)
+chain.register_backend2("HistoMaxVarDR", clustering3d.create_histoMax_variableDr)
+chain.register_backend2("HistoInterpolatedMax", clustering3d.create_histoInterpolatedMax)
+chain.register_backend2("HistoInterpolatedMax1stOrder", clustering3d.create_histoInterpolatedMax1stOrder)
+chain.register_backend2("HistoInterpolatedMax2ndOrder", clustering3d.create_histoInterpolatedMax2ndOrder)
 # Register ntuples
 ntuple_list = ['event', 'gen', 'multiclusters']
 chain.register_ntuple("MultiClustersNtuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
@@ -90,6 +95,11 @@ chain.register_ntuple("MultiClustersNtuple", lambda p,i : ntuple.create_ntuple(p
 chain.register_chain('Floatingpoint7', 'Supertriggercell', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
 chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
 chain.register_chain('Floatingpoint7', 'Bestchoice', 'Dummy', 'Histothreshold', 'MultiClustersNtuple')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'HistoMax', 'MultiClustersNtuple')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'HistoMaxVarDR', 'MultiClustersNtuple')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'HistoInterpolatedMax', 'MultiClustersNtuple')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'HistoInterpolatedMax1stOrder', 'MultiClustersNtuple')
+chain.register_chain('Floatingpoint7', 'Threshold', 'Dummy', 'HistoInterpolatedMax2ndOrder', 'MultiClustersNtuple')
 
 process = chain.create_sequences(process)
 

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -1,0 +1,119 @@
+import FWCore.ParameterSet.Config as cms 
+from Configuration.StandardSequences.Eras import eras
+from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
+
+# For old samples use the digi converter
+#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
+process = cms.Process('DIGI',eras.Phase2)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D17_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(50)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring('/store/relval/CMSSW_10_4_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/103X_upgrade2023_realistic_v2_2023D21noPU-v1/20000/F4344045-AEDE-4240-B7B1-27D2CF96C34E.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
+           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+from L1Trigger.L1THGCalUtilities.hgcalTriggerChain import HGCalTriggerChain
+import L1Trigger.L1THGCalUtilities.vfe as vfe
+import L1Trigger.L1THGCalUtilities.concentrator as concentrator
+import L1Trigger.L1THGCalUtilities.clustering2d as clustering2d
+import L1Trigger.L1THGCalUtilities.clustering3d as clustering3d
+
+chain = HGCalTriggerChain()
+chain.register_vfe("Floatingpoint7", lambda p : vfe.create_compression(p, 4, 3, True))
+chain.register_concentrator("Supertriggercell", concentrator.create_supertriggercell)
+chain.register_concentrator("Bestchoice", lambda p,i : concentrator.create_bestchoice(p,i, triggercells=12))
+chain.register_backend1("Dummy", clustering2d.create_dummy)
+chain.register_backend2("Histothreshold", clustering3d.create_histoThreshold)
+
+chain.register_chain('Floatingpoint7', 'Supertriggercell', 'Dummy', 'Histothreshold')
+chain.register_chain('Floatingpoint7', 'Bestchoice', 'Dummy', 'Histothreshold')
+
+process = chain.create_sequences(process)
+
+# Remove towers from sequence
+process.hgcalTriggerPrimitives.remove(process.hgcalTowerMap)
+process.hgcalTriggerPrimitives.remove(process.hgcalTower)
+
+process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
+print(process.hgcl1tpg_step)
+
+# load ntuplizer
+#process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
+#process.ntuple_multicluster_supertriggercell =  process.ntuple_multicluster.clone()
+#process.ntuple_multicluster_supertriggercell.Multiclusters = cms.InputTag('hgcalStage2SuperTriggerCell:HGCalBackendLayer2Processor3DClustering')
+#process.ntuple_multicluster_bestchoice =  process.ntuple_multicluster.clone()
+#process.ntuple_multicluster_bestchoice.Multiclusters = cms.InputTag('hgcalStage2BestChoice:HGCalBackendLayer2Processor3DClustering')
+#
+#process.hgcalTriggerNtuplizerSuperTriggerCell = process.hgcalTriggerNtuplizer.clone()
+#process.hgcalTriggerNtuplizerSuperTriggerCell.Ntuples = cms.VPSet(process.ntuple_multicluster_supertriggercell)
+#
+#process.hgcalTriggerNtuplizerBestChoice = process.hgcalTriggerNtuplizer.clone()
+#process.hgcalTriggerNtuplizerBestChoice.Ntuples = cms.VPSet(process.ntuple_multicluster_bestchoice)
+#
+#ntuples = cms.Sequence(process.hgcalTriggerNtuplizerSuperTriggerCell*process.hgcalTriggerNtuplizerBestChoice)
+#process.globalReplace("hgcalTriggerNtuples",ntuples)
+#
+#process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.hgcl1tpg_step)#, process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+


### PR DESCRIPTION
Add python utilities to produce multiple HGCAL TPG algorithmic chains.
This is a preliminary version:
- Cannot use the default producers in a chain because standard sequences are erased. One needs to recreate all the steps in a chain.
- Towers are not included in the chains
- Ntuple customization is very limited

Example usage is provided in `L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py`.