### PR TITLE
Using super trigger cells in the V9 geometry

### DIFF
--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -6,9 +6,12 @@
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
+
+      
 #include <array>
 #include <vector>
 
@@ -23,15 +26,15 @@ class HGCalConcentratorSuperTriggerCellImpl
   private:
 
     int getSuperTriggerCellId(int detid) const ;
-    static const int kSplit12_ = 0x3a;
-    static const int kSplit3_ = 0x30;
+    static std::map<int,int> kSplit_;
     static const int kWafer_offset_ = 6;
-
-    static const int kSTCsize16_ = 16;
-    static const int kSTCsize4_ = 4;
+    static const int kSTCsizeCoarse_ = 16;
+    static const int kSTCsizeFine_ = 4;
     static const int kNLayers_ = 3;
+    static const int kSplit_v9_ = 0x36;
 
     HGCalTriggerTools triggerTools_;
+    HGCSiliconDetIdToROC detIdToROC_;
     std::vector<unsigned> stcSize_;
 
     class SuperTriggerCell {
@@ -40,7 +43,7 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_;
         int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
-
+        
     public:
         SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0 ;}
         void add(const l1t::HGCalTriggerCell &c) {

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -15,7 +15,7 @@ conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSele
                      TCThreshold_fC = cms.double(0.),
                      TCThresholdBH_MIP = cms.double(0.),
                      triggercell_threshold_silicon = cms.double(2.), # MipT
-                     triggercell_threshold_scintillator = cms.double(2.) # MipT
+                     triggercell_threshold_scintillator = cms.double(2.), # MipT
                      )
 
 hgcalConcentratorProducer = cms.EDProducer(

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
 
 #include <unordered_map>
 
@@ -12,7 +13,7 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
             << "Inconsistent size of super trigger cell size vector" << stcSize_.size() ;
     }
     for(auto stc : stcSize_) {
-        if ( stc!=kSTCsize4_ && stc!=kSTCsize16_ ){
+        if ( stc!=kSTCsizeFine_ && stc!=kSTCsizeCoarse_ ){
             throw cms::Exception("HGCTriggerParameterError")
               << "Super Trigger Cell should be of size 4 or 16" ;
         }
@@ -20,24 +21,86 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
     
 }
 
+std::map<int,int> 
+HGCalConcentratorSuperTriggerCellImpl::kSplit_ = {
+  {4, 0x3a},
+  {16, 0x30}
+};
 
 int
 HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid) const {
-  // FIXME: won't work in the V9 geometry
-  HGCalDetId TC_id(detid);
-  if(TC_id.subdetId()==HGCHEB) {
-    return TC_id.cell(); //scintillator
-  } else {
 
-    int TC_wafer = TC_id.wafer();
-    int TC_12th = ( TC_id.cell() & kSplit12_ );
-    int TC_3rd = ( TC_id.cell() & kSplit3_ );
 
-    int thickness = triggerTools_.thicknessIndex(detid,true);
-    int TC_split = TC_12th;
-    if (stcSize_.at(thickness) == kSTCsize16_) TC_split = TC_3rd;
+  DetId TC_id( detid );
+  if ( TC_id.det() == DetId::Forward ){//V8
 
-    return TC_wafer<<kWafer_offset_ | TC_split;
+    HGCalDetId TC_idV8(detid);
+
+    if( triggerTools_.isScintillator(detid) ){
+      return TC_idV8.cell(); //scintillator
+    }
+    else{
+      int TC_wafer = TC_idV8.wafer();
+      int thickness = triggerTools_.thicknessIndex(detid,true);
+      int TC_split = ( TC_idV8.cell() & kSplit_.at( stcSize_.at(thickness) ) );
+
+      return TC_wafer<<kWafer_offset_ | TC_split;
+    }
+
+  }
+
+  else if ( TC_id.det() == DetId::HGCalTrigger ){//V9
+    
+    if( triggerTools_.isScintillator(detid) ){
+      HGCScintillatorDetId TC_idV9(detid);
+      return TC_idV9.ietaAbs() << HGCScintillatorDetId::kHGCalPhiOffset | TC_idV9.iphi(); //scintillator
+    }
+    else {
+      HGCalTriggerDetId TC_idV9(detid);
+
+      int TC_wafer = TC_idV9.waferU() << kWafer_offset_ | TC_idV9.waferV() ;
+      int thickness = triggerTools_.thicknessIndex(detid);
+
+      int TC_12th = 0;
+      int Uprime = 0;
+      int Vprime = 0;
+      int rocnum = detIdToROC_.getROCNumber( TC_idV9.triggerCellU() , TC_idV9.triggerCellV(), 1 );
+
+      if ( rocnum == 1 ){
+
+          Uprime = TC_idV9.triggerCellU();
+          Vprime = TC_idV9.triggerCellV() - TC_idV9.triggerCellU();
+
+      }
+      else if ( rocnum == 2 ){
+
+          Uprime = TC_idV9.triggerCellU()-TC_idV9.triggerCellV()-1;
+          Vprime = TC_idV9.triggerCellV();
+
+      }
+      else if ( rocnum == 3 ){
+
+          Uprime = TC_idV9.triggerCellU()-4;
+          Vprime = TC_idV9.triggerCellV()-4;
+
+      }
+
+      TC_12th =  (rocnum << 6) | ( (Uprime << 3 | Vprime) & kSplit_v9_ );
+
+      int TC_split =  TC_12th;
+      if (stcSize_.at(thickness) == kSTCsizeCoarse_){
+        TC_split =  rocnum;
+      }
+
+      return TC_wafer<<kWafer_offset_ | TC_split;
+      
+    }
+    
+    
+
+  }
+  else{
+    return -1;
   }
   
 }

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,9 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 
-def create_supertriggercell(process, inputs):
-    producer = process.hgcalConcentratorProducer.clone() 
+def create_supertriggercell(process, inputs,
+        stcSize = cms.vuint32(4,4,4) 
+        ):
+    producer = process.hgcalConcentratorProducer.clone()     
     producer.ProcessorParameters.Method = cms.string('superTriggerCellSelect')
+    producer.ProcessorParameters.stcSize = stcSize
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     return producer


### PR DESCRIPTION
I have implemented the ability to have super TCs in the V9 geometry, using a map.
The method is quite customisable - a new super TC layout just needs a new map to be defined.
Potentially this could be done better with a config file, but I wasn't sure how to do that.

The code for the V8 geometry remains the same for now.