### PR TITLE
Switch default clustering to HistoMax

### DIFF
--- a/L1Trigger/L1THGCal/python/customClustering.py
+++ b/L1Trigger/L1THGCal/python/customClustering.py
@@ -91,8 +91,13 @@ def custom_3dclustering_histoMax(process,
     parameters_c3d.type_multicluster = cms.string('HistoMaxC3d')
     return process
 
+
+dr_layerbylayer = ([0] + # no layer 0
+        [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 + # EM
+        [0.040]*6 + [0.050]*6 + # FH
+        [0.050]*12) # BH
 def custom_3dclustering_histoMax_variableDr(process,
-        distances = ([0] + [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +   [0.040]*6 + [0.050]*6  +  [0.050]*12),
+        distances = dr_layerbylayer,
         nBins_R = 36,
         nBins_Phi = 216,
         binSumsHisto = binSums,                        

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -5,13 +5,8 @@ import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
 import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
 import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
 
-C2d_parValues = cms.PSet( clusterType = cms.string('dRNNC2d'), # clustering type: dRC2d--> Geometric-dR clustering; NNC2d-->Nearest Neighbors clustering
-                          seeding_threshold_silicon = cms.double(5), # MipT
-                          seeding_threshold_scintillator = cms.double(5), # MipT
-                          clustering_threshold_silicon = cms.double(2), # MipT
-                          clustering_threshold_scintillator = cms.double(2), # MipT
-                          dR_cluster = cms.double(6.), # in cm
-                          calibSF_cluster=cms.double(0.),
+C2d_parValues = cms.PSet( clusterType = cms.string('dummyC2d'),
+                          calibSF_cluster=cms.double(1.),
                           layerWeights = layercalibparam.TrgLayer_weights,
                           applyLayerCalibration = cms.bool(True)
             )

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -5,17 +5,16 @@ import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
 import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
 
 from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_cone
-from L1Trigger.L1THGCal.customClustering import binSums
+from L1Trigger.L1THGCal.customClustering import binSums, dr_layerbylayer
 
-C3d_parValues = cms.PSet( type_multicluster = cms.string('dRC3d'),
-                          dR_multicluster = cms.double(0.01),
+C3d_parValues = cms.PSet( type_multicluster = cms.string('HistoMaxC3d'),
+                          dR_multicluster = cms.double(0.),
+                          dR_multicluster_byLayer = cms.vdouble(dr_layerbylayer),
                           minPt_multicluster = cms.double(0.5), # minimum pt of the multicluster (GeV)
-                          dist_dbscan_multicluster=cms.double(0.),
-                          minN_dbscan_multicluster=cms.uint32(0),
                           nBins_R_histo_multicluster = cms.uint32(36),
                           nBins_Phi_histo_multicluster = cms.uint32(216),
                           binSumsHisto = binSums,
-                          threshold_histo_multicluster = cms.double(20.),
+                          threshold_histo_multicluster = cms.double(0.),
                           EGIdentification=egamma_identification_drnn_cone.clone(),
                           neighbour_weights=cms.vdouble(  0    , 0.25, 0   ,
                                                           0.25 , 0  ,  0.25,

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -100,7 +100,6 @@ hgcalTriggerNtuplizer = cms.EDAnalyzer(
         ntuple_gentau,
         ntuple_digis,
         ntuple_triggercells,
-        ntuple_clusters,
         ntuple_multicluster,
         ntuple_tower
     )

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
@@ -67,9 +67,6 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
-# Change to V7 trigger geometry for older samples
-#  from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_ZoltanSplit_V7
-#  process = custom_geometry_ZoltanSplit_V7(process)
 
 # load ntuplizer
 process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')


### PR DESCRIPTION
Use dummy 2D clustering and HistoMax 3D clustering with layer-dependent dR as new default.
Currently no seed threshold is applied. Comparisons need to be done with a threshold of 20 mipT
