### PR TITLE
[Backport 10_4_0] Fix dEdx weights and use them for V9 geometry instead of cluster calibrations

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalLayersCalibrationCoefficients_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalLayersCalibrationCoefficients_cfi.py
@@ -55,7 +55,7 @@ AllLayer_weights = cms.vdouble(0.0,
                                0.326339
                                )
 
-TrgLayer_weights = cms.vdouble(0.0,                               
+TrgLayer_weights = cms.vdouble(0.0,
                                0.0183664,
                                0.,
                                0.0305622,
@@ -110,56 +110,14 @@ TrgLayer_weights = cms.vdouble(0.0,
                                0.328053
                                )
 
-TrgLayer_dEdX_weights = cms.vdouble(0.0,   # there is no layer zero
-                           8.603+8.0675, # Mev
-                           0., 
-                           8.0675*2, 
-                           0., 
-                           8.0675*2, 
-                           0., 
-                           8.0675*2., 
-                           0., 
-                           8.0675+8.9515, 
-                           0., 
-                           10.135*2, 
-                           0., 
-                           10.135*2., 
-                           0., 
-                           10.135*2., 
-                           0., 
-                           10.135*2., 
-                           0., 
-                           10.135+11.682, 
-                           0., 
-                           13.654*2., 
-                           0., 
-                           13.654*2., 
-                           0., 
-                           13.654*2., 
-                           0., 
-                           13.654+38.2005, 
-                           0., 
-                           55.0265, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           49.871, 
-                           62.005, 
-                           83.1675, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           92.196, 
-                           46.098)
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX
+
+TrgLayer_dEdX_weights = cms.vdouble()
+for lid, lw in enumerate(dEdX.weights):
+    if lid > 29:
+        TrgLayer_dEdX_weights.append(lw)
+    else:
+        if (lid % 2) == 1:
+            TrgLayer_dEdX_weights.append(lw+dEdX.weights[lid-1])
+        else:
+            TrgLayer_dEdX_weights.append(0)

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -13,7 +13,9 @@ hgcalTriggerPrimitives = cms.Sequence(hgcalVFEProducer*hgcalConcentratorProducer
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
+from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
 modifyHgcalTriggerPrimitivesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_geometry_V9)
+modifyHgcalTriggerPrimitivesCalibWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(lambda process : custom_cluster_calibration_global(process, factor=1))
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,


### PR DESCRIPTION
Backport #278 