### PR TITLE
Creating coarse trigger cells

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -15,6 +15,7 @@ class HGCalCoarseTriggerCellMapping
   public:
     HGCalCoarseTriggerCellMapping();
     void setEvenDetId(l1t::HGCalTriggerCell &c) const;
+    uint32_t getEvenDetId(int tcid) const;
     std::vector<uint32_t> getConstituentTriggerCells( int ctcId, int ctcSize) const;
     void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size ) const;
     int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -14,10 +14,15 @@ class HGCalCoarseTriggerCellMapping
 {
   public:
     HGCalCoarseTriggerCellMapping();
-    void getConstituentTriggerCells( int ctcId, int ctcSize, std::vector<int> & output_ids) const;
-    void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc );
+    std::vector<int> getConstituentTriggerCells( int ctcId, int ctcSize) const;
+    void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size ) const;
     int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;
     void checkSizeValidity(int CTCsize)const;
+
+    static constexpr int kCTCsizeCoarse_ = 16;
+    static constexpr int kCTCsizeMid_ = 8;
+    static constexpr int kCTCsizeFine_ = 4;
+    static constexpr int kCTCsizeVeryFine_ = 2;    
 
   private:
 
@@ -26,10 +31,6 @@ class HGCalCoarseTriggerCellMapping
     static const std::map<int,int> kSplit_v9_;
     static constexpr int kWafer_offset_ = 6;
     static constexpr int kSTCidMask_ = 63;
-    static constexpr int kCTCsizeCoarse_ = 16;
-    static constexpr int kCTCsizeMid_ = 8;
-    static constexpr int kCTCsizeFine_ = 4;
-    static constexpr int kCTCsizeVeryFine_ = 2;
     static constexpr int kSplit_v8_Coarse_ = 0x30;
     static constexpr int kSplit_v8_Mid_ = 0x38;
     static constexpr int kSplit_v8_Fine_ = 0x3a;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -47,6 +47,7 @@ class HGCalCoarseTriggerCellMapping
     static constexpr int kRocShift_ = 6;
     static constexpr int kRocMask_ = 0xC0;
     static constexpr int kRotate4_ = 4;
+    static constexpr int kRotate7_ = 7;
     static constexpr int kUShift_ = 3;
     static constexpr int kVShift_ = 0;
     static constexpr int kUMask_ = 0x38;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -13,12 +13,14 @@
 class HGCalCoarseTriggerCellMapping
 {
   public:
-    HGCalCoarseTriggerCellMapping();
+    HGCalCoarseTriggerCellMapping(const edm::ParameterSet& conf);
     void setEvenDetId(l1t::HGCalTriggerCell &c) const;
     uint32_t getEvenDetId(int tcid) const;
+    std::vector<uint32_t> getConstituentTriggerCellsByThickness( int ctcId, int thickness) const;
     std::vector<uint32_t> getConstituentTriggerCells( int ctcId, int ctcSize) const;
     void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size ) const;
     int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;
+    int getCoarseTriggerCellIdByThickness(int detid, int thickness) const ;
     void checkSizeValidity(int CTCsize)const;
 
     static constexpr int kCTCsizeCoarse_ = 16;
@@ -61,7 +63,8 @@ class HGCalCoarseTriggerCellMapping
 
     HGCalTriggerTools triggerTools_;
     HGCSiliconDetIdToROC detIdToROC_;
-    
+    std::vector<unsigned> stcSize_;
+
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -15,7 +15,7 @@ class HGCalCoarseTriggerCellMapping
   public:
     HGCalCoarseTriggerCellMapping();
     void setEvenDetId(l1t::HGCalTriggerCell &c) const;
-    std::vector<int> getConstituentTriggerCells( int ctcId, int ctcSize) const;
+    std::vector<uint32_t> getConstituentTriggerCells( int ctcId, int ctcSize) const;
     void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size ) const;
     int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;
     void checkSizeValidity(int CTCsize)const;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -39,10 +39,22 @@ class HGCalCoarseTriggerCellMapping
     static constexpr int kSplit_v9_VeryFine_ = 0x37;
     static constexpr int kSplit_v9_Fine_ = 0x36;
     static constexpr int kSplit_v9_Mid_ = 0x26;
+    static constexpr int kSplit_v9_Coarse_ = 0x24;
 
+    //For coarse TCs
     static constexpr int kRocShift_ = 6;
+    static constexpr int kRocMask_ = 0xC0;
     static constexpr int kRotate4_ = 4;
     static constexpr int kUShift_ = 3;
+    static constexpr int kVShift_ = 0;
+    static constexpr int kUMask_ = 0x38;
+    static constexpr int kVMask_ = 0x7;
+
+    //For original cells 
+    static constexpr int kHGCalCellUOffset_      = 0;
+    static constexpr int kHGCalCellUMask_        = 0xF;
+    static constexpr int kHGCalCellVOffset_      = 4;
+    static constexpr int kHGCalCellVMask_        = 0xF;
 
     HGCalTriggerTools triggerTools_;
     HGCSiliconDetIdToROC detIdToROC_;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -14,6 +14,7 @@ class HGCalCoarseTriggerCellMapping
 {
   public:
     HGCalCoarseTriggerCellMapping();
+    void setEvenDetId(l1t::HGCalTriggerCell &c) const;
     std::vector<int> getConstituentTriggerCells( int ctcId, int ctcSize) const;
     void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size ) const;
     int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -22,26 +22,26 @@ class HGCalCoarseTriggerCellMapping
   private:
 
 
-    static std::map<int,int> kSplit_;
-    static std::map<int,int> kSplit_v9_;
-    static const int kWafer_offset_ = 6;
-    static const int kSixBitMax_ = 63;
-    static const int kCTCsizeCoarse_ = 16;
-    static const int kCTCsizeMid_ = 8;
-    static const int kCTCsizeFine_ = 4;
-    static const int kCTCsizeVeryFine_ = 2;
-    static const int kSplit_v8_Coarse_ = 0x30;
-    static const int kSplit_v8_Mid_ = 0x38;
-    static const int kSplit_v8_Fine_ = 0x3a;
-    static const int kSplit_v8_VeryFine_ = 0x3e;
-    static const int kNLayers_ = 3;
-    static const int kSplit_v9_VeryFine_ = 0x37;
-    static const int kSplit_v9_Fine_ = 0x36;
-    static const int kSplit_v9_Mid_ = 0x26;
+    static const std::map<int,int> kSplit_;
+    static const std::map<int,int> kSplit_v9_;
+    static constexpr int kWafer_offset_ = 6;
+    static constexpr int kSTCidMask_ = 63;
+    static constexpr int kCTCsizeCoarse_ = 16;
+    static constexpr int kCTCsizeMid_ = 8;
+    static constexpr int kCTCsizeFine_ = 4;
+    static constexpr int kCTCsizeVeryFine_ = 2;
+    static constexpr int kSplit_v8_Coarse_ = 0x30;
+    static constexpr int kSplit_v8_Mid_ = 0x38;
+    static constexpr int kSplit_v8_Fine_ = 0x3a;
+    static constexpr int kSplit_v8_VeryFine_ = 0x3e;
+    static constexpr int kNLayers_ = 3;
+    static constexpr int kSplit_v9_VeryFine_ = 0x37;
+    static constexpr int kSplit_v9_Fine_ = 0x36;
+    static constexpr int kSplit_v9_Mid_ = 0x26;
 
-    static const int kRocShift_ = 6;
-    static const int kRotate4_ = 4;
-    static const int kUShift_ = 3;
+    static constexpr int kRocShift_ = 6;
+    static constexpr int kRotate4_ = 4;
+    static constexpr int kUShift_ = 3;
 
     HGCalTriggerTools triggerTools_;
     HGCSiliconDetIdToROC detIdToROC_;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -1,0 +1,51 @@
+#ifndef __L1Trigger_L1THGCal_HGCalCoarseTriggerCellMapping_h__
+#define __L1Trigger_L1THGCal_HGCalCoarseTriggerCellMapping_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+      
+class HGCalCoarseTriggerCellMapping
+{
+  public:
+    HGCalCoarseTriggerCellMapping();
+    void getConstituentTriggerCells( int ctcId, int ctcSize, std::vector<int> & output_ids) const;
+    void setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc );
+    int getCoarseTriggerCellId(int detid, int CTCsize = -1) const ;
+    void checkSizeValidity(int CTCsize)const;
+
+  private:
+
+
+    static std::map<int,int> kSplit_;
+    static std::map<int,int> kSplit_v9_;
+    static const int kWafer_offset_ = 6;
+    static const int kSixBitMax_ = 63;
+    static const int kCTCsizeCoarse_ = 16;
+    static const int kCTCsizeMid_ = 8;
+    static const int kCTCsizeFine_ = 4;
+    static const int kCTCsizeVeryFine_ = 2;
+    static const int kSplit_v8_Coarse_ = 0x30;
+    static const int kSplit_v8_Mid_ = 0x38;
+    static const int kSplit_v8_Fine_ = 0x3a;
+    static const int kSplit_v8_VeryFine_ = 0x3e;
+    static const int kNLayers_ = 3;
+    static const int kSplit_v9_VeryFine_ = 0x37;
+    static const int kSplit_v9_Fine_ = 0x36;
+    static const int kSplit_v9_Mid_ = 0x26;
+
+    static const int kRocShift_ = 6;
+    static const int kRotate4_ = 4;
+    static const int kUShift_ = 3;
+
+    HGCalTriggerTools triggerTools_;
+    HGCSiliconDetIdToROC detIdToROC_;
+    
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -41,6 +41,7 @@ class HGCalTriggerTools {
 
     void eventSetup(const edm::EventSetup&);
     GlobalPoint getTCPosition(const DetId& id) const;
+    bool validTriggerCell(const DetId& id) const;
     unsigned layers(ForwardSubdetector type) const;
     unsigned layers(DetId::Detector type) const ;
     unsigned layer(const DetId&) const;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -28,6 +28,7 @@ class HGCalConcentratorCoarsenerImpl
 
     HGCalTriggerTools triggerTools_;
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
+    bool fixedDataSizePerHGCROC_;
 
     std::unordered_map<int,float> coarseTCsumPt;
     std::unordered_map<int,int> coarseTCsumHwPt;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -46,9 +46,9 @@ class HGCalConcentratorCoarsenerImpl
 
     void updateCoarseTriggerCellMaps( const l1t::HGCalTriggerCell& tc, int ctcid );
     void assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &c, int ctcid);
-    void setEvenDetId(l1t::HGCalTriggerCell &c) const {
-      c.setDetId( c.detId() & ~1 );
-    }
+    //    void setEvenDetId(l1t::HGCalTriggerCell &c) const {
+    //  c.setDetId( c.detId() & ~1 );
+    //    }
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -9,7 +9,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
-
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
 
       
 #include <array>
@@ -26,22 +26,20 @@ class HGCalConcentratorCoarsenerImpl
 
   private:
 
-    int getSuperTriggerCellId(int detid) const ;
-    static const int kSplit_v8_VeryFine_ = 0x3e;
-
     HGCalTriggerTools triggerTools_;
+    HGCalCoarseTriggerCellMapping coarseTCmapping_;
 
     class SuperTriggerCell {
   
     private:
-        float sumPt_, sumMipPt_, fracsum_;
-        int sumHwPt_, maxHwPt_, stcId_; 
+        float sumPt_, sumMipPt_;
+        int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
 
     public:
         SuperTriggerCell(){  
-          sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0, stcId_ = 0; }
-        void add(const l1t::HGCalTriggerCell &c, int stcId) {
+          sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0; }
+        void add(const l1t::HGCalTriggerCell &c) {
             sumPt_ += c.pt();
             sumMipPt_ += c.mipPt();
             sumHwPt_ += c.hwPt();
@@ -50,10 +48,6 @@ class HGCalConcentratorCoarsenerImpl
                 maxId_ = c.detId();
             }
             
-            if  ( stcId_ == 0 ){
-              stcId_ = stcId;
-            }
-
         }
 
         void assignEnergy(l1t::HGCalTriggerCell &c) const {
@@ -63,12 +57,12 @@ class HGCalConcentratorCoarsenerImpl
             c.setPt( sumPt_ );
 
         }
+
         void setEvenDetId(l1t::HGCalTriggerCell &c) const {	  	  
 	  c.setDetId( c.detId() & ~1 );
         }
+
         unsigned GetMaxId()const{return maxId_;}
-        unsigned GetSTCId()const{return stcId_;}
-        int GetMaxHwPt()const{return maxHwPt_;}
 
     };
     

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -1,0 +1,77 @@
+#ifndef __L1Trigger_L1THGCal_HGCalConcentratorCoarsenerImpl_h__
+#define __L1Trigger_L1THGCal_HGCalConcentratorCoarsenerImpl_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+
+      
+#include <array>
+#include <vector>
+
+class HGCalConcentratorCoarsenerImpl
+{
+  public:
+    HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf);
+
+    void coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+    void eventSetup(const edm::EventSetup& es) {triggerTools_.eventSetup(es);}
+
+
+  private:
+
+    int getSuperTriggerCellId(int detid) const ;
+    static const int kSplit_v8_VeryFine_ = 0x3e;
+
+    HGCalTriggerTools triggerTools_;
+
+    class SuperTriggerCell {
+  
+    private:
+        float sumPt_, sumMipPt_, fracsum_;
+        int sumHwPt_, maxHwPt_, stcId_; 
+        unsigned maxId_;
+
+    public:
+        SuperTriggerCell(){  
+          sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0, stcId_ = 0; }
+        void add(const l1t::HGCalTriggerCell &c, int stcId) {
+            sumPt_ += c.pt();
+            sumMipPt_ += c.mipPt();
+            sumHwPt_ += c.hwPt();
+            if (maxId_ == 0 || c.hwPt() > maxHwPt_) {
+                maxHwPt_ = c.hwPt();
+                maxId_ = c.detId();
+            }
+            
+            if  ( stcId_ == 0 ){
+              stcId_ = stcId;
+            }
+
+        }
+
+        void assignEnergy(l1t::HGCalTriggerCell &c) const {
+
+            c.setHwPt(sumHwPt_);
+            c.setMipPt(sumMipPt_);
+            c.setPt( sumPt_ );
+
+        }
+        void setEvenDetId(l1t::HGCalTriggerCell &c) const {	  	  
+	  c.setDetId( c.detId() & ~1 );
+        }
+        unsigned GetMaxId()const{return maxId_;}
+        unsigned GetSTCId()const{return stcId_;}
+        int GetMaxHwPt()const{return maxHwPt_;}
+
+    };
+    
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -29,42 +29,18 @@ class HGCalConcentratorCoarsenerImpl
     HGCalTriggerTools triggerTools_;
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
 
-    class SuperTriggerCell {
-  
-    private:
-        float sumPt_, sumMipPt_;
-        int sumHwPt_, maxHwPt_; 
-        unsigned maxId_;
+    std::unordered_map<int,float> coarseTCsumPt;
+    std::unordered_map<int,int> coarseTCsumHwPt;
+    std::unordered_map<int,int> coarseTCmaxHwPt;
+    std::unordered_map<int,float> coarseTCsumMipPt;
+    std::unordered_map<int,unsigned> coarseTCmaxId;
 
-    public:
-        SuperTriggerCell(){  
-          sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0; }
-        void add(const l1t::HGCalTriggerCell &c) {
-            sumPt_ += c.pt();
-            sumMipPt_ += c.mipPt();
-            sumHwPt_ += c.hwPt();
-            if (maxId_ == 0 || c.hwPt() > maxHwPt_) {
-                maxHwPt_ = c.hwPt();
-                maxId_ = c.detId();
-            }
-            
-        }
 
-        void assignEnergy(l1t::HGCalTriggerCell &c) const {
-
-            c.setHwPt(sumHwPt_);
-            c.setMipPt(sumMipPt_);
-            c.setPt( sumPt_ );
-
-        }
-
-        void setEvenDetId(l1t::HGCalTriggerCell &c) const {	  	  
-	  c.setDetId( c.detId() & ~1 );
-        }
-
-        unsigned GetMaxId()const{return maxId_;}
-
-    };
+    void updateCoarseTriggerCellMaps( const l1t::HGCalTriggerCell& tc, int ctcid );
+    void assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &c, int ctcid);
+    void setEvenDetId(l1t::HGCalTriggerCell &c) const {
+      c.setDetId( c.detId() & ~1 );
+    }
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -29,6 +29,8 @@ class HGCalConcentratorCoarsenerImpl
     HGCalTriggerTools triggerTools_;
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
     bool fixedDataSizePerHGCROC_;
+    static constexpr int kCoarse2Size_ = 2;
+    static constexpr int kHighDensityThickness_ = 0;
 
     struct coarseTC{
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -30,12 +30,17 @@ class HGCalConcentratorCoarsenerImpl
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
     bool fixedDataSizePerHGCROC_;
 
-    std::unordered_map<int,float> coarseTCsumPt;
-    std::unordered_map<int,int> coarseTCsumHwPt;
-    std::unordered_map<int,int> coarseTCmaxHwPt;
-    std::unordered_map<int,float> coarseTCsumMipPt;
-    std::unordered_map<int,unsigned> coarseTCmaxId;
+    struct coarseTC{
 
+      float sumPt;
+      int sumHwPt;
+      int maxHwPt;
+      float sumMipPt;
+      unsigned maxId;
+
+    };
+
+    std::unordered_map<int,coarseTC> coarseTCMap_;
 
     void updateCoarseTriggerCellMaps( const l1t::HGCalTriggerCell& tc, int ctcid );
     void assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &c, int ctcid);

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -27,8 +27,8 @@ class HGCalConcentratorCoarsenerImpl
   private:
 
     HGCalTriggerTools triggerTools_;
-    HGCalCoarseTriggerCellMapping coarseTCmapping_;
     bool fixedDataSizePerHGCROC_;
+    HGCalCoarseTriggerCellMapping coarseTCmapping_;
     static constexpr int kCoarse2Size_ = 2;
     static constexpr int kHighDensityThickness_ = 0;
 
@@ -46,9 +46,6 @@ class HGCalConcentratorCoarsenerImpl
 
     void updateCoarseTriggerCellMaps( const l1t::HGCalTriggerCell& tc, int ctcid );
     void assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &c, int ctcid);
-    //    void setEvenDetId(l1t::HGCalTriggerCell &c) const {
-    //  c.setDetId( c.detId() & ~1 );
-    //    }
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -27,7 +27,7 @@ class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBas
 
   private:
     SelectionType selectionType_;
-    bool fixedDataSize_;
+    bool fixedDataSizePerHGCROC_;
     
     std::unique_ptr<HGCalConcentratorSelectionImpl> concentratorProcImpl_;
     std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> concentratorSTCImpl_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -28,6 +28,7 @@ class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBas
   private:
     SelectionType selectionType_;
     bool fixedDataSizePerHGCROC_;
+    bool coarsenTriggerCells_;
     
     std::unique_ptr<HGCalConcentratorSelectionImpl> concentratorProcImpl_;
     std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> concentratorSTCImpl_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -4,6 +4,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSelectionImpl.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h"
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
@@ -26,9 +27,11 @@ class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBas
 
   private:
     SelectionType selectionType_;
+    bool fixedDataSize_;
     
     std::unique_ptr<HGCalConcentratorSelectionImpl> concentratorProcImpl_;
     std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> concentratorSTCImpl_;
+    std::unique_ptr<HGCalConcentratorCoarsenerImpl> concentratorCoarsenerImpl_;
      
     HGCalTriggerTools triggerTools_;
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -30,7 +30,6 @@ class HGCalConcentratorSuperTriggerCellImpl
       superTriggerCell,
       oneBitFraction,
       equalShare,
-      coarse2TriggerCell
     };
     EnergyDivisionType energyDivisionType_;
     static constexpr int kNLayers_ = 3;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -26,6 +26,14 @@ class HGCalConcentratorSuperTriggerCellImpl
 
   private:
 
+    enum EnergyDivisionType{
+      superTriggerCell,
+      oneBitFraction,
+      equalShare
+    };
+    EnergyDivisionType energyDivisionType_;
+    bool fixedDataSize_;
+
     int getSuperTriggerCellId(int detid) const ;
     int getCoarseTriggerCellId(int detid) const ;
     static std::map<int,int> kSplit_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -147,12 +147,12 @@ class HGCalConcentratorSuperTriggerCellImpl
         unsigned GetMaxId()const{return maxId_;}
         int GetMaxHwPt()const{return maxHwPt_;}
         unsigned GetNTCs()const{return TClist_.size();}
-        std::vector<int> GetTCList()const{return TClist_;}
+        const std::vector<int>& GetTCList()const{return TClist_;}
         bool rejected()const{return reject_;}
         void reject(){reject_ = true;}
 
     };
-    void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+    void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
     void coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
     
 };

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -23,13 +23,16 @@ class HGCalConcentratorSuperTriggerCellImpl
     void superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
     void eventSetup(const edm::EventSetup& es) {triggerTools_.eventSetup(es);}
 
+
   private:
 
     int getSuperTriggerCellId(int detid) const ;
     static std::map<int,int> kSplit_;
     static const int kWafer_offset_ = 6;
     static const int kSTCsizeCoarse_ = 16;
+    static const int kSTCsizeMid_ = 8;
     static const int kSTCsizeFine_ = 4;
+    static const int kSTCsizeVeryFine_ = 2;
     static const int kNLayers_ = 3;
     static const int kSplit_v9_ = 0x36;
 
@@ -43,9 +46,11 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_;
         int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
-        
+	std::vector<int> TClist_;
+	bool reject_;
+
     public:
-        SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0 ;}
+        SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, reject_=false ;}
         void add(const l1t::HGCalTriggerCell &c) {
             sumPt_ += c.pt();
             sumMipPt_ += c.mipPt();
@@ -54,6 +59,8 @@ class HGCalConcentratorSuperTriggerCellImpl
                 maxHwPt_ = c.hwPt();
                 maxId_ = c.detId();
             }
+
+	    TClist_.push_back( c.detId() );
         }
         void assignEnergy(l1t::HGCalTriggerCell &c) const {
             c.setHwPt(sumHwPt_);
@@ -61,7 +68,13 @@ class HGCalConcentratorSuperTriggerCellImpl
             c.setPt( sumPt_ );
         }
         unsigned GetMaxId()const{return maxId_;}
+        unsigned GetNTCs()const{return TClist_.size();}
+	std::vector<int> GetTCList()const{return TClist_;}
+        bool rejected()const{return reject_;}
+        void reject(){reject_ = true;}
+
     };
+    void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -9,7 +9,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
-
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
 
       
 #include <array>
@@ -33,33 +33,9 @@ class HGCalConcentratorSuperTriggerCellImpl
       coarse2TriggerCell
     };
     EnergyDivisionType energyDivisionType_;
-
-    int getSuperTriggerCellId(int detid, int STCsize = -1) const ;
-    static std::map<int,int> kSplit_;
-    static std::map<int,int> kSplit_v9_;
-    static const int kWafer_offset_ = 6;
-    static const int kSixBitMax_ = 63;
-    static const int kSTCsizeCoarse_ = 16;
-    static const int kSTCsizeMid_ = 8;
-    static const int kSTCsizeFine_ = 4;
-    static const int kSTCsizeVeryFine_ = 2;
-    static const int kSplit_v8_Coarse_ = 0x30;
-    static const int kSplit_v8_Mid_ = 0x38;
-    static const int kSplit_v8_Fine_ = 0x3a;
-    static const int kSplit_v8_VeryFine_ = 0x3e;
     static const int kNLayers_ = 3;
-    static const int kSplit_v9_VeryFine_ = 0x37;
-    static const int kSplit_v9_Fine_ = 0x36;
-    static const int kSplit_v9_Mid_ = 0x26;
-
-
-    static const int kRocShift_ = 6;
-    static const int kRotate4_ = 4;
-    static const int kUShift_ = 3;
-
-
     HGCalTriggerTools triggerTools_;
-    HGCSiliconDetIdToROC detIdToROC_;
+    HGCalCoarseTriggerCellMapping coarseTCmapping_;
     std::vector<unsigned> stcSize_;
     bool fixedDataSize_;
 
@@ -69,8 +45,6 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_, stcId_; 
         unsigned maxId_;
-        HGCalDetId STC_HGCalDetId;
-        HGCalTriggerDetId STC_HGCalTriggerDetId;
 
     public:
         SuperTriggerCell(){  
@@ -150,7 +124,6 @@ class HGCalConcentratorSuperTriggerCellImpl
 
     };
     void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
-    void coarsenTriggerCells( std::vector<l1t::HGCalTriggerCell>& trigCellVecInput );
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -69,7 +69,6 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_, stcId_; 
         unsigned maxId_;
-        //        std::vector<int> TClist_;
         HGCalDetId STC_HGCalDetId;
         HGCalTriggerDetId STC_HGCalTriggerDetId;
 
@@ -85,9 +84,10 @@ class HGCalConcentratorSuperTriggerCellImpl
                 maxId_ = c.detId();
             }
             
-            if  ( stcId_ != 0 ){
+            if  ( stcId_ == 0 ){
               stcId_ = stcId;
             }
+
         }
         void getFractionSum(const l1t::HGCalTriggerCell &c) {
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -62,10 +62,22 @@ class HGCalConcentratorSuperTriggerCellImpl
 
 	    TClist_.push_back( c.detId() );
         }
-        void assignEnergy(l1t::HGCalTriggerCell &c) const {
+        void assignEnergy(l1t::HGCalTriggerCell &c, std::string type) const {
+
+	  if ( type == "STC" ){
             c.setHwPt(sumHwPt_);
             c.setMipPt(sumMipPt_);
             c.setPt( sumPt_ );
+	  }
+	  if ( type == "EqualShare" ){
+            c.setHwPt( sumHwPt_/4 );
+            c.setMipPt( sumMipPt_/4 );
+            c.setPt( sumPt_/4 );
+	  }
+
+
+
+
         }
         unsigned GetMaxId()const{return maxId_;}
         unsigned GetNTCs()const{return TClist_.size();}

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -35,9 +35,10 @@ class HGCalConcentratorSuperTriggerCellImpl
     std::string energyType_;
     bool fixedDataSize_;
 
-    int getSuperTriggerCellId(int detid) const ;
-    int getCoarseTriggerCellId(int detid) const ;
+    int getSuperTriggerCellId(int detid, int STCsize = -1) const ;
+    //    int getCoarseTriggerCellId(int detid) const ;
     static std::map<int,int> kSplit_;
+    static std::map<int,int> kSplit_v9_;
     static const int kWafer_offset_ = 6;
     static const int kSTCsizeCoarse_ = 16;
     static const int kSTCsizeMid_ = 8;
@@ -48,7 +49,10 @@ class HGCalConcentratorSuperTriggerCellImpl
     static const int kSplit_v8_Fine_ = 0x3a;
     static const int kSplit_v8_VeryFine_ = 0x3e;
     static const int kNLayers_ = 3;
-    static const int kSplit_v9_ = 0x36;
+    static const int kSplit_v9_VeryFine_ = 0x37;
+    static const int kSplit_v9_Fine_ = 0x36;
+    static const int kSplit_v9_Mid_ = 0x26;
+
 
     static const int kRocShift_ = 6;
     static const int kRotate4_ = 4;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -55,9 +55,9 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
-	std::vector<int> TClist_;
-	bool reject_;
-	//      int num_;
+        std::vector<int> TClist_;
+        bool reject_;
+        //      int num_;
 
     public:
         SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0,reject_=false ;}
@@ -70,81 +70,72 @@ class HGCalConcentratorSuperTriggerCellImpl
                 maxId_ = c.detId();
             }
 
-	    TClist_.push_back( c.detId() );
+            TClist_.push_back( c.detId() );
         }
         void addToList(const l1t::HGCalTriggerCell &c) {
-	  TClist_.push_back( c.detId() );
-	}
+          TClist_.push_back( c.detId() );
+        }
         void getFractionSum(const l1t::HGCalTriggerCell &c) {
 
-	  if ( c.detId() != maxId_ ){
-	    double f = c.pt() / sumPt_ ;
-	    double frac = 0;
-	    /* if ( f < 1./6. ){ */
-	    /*   frac = 1./12.; */
-	    /* } */
-	    /* else if ( f < 2./3. ){ */
-	    /*   frac = 3./12.; */
-	    /* } */
-	    /* else{ */
-	    /*   frac = 5./12.; */
-	    /* } */
-	    if ( f < 1./8. ){
-	      frac = 1./16.;
-	    }
-	    else{
-	      frac = 1./4.;
-	    }
-	    fracsum_ += frac;
-	  }
+          if ( c.detId() != maxId_ ){
+            double f = c.pt() / sumPt_ ;
+            double frac = 0;
+            if ( f < 1./8. ){
+              frac = 1./16.;
+            }
+            else{
+              frac = 1./4.;
+            }
+            fracsum_ += frac;
+          }
 
 
-	}
+        }
 
         void assignEnergy(l1t::HGCalTriggerCell &c, std::string type) const {
 
-	  if ( type == "STC" ){
+          if ( type == "STC" ){
             c.setHwPt(sumHwPt_);
             c.setMipPt(sumMipPt_);
             c.setPt( sumPt_ );
-	  }
-	  if ( type == "EqualShare" ){
+          }
+          if ( type == "EqualShare" ){
             c.setHwPt( sumHwPt_/4 );
             c.setMipPt( sumMipPt_/4 );
             c.setPt( sumPt_/4 );
-	  }
+          }
 
-	  if ( type == "1bit" ){
+          if ( type == "1bit" ){
 
-	    double f = c.pt() / sumPt_ ;
-	    double frac = 0;
-	    
-	    if ( c.detId() != maxId_ ){
-	      if ( f < 1./8. ){
-		frac = 1./16.;
-	      }
-	      else{
-		frac = 1./4.;
-	      }
-	    }
-	    else{
-	      frac = 1-fracsum_;
-	    }
-	    
-	    c.setHwPt(sumHwPt_ * frac );
-	    c.setMipPt(sumMipPt_ * frac );
-	    c.setPt( sumPt_ * frac );
-	  }
+            double f = c.pt() / sumPt_ ;
+            double frac = 0;
+            
+            if ( c.detId() != maxId_ ){
+              if ( f < 1./8. ){
+                frac = 1./16.;
+              }
+              else{
+                frac = 1./4.;
+              }
+            }
+            else{
+              frac = 1-fracsum_;
+            }
+            
+            c.setHwPt(sumHwPt_ * frac );
+            c.setMipPt(sumMipPt_ * frac );
+            c.setPt( sumPt_ * frac );
+          }
 
         }
         void SetMaxTC(const l1t::HGCalTriggerCell &c){
-	  maxId_ = c.detId();
-	  maxHwPt_ = c.hwPt();
-	}
+          maxId_ = c.detId();
+          maxHwPt_ = c.hwPt();
+        }
         unsigned GetMaxId()const{return maxId_;}
         int GetMaxHwPt()const{return maxHwPt_;}
         unsigned GetNTCs()const{return TClist_.size();}
-	std::vector<int> GetTCList()const{return TClist_;}
+        std::vector<int> GetTCList()const{return TClist_;}
         bool rejected()const{return reject_;}
         void reject(){reject_ = true;}
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -33,7 +33,7 @@ class HGCalConcentratorSuperTriggerCellImpl
       coarse2TriggerCell
     };
     EnergyDivisionType energyDivisionType_;
-    static const int kNLayers_ = 3;
+    static constexpr int kNLayers_ = 3;
     HGCalTriggerTools triggerTools_;
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
     std::vector<unsigned> stcSize_;
@@ -45,6 +45,7 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_, stcId_; 
         unsigned maxId_;
+	static constexpr float kEnergyShare_ = 4.;
 
     public:
         SuperTriggerCell(){  
@@ -87,9 +88,9 @@ class HGCalConcentratorSuperTriggerCellImpl
             c.setPt( sumPt_ );
           }
           else if ( energyDivisionType_ == equalShare ){
-            c.setHwPt( sumHwPt_/4 );
-            c.setMipPt( sumMipPt_/4 );
-            c.setPt( sumPt_/4 );
+            c.setHwPt( sumHwPt_/kEnergyShare_ );
+            c.setMipPt( sumMipPt_/kEnergyShare_ );
+            c.setPt( sumPt_/kEnergyShare_ );
           }
           else if (  energyDivisionType_ == oneBitFraction ){
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -32,14 +32,12 @@ class HGCalConcentratorSuperTriggerCellImpl
       equalShare,
     };
     EnergyDivisionType energyDivisionType_;
-    static constexpr int kNLayers_ = 3;
     static constexpr int kHighDensityThickness_ = 0;
     static constexpr int kOddNumberMask_ = 1;
 
     HGCalTriggerTools triggerTools_;
-    HGCalCoarseTriggerCellMapping coarseTCmapping_;
-    std::vector<unsigned> stcSize_;
     bool fixedDataSizePerHGCROC_;
+    HGCalCoarseTriggerCellMapping coarseTCmapping_;
 
     //Parameters for energyDivisionType_ = oneBitFraction
     double oneBitFractionThreshold_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -32,6 +32,7 @@ class HGCalConcentratorSuperTriggerCellImpl
       equalShare
     };
     EnergyDivisionType energyDivisionType_;
+    std::string energyType_;
     bool fixedDataSize_;
 
     int getSuperTriggerCellId(int detid) const ;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -64,6 +64,9 @@ class HGCalConcentratorSuperTriggerCellImpl
 
 	    TClist_.push_back( c.detId() );
         }
+        void addToList(const l1t::HGCalTriggerCell &c) {
+	  TClist_.push_back( c.detId() );
+	}
         void getFractionSum(const l1t::HGCalTriggerCell &c) {
 
 	  if ( c.detId() != maxId_ ){

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -68,7 +68,7 @@ class HGCalConcentratorSuperTriggerCellImpl
   
     private:
         float sumPt_, sumMipPt_, fracsum_;
-        int sumHwPt_, maxHwPt_; 
+        int sumHwPt_, maxHwPt_, stcId_; 
         unsigned maxId_;
         //        std::vector<int> TClist_;
         HGCalDetId STC_HGCalDetId;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -101,20 +101,19 @@ class HGCalConcentratorSuperTriggerCellImpl
 
         }
 
-        void assignEnergy(l1t::HGCalTriggerCell &c, std::string type) const {
+        void assignEnergy(l1t::HGCalTriggerCell &c, EnergyDivisionType energyDivisionType_) const {
 
-          if ( type == "STC" ){
+          if ( energyDivisionType_ == superTriggerCell || energyDivisionType_ == coarse2TriggerCell ){
             c.setHwPt(sumHwPt_);
             c.setMipPt(sumMipPt_);
             c.setPt( sumPt_ );
           }
-          if ( type == "EqualShare" ){
+	  else if ( energyDivisionType_ == equalShare ){
             c.setHwPt( sumHwPt_/4 );
             c.setMipPt( sumMipPt_/4 );
             c.setPt( sumPt_/4 );
           }
-
-          if ( type == "1bit" ){
+	  else if (  energyDivisionType_ == oneBitFraction ){
 
             double f = c.pt() / sumPt_ ;
             double frac = 0;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -29,7 +29,8 @@ class HGCalConcentratorSuperTriggerCellImpl
     enum EnergyDivisionType{
       superTriggerCell,
       oneBitFraction,
-      equalShare
+      equalShare,
+      coarse2TriggerCell
     };
     EnergyDivisionType energyDivisionType_;
     std::string energyType_;
@@ -69,10 +70,9 @@ class HGCalConcentratorSuperTriggerCellImpl
         int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
         std::vector<int> TClist_;
-        bool reject_;
 
     public:
-        SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0,reject_=false ;}
+        SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0 ;}
         void add(const l1t::HGCalTriggerCell &c) {
             sumPt_ += c.pt();
             sumMipPt_ += c.mipPt();
@@ -83,9 +83,6 @@ class HGCalConcentratorSuperTriggerCellImpl
             }
 
             TClist_.push_back( c.detId() );
-        }
-        void addToList(const l1t::HGCalTriggerCell &c) {
-          TClist_.push_back( c.detId() );
         }
         void getFractionSum(const l1t::HGCalTriggerCell &c) {
 
@@ -100,7 +97,6 @@ class HGCalConcentratorSuperTriggerCellImpl
             }
             fracsum_ += frac;
           }
-
 
         }
 
@@ -148,8 +144,6 @@ class HGCalConcentratorSuperTriggerCellImpl
         int GetMaxHwPt()const{return maxHwPt_;}
         unsigned GetNTCs()const{return TClist_.size();}
         const std::vector<int>& GetTCList()const{return TClist_;}
-        bool rejected()const{return reject_;}
-        void reject(){reject_ = true;}
 
     };
     void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -34,12 +34,12 @@ class HGCalConcentratorSuperTriggerCellImpl
     };
     EnergyDivisionType energyDivisionType_;
     std::string energyType_;
-    bool fixedDataSize_;
 
     int getSuperTriggerCellId(int detid, int STCsize = -1) const ;
     static std::map<int,int> kSplit_;
     static std::map<int,int> kSplit_v9_;
     static const int kWafer_offset_ = 6;
+    static const int kSixBitMax_ = 63;
     static const int kSTCsizeCoarse_ = 16;
     static const int kSTCsizeMid_ = 8;
     static const int kSTCsizeFine_ = 4;
@@ -62,6 +62,7 @@ class HGCalConcentratorSuperTriggerCellImpl
     HGCalTriggerTools triggerTools_;
     HGCSiliconDetIdToROC detIdToROC_;
     std::vector<unsigned> stcSize_;
+    bool fixedDataSize_;
 
     class SuperTriggerCell {
   

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -33,6 +33,9 @@ class HGCalConcentratorSuperTriggerCellImpl
     };
     EnergyDivisionType energyDivisionType_;
     static constexpr int kNLayers_ = 3;
+    static constexpr int kHighDensityThickness_ = 0;
+    static constexpr int kOddNumberMask_ = 1;
+
     HGCalTriggerTools triggerTools_;
     HGCalCoarseTriggerCellMapping coarseTCmapping_;
     std::vector<unsigned> stcSize_;
@@ -76,7 +79,10 @@ class HGCalConcentratorSuperTriggerCellImpl
         }
 	void addToFractionSum(float frac){
 	  fracsum_ += frac;
-	  if ( fracsum_ > 1 ) fracsum_ = 1;
+	  if ( fracsum_ > 1 ){
+	    throw cms::Exception("HGCTriggerParameterError")
+	      << "Sum of Trigger Cell fractions should not be greater than 1" ;
+	  }
 	}
         unsigned GetMaxId()const{return maxId_;}
         unsigned GetSTCId()const{return stcId_;}
@@ -91,7 +97,7 @@ class HGCalConcentratorSuperTriggerCellImpl
     };
     void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
     void assignSuperTriggerCellEnergy(l1t::HGCalTriggerCell &c, const SuperTriggerCell &stc) const;
-    float getTriggerCellOneBitFraction( float tcPt, float sumPt );
+    float getTriggerCellOneBitFraction( float tcPt, float sumPt ) const;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -33,7 +33,6 @@ class HGCalConcentratorSuperTriggerCellImpl
       coarse2TriggerCell
     };
     EnergyDivisionType energyDivisionType_;
-    std::string energyType_;
 
     int getSuperTriggerCellId(int detid, int STCsize = -1) const ;
     static std::map<int,int> kSplit_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -36,7 +36,6 @@ class HGCalConcentratorSuperTriggerCellImpl
     bool fixedDataSize_;
 
     int getSuperTriggerCellId(int detid, int STCsize = -1) const ;
-    //    int getCoarseTriggerCellId(int detid) const ;
     static std::map<int,int> kSplit_;
     static std::map<int,int> kSplit_v9_;
     static const int kWafer_offset_ = 6;
@@ -71,7 +70,6 @@ class HGCalConcentratorSuperTriggerCellImpl
         unsigned maxId_;
         std::vector<int> TClist_;
         bool reject_;
-        //      int num_;
 
     public:
         SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0,reject_=false ;}

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -150,7 +150,7 @@ class HGCalConcentratorSuperTriggerCellImpl
 
     };
     void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
-    void coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+    void coarsenTriggerCells( std::vector<l1t::HGCalTriggerCell>& trigCellVecInput );
     
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -70,11 +70,14 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_; 
         unsigned maxId_;
-        std::vector<int> TClist_;
+        //        std::vector<int> TClist_;
+        HGCalDetId STC_HGCalDetId;
+        HGCalTriggerDetId STC_HGCalTriggerDetId;
 
     public:
-        SuperTriggerCell(){  sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0 ;}
-        void add(const l1t::HGCalTriggerCell &c) {
+        SuperTriggerCell(){  
+          sumPt_=0, sumMipPt_=0, sumHwPt_=0, maxHwPt_=0, maxId_=0, fracsum_ = 0, stcId_ = 0; }
+        void add(const l1t::HGCalTriggerCell &c, int stcId) {
             sumPt_ += c.pt();
             sumMipPt_ += c.mipPt();
             sumHwPt_ += c.hwPt();
@@ -82,8 +85,10 @@ class HGCalConcentratorSuperTriggerCellImpl
                 maxHwPt_ = c.hwPt();
                 maxId_ = c.detId();
             }
-
-            TClist_.push_back( c.detId() );
+            
+            if  ( stcId_ != 0 ){
+              stcId_ = stcId;
+            }
         }
         void getFractionSum(const l1t::HGCalTriggerCell &c) {
 
@@ -108,12 +113,12 @@ class HGCalConcentratorSuperTriggerCellImpl
             c.setMipPt(sumMipPt_);
             c.setPt( sumPt_ );
           }
-	  else if ( energyDivisionType_ == equalShare ){
+          else if ( energyDivisionType_ == equalShare ){
             c.setHwPt( sumHwPt_/4 );
             c.setMipPt( sumMipPt_/4 );
             c.setPt( sumPt_/4 );
           }
-	  else if (  energyDivisionType_ == oneBitFraction ){
+          else if (  energyDivisionType_ == oneBitFraction ){
 
             double f = c.pt() / sumPt_ ;
             double frac = 0;
@@ -141,9 +146,8 @@ class HGCalConcentratorSuperTriggerCellImpl
           maxHwPt_ = c.hwPt();
         }
         unsigned GetMaxId()const{return maxId_;}
+        unsigned GetSTCId()const{return stcId_;}
         int GetMaxHwPt()const{return maxHwPt_;}
-        unsigned GetNTCs()const{return TClist_.size();}
-        const std::vector<int>& GetTCList()const{return TClist_;}
 
     };
     void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -55,6 +55,7 @@ class HGCalConcentratorSuperTriggerCellImpl
         float sumPt_, sumMipPt_, fracsum_;
         int sumHwPt_, maxHwPt_, stcId_; 
         unsigned maxId_;
+	std::map<int,float> tc_pts_;
 
     public:
         SuperTriggerCell(){  
@@ -71,6 +72,7 @@ class HGCalConcentratorSuperTriggerCellImpl
             if  ( stcId_ == 0 ){
               stcId_ = stcId;
             }
+	    tc_pts_[c.detId()] = c.pt();
 
         }
         void SetMaxTC(const l1t::HGCalTriggerCell &c){
@@ -93,9 +95,14 @@ class HGCalConcentratorSuperTriggerCellImpl
         int GetFractionSum()const{
 	  return fracsum_;
 	}
+	float GetTCpt(int tcid ){
+	  if ( tc_pts_.count(tcid) > 0 ) return tc_pts_[tcid];
+	  else return 0;
+	}
+
 
     };
-    void createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
+    void createAllTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
     void assignSuperTriggerCellEnergy(l1t::HGCalTriggerCell &c, const SuperTriggerCell &stc) const;
     float getTriggerCellOneBitFraction( float tcPt, float sumPt ) const;
 };

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -9,7 +9,7 @@ DEFINE_EDM_PLUGIN(HGCalConcentratorFactory,
 
 HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf)  : 
   HGCalConcentratorProcessorBase(conf),
-  fixedDataSize_(conf.getParameter<bool>("fixedDataSize"))
+  fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC"))
 { 
   std::string selectionType(conf.getParameter<std::string>("Method"));
   if (selectionType == "thresholdSelect"){
@@ -23,7 +23,7 @@ HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const e
   else if (selectionType == "superTriggerCellSelect"){
     selectionType_ = superTriggerCellSelect;
     concentratorSTCImpl_ = std::make_unique<HGCalConcentratorSuperTriggerCellImpl>(conf);
-    if ( fixedDataSize_ ) concentratorCoarsenerImpl_ = std::make_unique<HGCalConcentratorCoarsenerImpl>(conf);
+    if ( fixedDataSizePerHGCROC_ ) concentratorCoarsenerImpl_ = std::make_unique<HGCalConcentratorCoarsenerImpl>(conf);
   }
   else{
     throw cms::Exception("HGCTriggerParameterError")
@@ -58,7 +58,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
         concentratorProcImpl_->bestChoiceSelectImpl(module_trigcell.second, trigCellVecOutput);     
         break;
       case superTriggerCellSelect:
-	if ( fixedDataSize_ ){
+	if ( fixedDataSizePerHGCROC_ ){
 	  std::vector<l1t::HGCalTriggerCell> trigCellVecCoarsened;	  
 	  concentratorCoarsenerImpl_->coarseTriggerCellSelectImpl(module_trigcell.second,trigCellVecCoarsened);
 	  concentratorSTCImpl_->superTriggerCellSelectImpl(trigCellVecCoarsened, trigCellVecOutput);

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -30,7 +30,9 @@ HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const e
       << "Unknown type of concentrator selection '" << selectionType << "'";
   }
 
-  if ( coarsenTriggerCells_ || fixedDataSizePerHGCROC_ ){   
+  if ( fixedDataSizePerHGCROC_) coarsenTriggerCells_ = true;
+
+  if ( coarsenTriggerCells_ ){   
     concentratorCoarsenerImpl_ = std::make_unique<HGCalConcentratorCoarsenerImpl>(conf);
   }
 
@@ -55,7 +57,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
 
     std::vector<l1t::HGCalTriggerCell> trigCellVecOutput;
     std::vector<l1t::HGCalTriggerCell> trigCellVecCoarsened;	  
-    if ( coarsenTriggerCells_ || fixedDataSizePerHGCROC_ ){
+    if ( coarsenTriggerCells_ ){
       concentratorCoarsenerImpl_->coarseTriggerCellSelectImpl(module_trigcell.second,trigCellVecCoarsened);
 
       switch(selectionType_){

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -6,10 +6,12 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 def custom_triggercellselect_supertriggercell(process,
                                               stcSize=supertc_conc_proc.stcSize,
                                               type_energy_division=supertc_conc_proc.type_energy_division
+                                              fixedDataSize=supertc_conc_proc.fixedDataSize
                                               ):
     parameters = supertc_conc_proc.clone()
     parameters.stcSize = stcSize
     parameters.type_energy_division = type_energy_division
+    parameters.fixedDataSize = fixedDataSize
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -4,10 +4,12 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 
 
 def custom_triggercellselect_supertriggercell(process,
-                                              stcSize=supertc_conc_proc.stcSize
+                                              stcSize=supertc_conc_proc.stcSize,
+                                              type_energy_division=supertc_conc_proc.type_energy_division
                                               ):
     parameters = supertc_conc_proc.clone()
     parameters.stcSize = stcSize
+    parameters.type_energy_division = type_energy_division
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -6,12 +6,12 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 def custom_triggercellselect_supertriggercell(process,
                                               stcSize=supertc_conc_proc.stcSize,
                                               type_energy_division=supertc_conc_proc.type_energy_division,
-                                              fixedDataSize=supertc_conc_proc.fixedDataSize
+                                              fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC
                                               ):
     parameters = supertc_conc_proc.clone()
     parameters.stcSize = stcSize
     parameters.type_energy_division = type_energy_division
-    parameters.fixedDataSize = fixedDataSize
+    parameters.fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 
@@ -33,4 +33,30 @@ def custom_triggercellselect_bestchoice(process,
     parameters = best_conc_proc.clone()
     parameters.NData = triggercells
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
+    return process
+
+
+
+
+def custom_typeenergydivision_onebitfraction(process,
+                                             oneBitFractionThreshold = 0.125,
+                                             oneBitFractionLowValue = 0.0625,
+                                             oneBitFractionHighValue = 0.25,
+                                             ):
+    parameters = process.hgcalConcentratorProducer.ProcessorParameters = parameters
+    parameters.oneBitFractionThreshold = cms.double(oneBitFractionThreshold);
+    parameters.oneBitFractionLowValue = cms.double(oneBitFractionLowValue);
+    parameters.oneBitFractionHighValue = cms.double(oneBitFractionHighValue);
+
+    return process
+
+
+
+
+def custom_typeenergydivision_equalshare(process,
+                                         nTriggerCellsForDivision = 4
+                                         ):
+    parameters = process.hgcalConcentratorProducer.ProcessorParameters = parameters
+    parameters.nTriggerCellsForDivision = cms.int32(nTriggerCellsForDivision);
+
     return process

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -5,7 +5,7 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 
 def custom_triggercellselect_supertriggercell(process,
                                               stcSize=supertc_conc_proc.stcSize,
-                                              type_energy_division=supertc_conc_proc.type_energy_division
+                                              type_energy_division=supertc_conc_proc.type_energy_division,
                                               fixedDataSize=supertc_conc_proc.fixedDataSize
                                               ):
     parameters = supertc_conc_proc.clone()

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, typeenergydivision_onebitfraction_proc, typeenergydivision_equalshare_proc
 
 
 def custom_triggercellselect_supertriggercell(process,
@@ -39,14 +39,14 @@ def custom_triggercellselect_bestchoice(process,
 
 
 def custom_typeenergydivision_onebitfraction(process,
-                                             oneBitFractionThreshold = 0.125,
-                                             oneBitFractionLowValue = 0.0625,
-                                             oneBitFractionHighValue = 0.25,
+                                             oneBitFractionThreshold = typeenergydivision_onebitfraction_proc.oneBitFractionThreshold,
+                                             oneBitFractionLowValue = typeenergydivision_onebitfraction_proc.oneBitFractionLowValue,
+                                             oneBitFractionHighValue = typeenergydivision_onebitfraction_proc.oneBitFractionHighValue,
                                              ):
-    parameters = process.hgcalConcentratorProducer.ProcessorParameters = parameters
-    parameters.oneBitFractionThreshold = cms.double(oneBitFractionThreshold);
-    parameters.oneBitFractionLowValue = cms.double(oneBitFractionLowValue);
-    parameters.oneBitFractionHighValue = cms.double(oneBitFractionHighValue);
+    parameters = typeenergydivision_onebitfraction_proc.clone()
+    parameters.oneBitFractionThreshold = oneBitFractionThreshold;
+    parameters.oneBitFractionLowValue = oneBitFractionLowValue;
+    parameters.oneBitFractionHighValue = oneBitFractionHighValue;
 
     return process
 
@@ -56,7 +56,7 @@ def custom_typeenergydivision_onebitfraction(process,
 def custom_typeenergydivision_equalshare(process,
                                          nTriggerCellsForDivision = 4
                                          ):
-    parameters = process.hgcalConcentratorProducer.ProcessorParameters = parameters
-    parameters.nTriggerCellsForDivision = cms.int32(nTriggerCellsForDivision);
+    parameters = typeenergydivision_equalshare_proc.clone()
+    parameters.nTriggerCellsForDivision = nTriggerCellsForDivision;
 
     return process

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -37,7 +37,7 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              Method = cms.string('superTriggerCellSelect'),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4),
-                             fixedDataSize = cms.bool(True)
+                             fixedDataSizePerHGCROC = cms.bool(True)
                              )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -43,6 +43,30 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              coarsenTriggerCells = cms.bool(False)
                              )
 
+typeenergydivision_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                             Method = cms.string('superTriggerCellSelect'),
+                             type_energy_division = cms.string('oneBitFraction'),
+                             stcSize = cms.vuint32(4,8,8),
+                             fixedDataSizePerHGCROC = cms.bool(True),
+                             coarsenTriggerCells = cms.bool(False),
+                             oneBitFractionThreshold = 0.125,
+                             oneBitFractionLowValue = 0.0625,
+                             oneBitFractionHighValue = 0.25,
+                             )
+
+
+typeenergydivision_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                             Method = cms.string('superTriggerCellSelect'),
+                             type_energy_division = cms.string('equalShare'),
+                             stcSize = cms.vuint32(4,8,8),
+                             fixedDataSizePerHGCROC = cms.bool(True),
+                             coarsenTriggerCells = cms.bool(False),
+                             nTriggerCellsForDivision = 4
+)
+
+
+
+
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 # V9 samples have a different defintiion of the dEdx calibrations. To account for it

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -40,7 +40,7 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4),
                              fixedDataSizePerHGCROC = cms.bool(False),
-                             coarsenTriggerCells = cms.bool(False)
+                             coarsenTriggerCells = cms.bool(False),
                              )
 
 typeenergydivision_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -49,9 +49,9 @@ typeenergydivision_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('H
                              stcSize = cms.vuint32(4,8,8),
                              fixedDataSizePerHGCROC = cms.bool(True),
                              coarsenTriggerCells = cms.bool(False),
-                             oneBitFractionThreshold = 0.125,
-                             oneBitFractionLowValue = 0.0625,
-                             oneBitFractionHighValue = 0.25,
+                             oneBitFractionThreshold = cms.double(0.125),
+                             oneBitFractionLowValue = cms.double(0.0625),
+                             oneBitFractionHighValue = cms.double(0.25)
                              )
 
 
@@ -61,7 +61,7 @@ typeenergydivision_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCal
                              stcSize = cms.vuint32(4,8,8),
                              fixedDataSizePerHGCROC = cms.bool(True),
                              coarsenTriggerCells = cms.bool(False),
-                             nTriggerCellsForDivision = 4
+                             nTriggerCellsForDivision = cms.vuint32(4),
 )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -16,6 +16,7 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                TCThresholdBH_MIP = cms.double(0.),
                                triggercell_threshold_silicon = cms.double(2.), # MipT
                                triggercell_threshold_scintillator = cms.double(2.), # MipT
+                               coarsenTriggerCells = cms.bool(False)
                                )
 
 
@@ -30,6 +31,7 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           TCThresholdBH_MIP = cms.double(0.),
                           triggercell_threshold_silicon = cms.double(0.),
                           triggercell_threshold_scintillator = cms.double(0.),
+                          coarsenTriggerCells = cms.bool(False)
                           )
 
 
@@ -37,7 +39,8 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              Method = cms.string('superTriggerCellSelect'),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4),
-                             fixedDataSizePerHGCROC = cms.bool(True)
+                             fixedDataSizePerHGCROC = cms.bool(False)
+                             coarsenTriggerCells = cms.bool(False)
                              )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -39,7 +39,7 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              Method = cms.string('superTriggerCellSelect'),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4),
-                             fixedDataSizePerHGCROC = cms.bool(False)
+                             fixedDataSizePerHGCROC = cms.bool(False),
                              coarsenTriggerCells = cms.bool(False)
                              )
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -36,7 +36,8 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.string('superTriggerCellSelect'),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
-                             stcSize = cms.vuint32(4,4,4)
+                             stcSize = cms.vuint32(4,4,4),
+                             fixedDataSize = cms.bool(True)
                              )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -5,8 +5,6 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
 adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
-<<<<<<< Updated upstream
-
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.string('thresholdSelect'),
                                NData = cms.uint32(999),
@@ -37,7 +35,7 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.string('superTriggerCellSelect'),
-                             type_energy_division = cms.string('equalShare'),# superTriggerCell,oneBitFraction,equalShare
+                             type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4)
                              )
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -5,6 +5,7 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
 adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
+<<<<<<< Updated upstream
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.string('thresholdSelect'),
@@ -36,6 +37,7 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.string('superTriggerCellSelect'),
+                             type_energy_division = cms.string('equalShare'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(4,4,4)
                              )
 
@@ -49,7 +51,6 @@ phase2_hgcalV9.toModify(threshold_conc_proc,
                         triggercell_threshold_silicon=cms.double(1.5),  # MipT
                         triggercell_threshold_scintillator=cms.double(1.5),  # MipT
                         )
-
 
 hgcalConcentratorProducer = cms.EDProducer(
     "HGCalConcentratorProducer",

--- a/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
@@ -34,6 +34,8 @@ thicknessCorrection_200 = thicknessCorrection[1]
 triggerCellLsbBeforeCompression = 100./1024.
 triggerCellTruncationBits = 0
 
+sensor_thresh = 3.
+
 vfe_proc = cms.PSet( ProcessorName = cms.string('HGCalVFEProcessorSums'),
                      linLSB = cms.double(triggerCellLsbBeforeCompression),
                      adcsaturation = adcSaturation_fC,
@@ -46,8 +48,8 @@ vfe_proc = cms.PSet( ProcessorName = cms.string('HGCalVFEProcessorSums'),
                      scintillatorCellLSB_MIP = cms.double(float(adcSaturationBH_MIP.value())/(2**float(adcNbitsBH.value()))),
                      # cell thresholds before TC sums
                      # Cut at 3sigma of the noise
-                     thresholdsSilicon = cms.vdouble([3.*x for x in digiparam.HGCAL_noise_fC.values.value()]),
-                     thresholdScintillator = cms.double(3.*digiparam.HGCAL_noise_MIP.value.value()),
+                     thresholdsSilicon = cms.vdouble([sensor_thresh*x for x in digiparam.HGCAL_noise_fC.values.value()]),
+                     thresholdScintillator = cms.double(sensor_thresh*digiparam.HGCAL_noise_MIP.value.value()),
                      # Floating point compression
                      exponentBits = cms.uint32(4),
                      mantissaBits = cms.uint32(4),

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -3,8 +3,17 @@
 
 
 HGCalCoarseTriggerCellMapping::
-HGCalCoarseTriggerCellMapping()
+HGCalCoarseTriggerCellMapping(const edm::ParameterSet& conf)
+  :  stcSize_(conf.existsAs<std::vector<unsigned>>("stcSize") ? conf.getParameter<std::vector<unsigned>>("stcSize") : 
+	      std::vector<unsigned>{2,2,2})
 {
+      if ( stcSize_.size() != kNLayers_ ){
+        throw cms::Exception("HGCTriggerParameterError")
+            << "Inconsistent size of coarse trigger cell size vector" << stcSize_.size() ;
+    }
+
+    for(auto stc : stcSize_) checkSizeValidity(stc);
+
 }
 
 
@@ -75,6 +84,11 @@ HGCalCoarseTriggerCellMapping:: getEvenDetId(int tcid) const {
   }
 
   return evenid;
+}
+
+int
+HGCalCoarseTriggerCellMapping::getCoarseTriggerCellIdByThickness(int detid, int thickness) const {
+  return getCoarseTriggerCellId( detid, stcSize_.at(thickness) );
 }
 
 int
@@ -149,9 +163,17 @@ HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) co
 
 std::vector<uint32_t>
 HGCalCoarseTriggerCellMapping::
+getConstituentTriggerCellsByThickness( int ctcId, int thickness) const
+{ 
+  return getConstituentTriggerCells( ctcId, stcSize_.at(thickness));
+}
+
+
+std::vector<uint32_t>
+HGCalCoarseTriggerCellMapping::
 getConstituentTriggerCells( int ctcId, int ctcSize) const
 { 
-
+  
   std::vector<uint32_t> output_ids;
   DetId TC_id( ctcId );
 

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -35,16 +35,22 @@ HGCalCoarseTriggerCellMapping::checkSizeValidity(int ctcSize )const{
 
 void
 HGCalCoarseTriggerCellMapping:: setEvenDetId(l1t::HGCalTriggerCell &c) const {
+  c.setDetId( getEvenDetId( c.detId() ) );
+}
+
+uint32_t
+HGCalCoarseTriggerCellMapping:: getEvenDetId(int tcid) const {
   
-  DetId TC_id( c.detId() );
+  int evenid = -1;
+  DetId TC_id( tcid );
   if ( TC_id.det() == DetId::Forward ){//V8
-    c.setDetId( c.detId() & ~1 );
+    evenid = tcid & ~1;
   }
   else if ( TC_id.det() == DetId::HGCalTrigger ){//V9
     int Uprime = 0;
     int newU = 0;
     int newV = 0;
-    HGCalTriggerDetId TC_idV9(c.detId());  
+    HGCalTriggerDetId TC_idV9(tcid);  
     int rocnum = detIdToROC_.getROCNumber( TC_idV9.triggerCellU() , TC_idV9.triggerCellV(), 1 );
     if ( rocnum == 1 ){
       Uprime = TC_idV9.triggerCellU();
@@ -62,13 +68,15 @@ HGCalCoarseTriggerCellMapping:: setEvenDetId(l1t::HGCalTriggerCell &c) const {
       newV = TC_idV9.triggerCellV();
     }
 
-    int newid = c.detId() & ~(HGCalDetId::kHGCalCellMask);
-    newid |= ( ((newU & kHGCalCellUMask_) << kHGCalCellUOffset_ ) |
+    evenid = tcid & ~(HGCalDetId::kHGCalCellMask);
+    evenid |= ( ((newU & kHGCalCellUMask_) << kHGCalCellUOffset_ ) |
 	       ((newV & kHGCalCellVMask_) << kHGCalCellVOffset_ ));
 
-    c.setDetId( newid );
+    //c.setDetId( newid );
 
   }
+
+  return evenid;
 }
 
 int

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -1,0 +1,147 @@
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+
+
+HGCalCoarseTriggerCellMapping::
+HGCalCoarseTriggerCellMapping()
+{
+}
+
+
+std::map<int,int> 
+HGCalCoarseTriggerCellMapping::kSplit_ = {
+  {kCTCsizeVeryFine_, kSplit_v8_VeryFine_},
+  {kCTCsizeFine_, kSplit_v8_Fine_},
+  {kCTCsizeMid_, kSplit_v8_Mid_},
+  {kCTCsizeCoarse_, kSplit_v8_Coarse_}
+};
+
+std::map<int,int> 
+HGCalCoarseTriggerCellMapping::kSplit_v9_ = {
+  {kCTCsizeVeryFine_, kSplit_v9_VeryFine_},
+  {kCTCsizeFine_, kSplit_v9_Fine_},
+  {kCTCsizeMid_, kSplit_v9_Mid_},
+};
+
+void
+HGCalCoarseTriggerCellMapping::checkSizeValidity(int ctcSize )const{
+  if ( ctcSize!=kCTCsizeFine_ && ctcSize!=kCTCsizeCoarse_ && ctcSize!=kCTCsizeMid_ && ctcSize!=kCTCsizeVeryFine_){
+    throw cms::Exception("HGCTriggerParameterError")
+      << "Coarse Trigger Cell should be of size "<<
+      kCTCsizeVeryFine_ << " or " << kCTCsizeFine_ <<
+      kCTCsizeMid_ << " or " << kCTCsizeCoarse_;
+  }
+}
+
+int
+HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) const {
+
+  checkSizeValidity (ctcSize);
+
+  DetId TC_id( detid );
+  if ( TC_id.det() == DetId::Forward ){//V8
+
+    HGCalDetId TC_idV8(detid);
+
+    if( triggerTools_.isScintillator(detid) ){
+      return detid; //scintillator
+    }
+    else{
+      int TC_split = (TC_idV8.cell() & kSplit_.at( ctcSize ) );
+      detid =  (detid & ~(TC_idV8.kHGCalCellMask ) ) | TC_split;
+      return detid;
+    }
+
+  }
+
+  else if ( TC_id.det() == DetId::HGCalTrigger ){//V9
+    
+    if( triggerTools_.isScintillator(detid) ){
+      HGCScintillatorDetId TC_idV9(detid);
+      return TC_idV9.ietaAbs() << HGCScintillatorDetId::kHGCalPhiOffset | TC_idV9.iphi(); //scintillator
+    }
+    else {
+      HGCalTriggerDetId TC_idV9(detid);
+
+      int TC_wafer = TC_idV9.waferU() << kWafer_offset_ | TC_idV9.waferV() ;
+
+      int Uprime = 0;
+      int Vprime = 0;
+      int rocnum = detIdToROC_.getROCNumber( TC_idV9.triggerCellU() , TC_idV9.triggerCellV(), 1 );
+
+      if ( rocnum == 1 ){
+
+          Uprime = TC_idV9.triggerCellU();
+          Vprime = TC_idV9.triggerCellV() - TC_idV9.triggerCellU();
+
+      }
+      else if ( rocnum == 2 ){
+
+          Uprime = TC_idV9.triggerCellU()-TC_idV9.triggerCellV()-1;
+          Vprime = TC_idV9.triggerCellV();
+
+      }
+      else if ( rocnum == 3 ){
+
+          Uprime = TC_idV9.triggerCellU()-kRotate4_;
+          Vprime = TC_idV9.triggerCellV()-kRotate4_;
+
+      }
+
+      int TC_split = -1;
+
+      if (ctcSize == kCTCsizeCoarse_){
+	TC_split =  rocnum;
+      }
+      else{
+	TC_split =  (rocnum << kRocShift_) | ( (Uprime << kUShift_ | Vprime) & kSplit_v9_.at( ctcSize ) );
+      }
+
+      return TC_wafer<<kWafer_offset_ | TC_split;
+      
+    }
+        
+  }
+  else{
+    return -1;
+  }
+  
+}
+
+void 
+HGCalCoarseTriggerCellMapping::
+getConstituentTriggerCells( int ctcId, int ctcSize, std::vector<int> & output_ids ) const
+{ 
+  
+  int SplitInv = ~( (~kSixBitMax_) | kSplit_.at ( ctcSize ) );
+
+  for ( int i = 0; i < SplitInv + 1 ; i++ ){
+    if (  (i & SplitInv)!=i  )  continue; 
+
+    output_ids.emplace_back( ctcId | i );
+
+  }
+
+}
+
+
+void 
+HGCalCoarseTriggerCellMapping::
+setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc )
+{ 
+
+     if (tc.subdetId() == HGCHEB) return;
+
+     int detid = tc.detId();        
+     int detid_odd = detid | 1;
+     GlobalPoint point_even = triggerTools_.getTCPosition(detid);
+     GlobalPoint point_odd = triggerTools_.getTCPosition(detid_odd);
+     GlobalPoint average_point  ( (point_even.x()+point_odd.x())/2,(point_even.y()+point_odd.y())/2,(point_even.z()+point_odd.z())/2  );     
+
+     math::PtEtaPhiMLorentzVector p4(tc.pt(), average_point.eta(), average_point.phi(), tc.mass());
+     tc.setPosition( average_point );
+     tc.setP4(p4);
+
+}
+
+

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -58,21 +58,19 @@ HGCalCoarseTriggerCellMapping:: getEvenDetId(int tcid) const {
       newV = TC_idV9.triggerCellV() - TC_idV9.triggerCellU() + newU;
     }
     else if ( rocnum == 2 ){
-      Uprime = TC_idV9.triggerCellU()-TC_idV9.triggerCellV()-1;
+      Uprime = TC_idV9.triggerCellU() - TC_idV9.triggerCellV()-1;
       newU = ( Uprime&~1 ) + TC_idV9.triggerCellV()+1;
       newV = TC_idV9.triggerCellV();
     }
-    else if ( rocnum == 3 ){
-      Uprime = TC_idV9.triggerCellU()-kRotate4_;
-      newU = ( Uprime&~1 ) + kRotate4_;
-      newV = TC_idV9.triggerCellV();
+    else if ( rocnum == 3 ){      
+      Uprime = TC_idV9.triggerCellV() - kRotate4_;      
+      newU = TC_idV9.triggerCellU();
+      newV = ( Uprime&~1 ) + kRotate4_;
     }
 
     evenid = tcid & ~(HGCalDetId::kHGCalCellMask);
     evenid |= ( ((newU & kHGCalCellUMask_) << kHGCalCellUOffset_ ) |
 	       ((newV & kHGCalCellVMask_) << kHGCalCellVOffset_ ));
-
-    //c.setDetId( newid );
 
   }
 
@@ -129,19 +127,12 @@ HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) co
       }
       else if ( rocnum == 3 ){
 
-          Uprime = TC_idV9.triggerCellU()-kRotate4_;
-          Vprime = TC_idV9.triggerCellV()-kRotate4_;
+          Uprime = TC_idV9.triggerCellV() - kRotate4_;
+          Vprime = kRotate7_ - TC_idV9.triggerCellU();
 
       }
 
-      //      int TC_split = -1;
-
-      // if (ctcSize == kCTCsizeCoarse_){
-      // 	TC_split =  rocnum;
-      // }
-      // else{
       int TC_split =  (rocnum << kRocShift_) | ( (Uprime << kUShift_ | Vprime) & kSplit_v9_.at( ctcSize ) );
-      //      }
 
       detid =  (detid & ~(HGCalDetId::kHGCalCellMask ) ) | TC_split;
 
@@ -197,8 +188,8 @@ getConstituentTriggerCells( int ctcId, int ctcSize) const
 	V = Vprime;
       }    
       else if ( rocnum == 3 ){
-	U = Uprime + kRotate4_;
-	V = Vprime + kRotate4_;
+	U = kRotate7_ - Vprime;
+	V = Uprime + kRotate4_;
       }
       
       ctcId &= ~(HGCalDetId::kHGCalCellMask);

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -33,6 +33,44 @@ HGCalCoarseTriggerCellMapping::checkSizeValidity(int ctcSize )const{
   }
 }
 
+void
+HGCalCoarseTriggerCellMapping:: setEvenDetId(l1t::HGCalTriggerCell &c) const {
+  
+  DetId TC_id( c.detId() );
+  if ( TC_id.det() == DetId::Forward ){//V8
+    c.setDetId( c.detId() & ~1 );
+  }
+  else if ( TC_id.det() == DetId::HGCalTrigger ){//V9
+    int Uprime = 0;
+    int newU = 0;
+    int newV = 0;
+    HGCalTriggerDetId TC_idV9(c.detId());  
+    int rocnum = detIdToROC_.getROCNumber( TC_idV9.triggerCellU() , TC_idV9.triggerCellV(), 1 );
+    if ( rocnum == 1 ){
+      Uprime = TC_idV9.triggerCellU();
+      newU = ( Uprime&~1 );
+      newV = TC_idV9.triggerCellV() - TC_idV9.triggerCellU() + newU;
+    }
+    else if ( rocnum == 2 ){
+      Uprime = TC_idV9.triggerCellU()-TC_idV9.triggerCellV()-1;
+      newU = ( Uprime&~1 ) + TC_idV9.triggerCellV()+1;
+      newV = TC_idV9.triggerCellV();
+    }
+    else if ( rocnum == 3 ){
+      Uprime = TC_idV9.triggerCellU()-kRotate4_;
+      newU = ( Uprime&~1 ) + kRotate4_;
+      newV = TC_idV9.triggerCellV();
+    }
+
+    int newid = c.detId() & ~(HGCalDetId::kHGCalCellMask);
+    newid |= ( ((newU & kHGCalCellUMask_) << kHGCalCellUOffset_ ) |
+	       ((newV & kHGCalCellVMask_) << kHGCalCellVOffset_ ));
+
+    c.setDetId( newid );
+
+  }
+}
+
 int
 HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) const {
 

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -148,12 +148,12 @@ HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) co
   
 }
 
-std::vector<int>
+std::vector<uint32_t>
 HGCalCoarseTriggerCellMapping::
 getConstituentTriggerCells( int ctcId, int ctcSize) const
 { 
 
-  std::vector<int> output_ids;
+  std::vector<uint32_t> output_ids;
   DetId TC_id( ctcId );
 
   if ( TC_id.det() == DetId::Forward ){//V8  
@@ -214,7 +214,7 @@ setCoarseTriggerCellPosition( l1t::HGCalTriggerCell& tc, const int coarse_size )
 
      if (tc.subdetId() == HGCHEB) return;
 
-     std::vector<int> constituentTCs = getConstituentTriggerCells ( getCoarseTriggerCellId(tc.detId(), coarse_size ), coarse_size );
+     std::vector<uint32_t> constituentTCs = getConstituentTriggerCells ( getCoarseTriggerCellId(tc.detId(), coarse_size ), coarse_size );
      
      double xsum = 0;
      double ysum = 0;

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -8,7 +8,7 @@ HGCalCoarseTriggerCellMapping()
 }
 
 
-std::map<int,int> 
+const std::map<int,int> 
 HGCalCoarseTriggerCellMapping::kSplit_ = {
   {kCTCsizeVeryFine_, kSplit_v8_VeryFine_},
   {kCTCsizeFine_, kSplit_v8_Fine_},
@@ -16,7 +16,7 @@ HGCalCoarseTriggerCellMapping::kSplit_ = {
   {kCTCsizeCoarse_, kSplit_v8_Coarse_}
 };
 
-std::map<int,int> 
+const std::map<int,int> 
 HGCalCoarseTriggerCellMapping::kSplit_v9_ = {
   {kCTCsizeVeryFine_, kSplit_v9_VeryFine_},
   {kCTCsizeFine_, kSplit_v9_Fine_},
@@ -48,7 +48,7 @@ HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(int detid, int ctcSize) co
     }
     else{
       int TC_split = (TC_idV8.cell() & kSplit_.at( ctcSize ) );
-      detid =  (detid & ~(TC_idV8.kHGCalCellMask ) ) | TC_split;
+      detid =  (detid & ~(HGCalDetId::kHGCalCellMask ) ) | TC_split;
       return detid;
     }
 
@@ -113,7 +113,7 @@ HGCalCoarseTriggerCellMapping::
 getConstituentTriggerCells( int ctcId, int ctcSize, std::vector<int> & output_ids ) const
 { 
   
-  int SplitInv = ~( (~kSixBitMax_) | kSplit_.at ( ctcSize ) );
+  int SplitInv = ~( (~kSTCidMask_) | kSplit_.at ( ctcSize ) );
 
   for ( int i = 0; i < SplitInv + 1 ; i++ ){
     if (  (i & SplitInv)!=i  )  continue; 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -56,6 +56,15 @@ eventSetup(const edm::EventSetup& es)
   }
 }
 
+bool HGCalTriggerTools::validTriggerCell(const DetId& id) const {
+  if(id.det() == DetId::Hcal || id.det()==DetId::HGCalEE) {
+    throw cms::Exception("hgcal::HGCalTriggerTools")
+      << "method getTCPosition called for DetId not belonging to a TC";
+  }
+
+  return ( geom_->validTriggerCell(id) );
+}
+
 GlobalPoint HGCalTriggerTools::getTCPosition(const DetId& id) const {
   if(id.det() == DetId::Hcal || id.det()==DetId::HGCalEE) {
     throw cms::Exception("hgcal::HGCalTriggerTools")

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -57,11 +57,6 @@ eventSetup(const edm::EventSetup& es)
 }
 
 bool HGCalTriggerTools::validTriggerCell(const DetId& id) const {
-  if(id.det() == DetId::Hcal || id.det()==DetId::HGCalEE) {
-    throw cms::Exception("hgcal::HGCalTriggerTools")
-      << "method getTCPosition called for DetId not belonging to a TC";
-  }
-
   return ( geom_->validTriggerCell(id) );
 }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -5,6 +5,7 @@
 
 HGCalConcentratorCoarsenerImpl::
 HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
+  : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC"))
 {    
 }
 
@@ -40,6 +41,7 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
   // first pass, fill the coarse trigger cell information
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB)  continue;
+
     int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
     updateCoarseTriggerCellMaps( tc, ctcid );
   }
@@ -49,12 +51,20 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
       trigCellVecOutput.push_back( tc );
     } else {
       int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
-      
+      int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
+
+      if ( fixedDataSizePerHGCROC_ && thickness == 0 ){
+	trigCellVecOutput.push_back( tc );
+	continue;
+      }      
+
       if ( tc.detId() == coarseTCmaxId[ctcid]){
-        trigCellVecOutput.push_back( tc );
+	trigCellVecOutput.push_back( tc );
 	assignCoarseTriggerCellEnergy( trigCellVecOutput.back(), ctcid );
 	setEvenDetId(trigCellVecOutput.back());        
+	coarseTCmapping_.setCoarseTriggerCellPosition( trigCellVecOutput.back() );
       }
+
 
     }
   }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -43,7 +43,7 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB)  continue;
 
-    int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
+    int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),kCoarse2Size_);
     updateCoarseTriggerCellMaps( tc, ctcid );
   }
 
@@ -51,10 +51,10 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
     if (tc.subdetId() == HGCHEB) {
       trigCellVecOutput.push_back( tc );
     } else {
-      int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
+      int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),kCoarse2Size_);
       int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
 
-      if ( fixedDataSizePerHGCROC_ && thickness == 0 ){
+      if ( fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_ ){
 	trigCellVecOutput.push_back( tc );
 	continue;
       }      
@@ -63,7 +63,7 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
 	trigCellVecOutput.push_back( tc );
 	assignCoarseTriggerCellEnergy( trigCellVecOutput.back(), ctcid );
 	setEvenDetId(trigCellVecOutput.back());        
-	coarseTCmapping_.setCoarseTriggerCellPosition( trigCellVecOutput.back() );
+	coarseTCmapping_.setCoarseTriggerCellPosition( trigCellVecOutput.back(), kCoarse2Size_ );
       }
 
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -1,0 +1,66 @@
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+
+#include <unordered_map>
+
+HGCalConcentratorCoarsenerImpl::
+HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
+{    
+}
+
+int
+HGCalConcentratorCoarsenerImpl::getSuperTriggerCellId(int detid) const {
+
+  DetId TC_id( detid );
+  if ( TC_id.det() == DetId::Forward ){//V8
+
+    HGCalDetId TC_idV8(detid);
+
+    if( triggerTools_.isScintillator(detid) ){
+      return detid; //scintillator
+    }
+    else{
+      int thickness = triggerTools_.thicknessIndex(detid,true);
+      int TC_split = (TC_idV8.cell() & kSplit_v8_VeryFine_ );
+      detid =  (detid & ~(TC_idV8.kHGCalCellMask ) ) | TC_split;
+      return detid;
+    }
+
+  }
+  else{
+    return -1;
+  }
+  
+}
+
+void 
+HGCalConcentratorCoarsenerImpl::
+coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
+{ 
+
+  std::unordered_map<unsigned,SuperTriggerCell> STCs;
+
+  // first pass, fill the coarse trigger cells
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+    if (tc.subdetId() == HGCHEB)  continue;
+    int stcid = getSuperTriggerCellId(tc.detId());
+    STCs[stcid].add(tc, stcid);
+  }
+
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+    if (tc.subdetId() == HGCHEB) {
+      trigCellVecOutput.push_back( tc );
+    } else {
+      const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+    
+      if (tc.detId() == stc.GetMaxId()){
+        trigCellVecOutput.push_back( tc );
+        stc.assignEnergy(trigCellVecOutput.back());        
+        stc.setEvenDetId(trigCellVecOutput.back());        
+      }
+
+    }
+  }
+
+
+}

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -8,30 +8,52 @@ HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
 {    
 }
 
+
+void 
+HGCalConcentratorCoarsenerImpl::
+updateCoarseTriggerCellMaps(const l1t::HGCalTriggerCell& tc, int ctcid){
+
+  coarseTCsumPt[ctcid] += tc.pt();
+  coarseTCsumHwPt[ctcid] += tc.hwPt();
+  coarseTCsumMipPt[ctcid] += tc.mipPt();
+
+  if ( tc.hwPt() > coarseTCmaxHwPt[ctcid] ){
+    coarseTCmaxId[ctcid] = tc.detId();
+    coarseTCmaxHwPt[ctcid] = tc.hwPt();
+  }
+
+}
+
+void
+HGCalConcentratorCoarsenerImpl::
+assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &tc, int ctcid){
+    tc.setHwPt(coarseTCsumHwPt[ctcid]);
+    tc.setMipPt(coarseTCsumMipPt[ctcid]);
+    tc.setPt(coarseTCsumPt[ctcid]);
+}
+
 void 
 HGCalConcentratorCoarsenerImpl::
 coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
 { 
 
-  std::unordered_map<unsigned,SuperTriggerCell> CTCs;
-
-  // first pass, fill the coarse trigger cells
+  // first pass, fill the coarse trigger cell information
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB)  continue;
     int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
-    CTCs[ctcid].add(tc);
+    updateCoarseTriggerCellMaps( tc, ctcid );
   }
 
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB) {
       trigCellVecOutput.push_back( tc );
     } else {
-      const auto & ctc = CTCs[coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2)]; 
-    
-      if (tc.detId() == ctc.GetMaxId()){
+      int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
+      
+      if ( tc.detId() == coarseTCmaxId[ctcid]){
         trigCellVecOutput.push_back( tc );
-        ctc.assignEnergy(trigCellVecOutput.back());        
-        ctc.setEvenDetId(trigCellVecOutput.back());        
+	assignCoarseTriggerCellEnergy( trigCellVecOutput.back(), ctcid );
+	setEvenDetId(trigCellVecOutput.back());        
       }
 
     }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -62,7 +62,7 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
       if ( tc.detId() == coarseTCMap_[ctcid].maxId){
 	trigCellVecOutput.push_back( tc );
 	assignCoarseTriggerCellEnergy( trigCellVecOutput.back(), ctcid );
-	setEvenDetId(trigCellVecOutput.back());        
+	coarseTCmapping_.setEvenDetId(trigCellVecOutput.back());        
 	coarseTCmapping_.setCoarseTriggerCellPosition( trigCellVecOutput.back(), kCoarse2Size_ );
       }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -13,14 +13,15 @@ HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
 void 
 HGCalConcentratorCoarsenerImpl::
 updateCoarseTriggerCellMaps(const l1t::HGCalTriggerCell& tc, int ctcid){
+  
 
-  coarseTCsumPt[ctcid] += tc.pt();
-  coarseTCsumHwPt[ctcid] += tc.hwPt();
-  coarseTCsumMipPt[ctcid] += tc.mipPt();
+  coarseTCMap_[ctcid].sumPt += tc.pt();
+  coarseTCMap_[ctcid].sumHwPt += tc.hwPt();
+  coarseTCMap_[ctcid].sumMipPt += tc.mipPt();
 
-  if ( tc.hwPt() > coarseTCmaxHwPt[ctcid] ){
-    coarseTCmaxId[ctcid] = tc.detId();
-    coarseTCmaxHwPt[ctcid] = tc.hwPt();
+  if ( tc.hwPt() > coarseTCMap_[ctcid].sumHwPt ){
+    coarseTCMap_[ctcid].maxId = tc.detId();
+    coarseTCMap_[ctcid].maxHwPt = tc.hwPt();
   }
 
 }
@@ -28,9 +29,9 @@ updateCoarseTriggerCellMaps(const l1t::HGCalTriggerCell& tc, int ctcid){
 void
 HGCalConcentratorCoarsenerImpl::
 assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell &tc, int ctcid){
-    tc.setHwPt(coarseTCsumHwPt[ctcid]);
-    tc.setMipPt(coarseTCsumMipPt[ctcid]);
-    tc.setPt(coarseTCsumPt[ctcid]);
+    tc.setHwPt(coarseTCMap_[ctcid].sumHwPt);
+    tc.setMipPt(coarseTCMap_[ctcid].sumMipPt);
+    tc.setPt(coarseTCMap_[ctcid].sumPt);
 }
 
 void 
@@ -58,7 +59,7 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
 	continue;
       }      
 
-      if ( tc.detId() == coarseTCmaxId[ctcid]){
+      if ( tc.detId() == coarseTCMap_[ctcid].maxId){
 	trigCellVecOutput.push_back( tc );
 	assignCoarseTriggerCellEnergy( trigCellVecOutput.back(), ctcid );
 	setEvenDetId(trigCellVecOutput.back());        

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -8,55 +8,30 @@ HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
 {    
 }
 
-int
-HGCalConcentratorCoarsenerImpl::getSuperTriggerCellId(int detid) const {
-
-  DetId TC_id( detid );
-  if ( TC_id.det() == DetId::Forward ){//V8
-
-    HGCalDetId TC_idV8(detid);
-
-    if( triggerTools_.isScintillator(detid) ){
-      return detid; //scintillator
-    }
-    else{
-      int thickness = triggerTools_.thicknessIndex(detid,true);
-      int TC_split = (TC_idV8.cell() & kSplit_v8_VeryFine_ );
-      detid =  (detid & ~(TC_idV8.kHGCalCellMask ) ) | TC_split;
-      return detid;
-    }
-
-  }
-  else{
-    return -1;
-  }
-  
-}
-
 void 
 HGCalConcentratorCoarsenerImpl::
 coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
 { 
 
-  std::unordered_map<unsigned,SuperTriggerCell> STCs;
+  std::unordered_map<unsigned,SuperTriggerCell> CTCs;
 
   // first pass, fill the coarse trigger cells
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB)  continue;
-    int stcid = getSuperTriggerCellId(tc.detId());
-    STCs[stcid].add(tc, stcid);
+    int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2);
+    CTCs[ctcid].add(tc);
   }
 
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB) {
       trigCellVecOutput.push_back( tc );
     } else {
-      const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+      const auto & ctc = CTCs[coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),2)]; 
     
-      if (tc.detId() == stc.GetMaxId()){
+      if (tc.detId() == ctc.GetMaxId()){
         trigCellVecOutput.push_back( tc );
-        stc.assignEnergy(trigCellVecOutput.back());        
-        stc.setEvenDetId(trigCellVecOutput.back());        
+        ctc.assignEnergy(trigCellVecOutput.back());        
+        ctc.setEvenDetId(trigCellVecOutput.back());        
       }
 
     }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -5,7 +5,8 @@
 
 HGCalConcentratorCoarsenerImpl::
 HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
-  : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC"))
+  : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+    coarseTCmapping_(conf)
 {    
 }
 
@@ -42,7 +43,6 @@ coarseTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVe
   // first pass, fill the coarse trigger cell information
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
     if (tc.subdetId() == HGCHEB)  continue;
-
     int ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),kCoarse2Size_);
     updateCoarseTriggerCellMaps( tc, ctcid );
   }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -153,7 +153,7 @@ HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid, int STCs
 
 void 
 HGCalConcentratorSuperTriggerCellImpl::
-createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
+createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const
 { 
 
 
@@ -334,7 +334,7 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
 
       if (!(tc.detId() & 1)) { //if even
         const auto & ctc = coarseTCs[getSuperTriggerCellId(tc.detId(),2)]; 
-        const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+        auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
         trigCellVecOutput.push_back( tc );
         ctc.assignEnergy(trigCellVecOutput.back(), "STC");      
         //        //reassign max id to the correct one;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -50,30 +50,6 @@ HGCalConcentratorSuperTriggerCellImpl::kSplit_v9_ = {
   {kSTCsizeMid_, kSplit_v9_Mid_},
 };
 
-// int
-// HGCalConcentratorSuperTriggerCellImpl::getCoarseTriggerCellId(int detid) const {
-
-//   DetId TC_id( detid );
-//   if ( TC_id.det() == DetId::Forward ){//V8
-    
-//     HGCalDetId TC_idV8(detid);
-    
-//     if( triggerTools_.isScintillator(detid) ){
-//       return TC_idV8.cell(); //scintillator
-//     }
-//     else{
-//       int TC_wafer = TC_idV8.wafer();
-//       int TC_split = ( TC_idV8.cell() & kSplit_.at( 2 ) );
-//       return TC_wafer<<kWafer_offset_ | TC_split;
-//     }
-//   }
-//   else if ( TC_id.det() == DetId::HGCalTrigger ){//V9
-    
-//   }
-
-
-// }
-
 int
 HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid, int STCsize) const {
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -55,8 +55,8 @@ createAllTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std:
 
       for (const auto& id: output_ids){
 
-	if ( fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_ && id&kOddNumberMask_) {
-	  continue;//fixv9
+	if ( fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_ && id!=coarseTCmapping_.getEvenDetId(id)) {
+	  continue;
 	}
 
         if ( !triggerTools_.validTriggerCell(id) ) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -53,7 +53,6 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
     for (const auto& s: STCs){
 
       int thickness = triggerTools_.thicknessIndex(s.second.GetSTCId(),true);
-      
       std::vector<int> output_ids;
       coarseTCmapping_.getConstituentTriggerCells( s.second.GetSTCId(), stcSize_.at(thickness), output_ids );
 
@@ -164,7 +163,10 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
   //Change coarse TC positions if needed
   if ( fixedDataSizePerHGCROC_ == true ){
     for  (l1t::HGCalTriggerCell & tc : trigCellVecInputEnlarged) {
-      coarseTCmapping_.setCoarseTriggerCellPosition( tc );
+      int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
+      if ( thickness > 0 ){
+	coarseTCmapping_.setCoarseTriggerCellPosition( tc );
+      }
     }
   }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -5,8 +5,7 @@
 
 HGCalConcentratorSuperTriggerCellImpl::
 HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
-  : energyType_(conf.getParameter<string>("type_energy_division")),
-    stcSize_(conf.getParameter< std::vector<unsigned> >("stcSize")),
+  : stcSize_(conf.getParameter< std::vector<unsigned> >("stcSize")),
     fixedDataSize_(conf.getParameter<bool>("fixedDataSize"))
 {
 
@@ -22,6 +21,8 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
               kSTCsizeMid_ << " or " << kSTCsizeCoarse_;
         }
     }
+
+    std::string energyType_(conf.getParameter<string>("type_energy_division"));
 
     if(energyType_=="superTriggerCell"){
       energyDivisionType_ = superTriggerCell;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -5,7 +5,8 @@
 
 HGCalConcentratorSuperTriggerCellImpl::
 HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
-  : stcSize_(conf.getParameter< std::vector<unsigned> >("stcSize"))
+  : energyType_(conf.getParameter<string>("type_energy_division")),
+    stcSize_(conf.getParameter< std::vector<unsigned> >("stcSize"))
 {
 
     if ( stcSize_.size() != kNLayers_ ){
@@ -18,6 +19,17 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
               << "Super Trigger Cell should be of size 2, 4, 8 or 16" ;
         }
     }
+
+    if(energyType_=="superTriggerCell"){
+      energyDivisionType_ = superTriggerCell;
+    }else if(energyType_=="oneBitFraction"){
+      energyDivisionType_ = oneBitFraction;
+    }else if(energyType_=="equalShare"){
+      energyDivisionType_ = equalShare;
+    }else {
+      energyDivisionType_ = superTriggerCell;
+    } 
+
     
 }
 
@@ -338,7 +350,6 @@ HGCalConcentratorSuperTriggerCellImpl::
 superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
 { 
 
-  energyDivisionType_ = superTriggerCell;
   fixedDataSize_ = true;
 
   std::unordered_map<unsigned,SuperTriggerCell> STCs;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -75,10 +75,10 @@ HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid, int STCs
       int thickness = triggerTools_.thicknessIndex(detid,true);
       int TC_split = -1;
       if ( STCsize > 0 ){
-	( TC_idV8.cell() & kSplit_.at( STCsize ) );
+	TC_split = ( TC_idV8.cell() & kSplit_.at( STCsize ) );
       }
       else{
-	( TC_idV8.cell() & kSplit_.at( stcSize_.at(thickness) ) );
+        TC_split = (TC_idV8.cell() & kSplit_.at( stcSize_.at(thickness) ) );
       }
 
 
@@ -334,7 +334,7 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
 
       if (!(tc.detId() & 1)) { //if even
         const auto & ctc = coarseTCs[getSuperTriggerCellId(tc.detId(),2)]; 
-        auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+        const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
         trigCellVecOutput.push_back( tc );
         ctc.assignEnergy(trigCellVecOutput.back(), "STC");      
         //        //reassign max id to the correct one;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -155,57 +155,57 @@ HGCalConcentratorSuperTriggerCellImpl::
 createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const
 { 
 
-
     for (auto& s: STCs){
 
-      bool satisfy = false;
+      //      bool satisfy = false;
       //Find and create missing TCs (for super TC 4)
       int thickness = triggerTools_.thicknessIndex(s.second.GetTCList().at(0),true);
             
       if ( stcSize_.at(thickness) ==  4 ){
         
-        for ( int i = 0; i < 2; i++ ){
+        // for ( int i = 0; i < 2; i++ ){
+        //   for ( int j = 0; j < 2; j++ ){
+            
+        //     satisfy = false;
+        //     for (auto tc:s.second.GetTCList() ){
+        //       HGCalDetId TC_idV8(tc);
+        //       if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>2) & 1) == j )){
+        //         satisfy = true;
+        //       }
+              
+        //     }
+        //     if ( satisfy == false ){//Create new TC
+
+	for ( int i = 0; i < 2; i++ ){
           for ( int j = 0; j < 2; j++ ){
+	    int tc_base = s.second.GetTCList().at(0);
+	    //Clear relevant bits         
+	    tc_base = tc_base & ~(1 << 2); 
+	    tc_base = tc_base & ~(1); 
+	    //Set bits based on i and j values
+	    int newtc = tc_base | i;
+	    newtc = newtc | (j<<2);
+	    
+	    if ( !triggerTools_.validTriggerCell(newtc) ) {
+	      s.second.reject();
+	      continue;
+	    }
             
-            satisfy = false;
-            for (auto tc:s.second.GetTCList() ){
-              HGCalDetId TC_idV8(tc);
-              if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>2) & 1) == j )){
-                satisfy = true;
-              }
-              
-            }
-            if ( satisfy == false ){//Create new TC
-              int tc_base = s.second.GetTCList().at(0);
-              //Clear relevant bits         
-              tc_base = tc_base & ~(1 << 2); 
-              tc_base = tc_base & ~(1); 
-              //Set bits based on i and j values
-              int newtc = tc_base | i;
-              newtc = newtc | (j<<2);
-
-                if ( !triggerTools_.validTriggerCell(newtc) ) {
-                  s.second.reject();
-                  continue;
-                }
-              
-              l1t::HGCalTriggerCell triggerCell;
-              GlobalPoint point = triggerTools_.getTCPosition(newtc);
-              math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-
-              triggerCell.setPosition(point);
-              triggerCell.setP4(p4);
-              triggerCell.setDetId(newtc);
-              
-              s.second.addToList( triggerCell );
-              trigCellVecOutput.push_back ( triggerCell );
-              
-            }
+	    l1t::HGCalTriggerCell triggerCell;
+	    GlobalPoint point = triggerTools_.getTCPosition(newtc);
+	    math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+	    
+	    triggerCell.setPosition(point);
+	    triggerCell.setP4(p4);
+	    triggerCell.setDetId(newtc);
             
-          }
+	    s.second.addToList( triggerCell );
+	    trigCellVecOutput.push_back ( triggerCell );
+            
+	  }
         }
       }
-
+      
       else if (stcSize_.at(thickness) == 2){
         
         for ( int i = 0; i < 2; i++ ){
@@ -372,7 +372,7 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
 
   // first pass, fill the "coarse" trigger cells
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
-    trigCellVecInputEnlarged.push_back ( tc );
+    //    trigCellVecInputEnlarged.push_back ( tc );
     if (tc.subdetId() == HGCHEB) continue;
     STCs[getSuperTriggerCellId(tc.detId())].add(tc);
   }
@@ -381,9 +381,9 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
   //The missing trigger cells are needed to be created both for coarsening the existing TC
   // in the thick modules (for the fixed data size choice), or for any of the energy spread algorithms (except super TCs)
 
-  if ( fixedDataSize_ == true || energyDivisionType_!=superTriggerCell){
-    createMissingTriggerCells( STCs, trigCellVecInputEnlarged);
-  }
+  //  if ( fixedDataSize_ == true || energyDivisionType_!=superTriggerCell){
+  createMissingTriggerCells( STCs, trigCellVecInputEnlarged);
+  //  }
 
 
   //Coarsen if needed

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -168,7 +168,7 @@ HGCalConcentratorSuperTriggerCellImpl::
 createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const
 { 
 
-    for (auto& s: STCs){
+    for (const auto& s: STCs){
 
       //      bool satisfy = false;
       //Find and create missing TCs (for super TC 4)

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -99,7 +99,6 @@ HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid, int STCs
       int TC_wafer = TC_idV9.waferU() << kWafer_offset_ | TC_idV9.waferV() ;
       int thickness = triggerTools_.thicknessIndex(detid);
 
-      int TC_12th = 0;
       int Uprime = 0;
       int Vprime = 0;
       int rocnum = detIdToROC_.getROCNumber( TC_idV9.triggerCellU() , TC_idV9.triggerCellV(), 1 );

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -35,8 +35,6 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
 
       nTriggerCellsForDivision_ = conf.getParameter<int>("nTriggerCellsForDivision");
 
-    }else if(energyType_=="coarse2TriggerCell"){
-      energyDivisionType_ = coarse2TriggerCell;
     }else {
       energyDivisionType_ = superTriggerCell;
     } 
@@ -85,7 +83,7 @@ void
 HGCalConcentratorSuperTriggerCellImpl::
  assignSuperTriggerCellEnergy(l1t::HGCalTriggerCell &c, const SuperTriggerCell &stc) const {
       
-  if ( energyDivisionType_ == superTriggerCell || energyDivisionType_ == coarse2TriggerCell ){
+  if ( energyDivisionType_ == superTriggerCell ){
     c.setHwPt(stc.GetSumHwPt());
     c.setMipPt(stc.GetSumMipPt());
     c.setPt(stc.GetSumPt());
@@ -194,11 +192,10 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
       int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
       const auto & stc = STCs[coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness))]; 
     
-      if ( (energyDivisionType_!=superTriggerCell && energyDivisionType_!=coarse2TriggerCell)
+      if ( (energyDivisionType_!=superTriggerCell)
            || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) )
-           || ( energyDivisionType_==coarse2TriggerCell && (!(tc.detId() & 1))  )
            )  {
-
+	
         trigCellVecOutput.push_back( tc );
         assignSuperTriggerCellEnergy(trigCellVecOutput.back(), stc);        
         

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -136,141 +136,141 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
       int thickness = triggerTools_.thicknessIndex(s.second.GetTCList().at(0),true);
             
       if ( stcSize_.at(thickness) ==  4 ){
-	
-	for ( int i = 0; i < 2; i++ ){
-	  for ( int j = 0; j < 2; j++ ){
-	    
-	    satisfy = false;
-	    for (auto tc:s.second.GetTCList() ){
-	      HGCalDetId TC_idV8(tc);
-	      if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>2) & 1) == j )){
-		satisfy = true;
-	      }
-	      
-	    }
-	    if ( satisfy == false ){//Create new TC
-	      int tc_base = s.second.GetTCList().at(0);
-	      //Clear relevant bits	    
-	      tc_base = tc_base & ~(1 << 2); 
-	      tc_base = tc_base & ~(1); 
-	      //Set bits based on i and j values
-	      int newtc = tc_base | i;
-	      newtc = newtc | (j<<2);
+        
+        for ( int i = 0; i < 2; i++ ){
+          for ( int j = 0; j < 2; j++ ){
+            
+            satisfy = false;
+            for (auto tc:s.second.GetTCList() ){
+              HGCalDetId TC_idV8(tc);
+              if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>2) & 1) == j )){
+                satisfy = true;
+              }
+              
+            }
+            if ( satisfy == false ){//Create new TC
+              int tc_base = s.second.GetTCList().at(0);
+              //Clear relevant bits         
+              tc_base = tc_base & ~(1 << 2); 
+              tc_base = tc_base & ~(1); 
+              //Set bits based on i and j values
+              int newtc = tc_base | i;
+              newtc = newtc | (j<<2);
 
-		if ( !triggerTools_.validTriggerCell(newtc) ) {
-		  s.second.reject();
-		  continue;
-		}
-	      
-	      l1t::HGCalTriggerCell triggerCell;
-	      GlobalPoint point = triggerTools_.getTCPosition(newtc);
-	      math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+                if ( !triggerTools_.validTriggerCell(newtc) ) {
+                  s.second.reject();
+                  continue;
+                }
+              
+              l1t::HGCalTriggerCell triggerCell;
+              GlobalPoint point = triggerTools_.getTCPosition(newtc);
+              math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
 
-	      triggerCell.setPosition(point);
-	      triggerCell.setP4(p4);
-	      triggerCell.setDetId(newtc);
-	      
-	      s.second.addToList( triggerCell );
-	      trigCellVecOutput.push_back ( triggerCell );
-	      
-	    }
-	    
-	  }
-	}
+              triggerCell.setPosition(point);
+              triggerCell.setP4(p4);
+              triggerCell.setDetId(newtc);
+              
+              s.second.addToList( triggerCell );
+              trigCellVecOutput.push_back ( triggerCell );
+              
+            }
+            
+          }
+        }
       }
 
       else if (stcSize_.at(thickness) == 2){
-	
-	for ( int i = 0; i < 2; i++ ){
-	  
-	  satisfy = false;
-	  for (auto tc:s.second.GetTCList() ){
-	    HGCalDetId TC_idV8(tc);
-	    if ( ((TC_idV8.cell() & 1) == i)){
-	      satisfy = true;
-	    }
-	  }
-	  if ( satisfy == false ){//Create new TC
-	    int tc_base = s.second.GetTCList().at(0);
-	    //Clear relevant bits	    
-	    tc_base = tc_base & ~(1); 
-	    //Set bits based on i value
-	    int newtc = tc_base | i;
-	    
-	    if ( !triggerTools_.validTriggerCell(newtc) ) {
-	      s.second.reject();
-	      continue;
-	    }
-	    
-	    
-	    l1t::HGCalTriggerCell triggerCell;
-	    GlobalPoint point = triggerTools_.getTCPosition(newtc);
-	    math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-	    
-	    triggerCell.setPosition(point);	    
-	    triggerCell.setP4(p4);
-	    triggerCell.setDetId(newtc);
+        
+        for ( int i = 0; i < 2; i++ ){
+          
+          satisfy = false;
+          for (auto tc:s.second.GetTCList() ){
+            HGCalDetId TC_idV8(tc);
+            if ( ((TC_idV8.cell() & 1) == i)){
+              satisfy = true;
+            }
+          }
+          if ( satisfy == false ){//Create new TC
+            int tc_base = s.second.GetTCList().at(0);
+            //Clear relevant bits           
+            tc_base = tc_base & ~(1); 
+            //Set bits based on i value
+            int newtc = tc_base | i;
+            
+            if ( !triggerTools_.validTriggerCell(newtc) ) {
+              s.second.reject();
+              continue;
+            }
+            
+            
+            l1t::HGCalTriggerCell triggerCell;
+            GlobalPoint point = triggerTools_.getTCPosition(newtc);
+            math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+            
+            triggerCell.setPosition(point);         
+            triggerCell.setP4(p4);
+            triggerCell.setDetId(newtc);
 
-	    s.second.addToList( triggerCell );	    
-	    
-	    trigCellVecOutput.push_back ( triggerCell );
-	    
-	  }
-	  
-	}
-	
+            s.second.addToList( triggerCell );      
+            
+            trigCellVecOutput.push_back ( triggerCell );
+            
+          }
+          
+        }
+        
       }
       
 
       else if (stcSize_.at(thickness) == 8){
-	
-	for ( int i = 0; i < 2; i++ ){
-	  for ( int j = 0; j < 2; j++ ){
-	    for ( int k = 0; k < 2; k++ ){
-	      
-	      satisfy = false;
-	      for (auto tc:s.second.GetTCList() ){
-		HGCalDetId TC_idV8(tc);
-		if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>1) & 1) == j && ((TC_idV8.cell()>>2) & 1) == k)){
-		  satisfy = true;
-		}
-	      }
-	      if ( satisfy == false ){//Create new TC
-		int tc_base = s.second.GetTCList().at(0);
-		//Clear relevant bits	    
-		tc_base = tc_base & ~(1); 
-		tc_base = tc_base & ~(1 << 1); 
-		tc_base = tc_base & ~(1 << 2); 
-		//Set bits based on i value
-		int newtc = tc_base | i;
-		newtc = newtc | (j<<1);
-		newtc = newtc | (k<<2);
-		
-		if ( !triggerTools_.validTriggerCell(newtc) ) {
-		  s.second.reject();
-		  continue;
-		}
-		
-		
-		l1t::HGCalTriggerCell triggerCell;
-		GlobalPoint point = triggerTools_.getTCPosition(newtc);
-		math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-		
-		triggerCell.setPosition(point);	    
-		triggerCell.setP4(p4);
-		triggerCell.setDetId(newtc);
+        
+        for ( int i = 0; i < 2; i++ ){
+          for ( int j = 0; j < 2; j++ ){
+            for ( int k = 0; k < 2; k++ ){
+              
+              satisfy = false;
+              for (auto tc:s.second.GetTCList() ){
+                HGCalDetId TC_idV8(tc);
+                if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>1) & 1) == j && ((TC_idV8.cell()>>2) & 1) == k)){
+                  satisfy = true;
+                }
+              }
+              if ( satisfy == false ){//Create new TC
+                int tc_base = s.second.GetTCList().at(0);
+                //Clear relevant bits       
+                tc_base = tc_base & ~(1); 
+                tc_base = tc_base & ~(1 << 1); 
+                tc_base = tc_base & ~(1 << 2); 
+                //Set bits based on i value
+                int newtc = tc_base | i;
+                newtc = newtc | (j<<1);
+                newtc = newtc | (k<<2);
+                
+                if ( !triggerTools_.validTriggerCell(newtc) ) {
+                  s.second.reject();
+                  continue;
+                }
+                
+                
+                l1t::HGCalTriggerCell triggerCell;
+                GlobalPoint point = triggerTools_.getTCPosition(newtc);
+                math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+                
+                triggerCell.setPosition(point);     
+                triggerCell.setP4(p4);
+                triggerCell.setDetId(newtc);
 
-		s.second.addToList( triggerCell );	    		
-		trigCellVecOutput.push_back ( triggerCell );
-		
-	      }
-	      
-	    }
-	    
-	  }
-	  
-	}
-	
+                s.second.addToList( triggerCell );                      
+                trigCellVecOutput.push_back ( triggerCell );
+                
+              }
+              
+            }
+            
+          }
+          
+        }
+        
       }
      
 
@@ -305,18 +305,18 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
      if ( thickness > 0 ){
 
       if (!(tc.detId() & 1)) { //if even
-	const auto & ctc = coarseTCs[getCoarseTriggerCellId(tc.detId())]; 
-	auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
-	trigCellVecOutput.push_back( tc );
-	ctc.assignEnergy(trigCellVecOutput.back(), "STC");	
-	// 	  //reassign max id to the correct one;
-	if ( trigCellVecOutput.back().hwPt() >= stc.GetMaxHwPt() ){
+        const auto & ctc = coarseTCs[getCoarseTriggerCellId(tc.detId())]; 
+        auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+        trigCellVecOutput.push_back( tc );
+        ctc.assignEnergy(trigCellVecOutput.back(), "STC");      
+        //        //reassign max id to the correct one;
+        if ( trigCellVecOutput.back().hwPt() >= stc.GetMaxHwPt() ){
 
-	  if ( stc.GetMaxId() != tc.detId() ){
-	    stc.SetMaxTC( trigCellVecOutput.back() );
-	  }
+          if ( stc.GetMaxId() != tc.detId() ){
+            stc.SetMaxTC( trigCellVecOutput.back() );
+          }
 
-	}
+        }
       }
 
     }
@@ -389,12 +389,12 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
     
       if ( (energyDivisionType_!=superTriggerCell) || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) ) )  {
 
-	trigCellVecOutput.push_back( tc );
-	
-	if (energyDivisionType_==superTriggerCell)  stc.assignEnergy(trigCellVecOutput.back(), "STC");
-	if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
-	if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
-       	
+        trigCellVecOutput.push_back( tc );
+        
+        if (energyDivisionType_==superTriggerCell)  stc.assignEnergy(trigCellVecOutput.back(), "STC");
+        if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
+        if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
+        
       }
             
     }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -5,20 +5,20 @@
 
 HGCalConcentratorSuperTriggerCellImpl::
 HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
-  : stcSize_(conf.getParameter< std::vector<unsigned> >("stcSize")),
-    fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC"))
+  : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+    coarseTCmapping_(conf)
 {
 
-    if ( stcSize_.size() != kNLayers_ ){
-        throw cms::Exception("HGCTriggerParameterError")
-            << "Inconsistent size of super trigger cell size vector" << stcSize_.size() ;
-    }
-    for(auto stc : stcSize_) {
+    // if ( stcSize_.size() != kNLayers_ ){
+    //     throw cms::Exception("HGCTriggerParameterError")
+    //         << "Inconsistent size of super trigger cell size vector" << stcSize_.size() ;
+    // }
+    // for(auto stc : stcSize_) {
 
-      coarseTCmapping_.checkSizeValidity(stc);
+    //   coarseTCmapping_.checkSizeValidity(stc);
 
-    }
-
+    // }
+  //    coarseTCmapping_(conf);
     std::string energyType(conf.getParameter<string>("type_energy_division"));
 
     if( energyType == "superTriggerCell" ){
@@ -51,7 +51,7 @@ createAllTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std:
     for (auto& s: STCs){
 
       int thickness = triggerTools_.thicknessIndex(s.second.GetSTCId(),true);
-      std::vector<uint32_t> output_ids = coarseTCmapping_.getConstituentTriggerCells( s.second.GetSTCId(), stcSize_.at(thickness) );
+      std::vector<uint32_t> output_ids = coarseTCmapping_.getConstituentTriggerCellsByThickness( s.second.GetSTCId(), thickness );
 
       for (const auto& id: output_ids){
 
@@ -100,7 +100,8 @@ createAllTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, std:
     for (const  l1t::HGCalTriggerCell & tc : trigCellVecOutput){
       
       int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
-      const auto & stc = STCs[coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness))]; 
+      //      const auto & stc = STCs[coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness))]; 
+      const auto & stc = STCs[coarseTCmapping_.getCoarseTriggerCellIdByThickness(tc.detId(),thickness)]; 
     
       if ( (energyDivisionType_!=superTriggerCell)
            || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) )
@@ -189,7 +190,8 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
       continue;
     }
     int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
-    int stcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness));
+    //    int stcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness));
+    int stcid = coarseTCmapping_.getCoarseTriggerCellIdByThickness(tc.detId(),thickness);
     STCs[stcid].add(tc, stcid);
   }
 
@@ -199,7 +201,8 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
     for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
       if (tc.subdetId() == HGCHEB) continue;
       int thickness = triggerTools_.thicknessIndex(tc.detId(),true);      
-      int stcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness)); 
+      //      int stcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId(),stcSize_.at(thickness)); 
+      int stcid = coarseTCmapping_.getCoarseTriggerCellIdByThickness(tc.detId(),thickness); 
 
       if ( tc.detId() != STCs[stcid].GetMaxId() ){
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -28,6 +28,8 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
       energyDivisionType_ = oneBitFraction;
     }else if(energyType_=="equalShare"){
       energyDivisionType_ = equalShare;
+    }else if(energyType_=="coarse2TriggerCell"){
+      energyDivisionType_ = coarse2TriggerCell;
     }else {
       energyDivisionType_ = superTriggerCell;
     } 
@@ -160,152 +162,31 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
       //      bool satisfy = false;
       //Find and create missing TCs (for super TC 4)
       int thickness = triggerTools_.thicknessIndex(s.second.GetTCList().at(0),true);
-            
-      if ( stcSize_.at(thickness) ==  4 ){
-        
-        // for ( int i = 0; i < 2; i++ ){
-        //   for ( int j = 0; j < 2; j++ ){
-            
-        //     satisfy = false;
-        //     for (auto tc:s.second.GetTCList() ){
-        //       HGCalDetId TC_idV8(tc);
-        //       if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>2) & 1) == j )){
-        //         satisfy = true;
-        //       }
-              
-        //     }
-        //     if ( satisfy == false ){//Create new TC
-
-	for ( int i = 0; i < 2; i++ ){
-          for ( int j = 0; j < 2; j++ ){
-	    int tc_base = s.second.GetTCList().at(0);
-	    //Clear relevant bits         
-	    tc_base = tc_base & ~(1 << 2); 
-	    tc_base = tc_base & ~(1); 
-	    //Set bits based on i and j values
-	    int newtc = tc_base | i;
-	    newtc = newtc | (j<<2);
-	    
-	    if ( !triggerTools_.validTriggerCell(newtc) ) {
-	      s.second.reject();
-	      continue;
-	    }
-            
-	    l1t::HGCalTriggerCell triggerCell;
-	    GlobalPoint point = triggerTools_.getTCPosition(newtc);
-	    math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-	    
-	    triggerCell.setPosition(point);
-	    triggerCell.setP4(p4);
-	    triggerCell.setDetId(newtc);
-            
-	    s.second.addToList( triggerCell );
-	    trigCellVecOutput.push_back ( triggerCell );
-            
-	  }
-        }
-      }
       
-      else if (stcSize_.at(thickness) == 2){
+      int kSplitInv = ~(INT_MAX & kSplit_.at ( thickness ));
+      int tc_base = s.second.GetTCList().at(0);
+      for ( int i = 0; i < kSplitInv + 1 ; i++ ){
+	if (  (i & ~kSplitInv)!=i	 )  continue; 
+	
+	int newtc = tc_base | i;
+	
+	if ( !triggerTools_.validTriggerCell(newtc) ) {
+	  continue;
+	}
+	
+	l1t::HGCalTriggerCell triggerCell;
+	GlobalPoint point = triggerTools_.getTCPosition(newtc);
+	math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+	
+	triggerCell.setPosition(point);
+	triggerCell.setP4(p4);
+	triggerCell.setDetId(newtc);
         
-        for ( int i = 0; i < 2; i++ ){
-          
-          satisfy = false;
-          for (auto tc:s.second.GetTCList() ){
-            HGCalDetId TC_idV8(tc);
-            if ( ((TC_idV8.cell() & 1) == i)){
-              satisfy = true;
-            }
-          }
-          if ( satisfy == false ){//Create new TC
-            int tc_base = s.second.GetTCList().at(0);
-            //Clear relevant bits           
-            tc_base = tc_base & ~(1); 
-            //Set bits based on i value
-            int newtc = tc_base | i;
-            
-            if ( !triggerTools_.validTriggerCell(newtc) ) {
-              s.second.reject();
-              continue;
-            }
-            
-            
-            l1t::HGCalTriggerCell triggerCell;
-            GlobalPoint point = triggerTools_.getTCPosition(newtc);
-            math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-            
-            triggerCell.setPosition(point);         
-            triggerCell.setP4(p4);
-            triggerCell.setDetId(newtc);
-
-            s.second.addToList( triggerCell );      
-            
-            trigCellVecOutput.push_back ( triggerCell );
-            
-          }
-          
-        }
+	trigCellVecOutput.push_back ( triggerCell );
         
+	
       }
-      
-
-      else if (stcSize_.at(thickness) == 8){
-        
-        for ( int i = 0; i < 2; i++ ){
-          for ( int j = 0; j < 2; j++ ){
-            for ( int k = 0; k < 2; k++ ){
-              
-              satisfy = false;
-              for (auto tc:s.second.GetTCList() ){
-                HGCalDetId TC_idV8(tc);
-                if ( ((TC_idV8.cell() & 1) == i && ((TC_idV8.cell()>>1) & 1) == j && ((TC_idV8.cell()>>2) & 1) == k)){
-                  satisfy = true;
-                }
-              }
-              if ( satisfy == false ){//Create new TC
-                int tc_base = s.second.GetTCList().at(0);
-                //Clear relevant bits       
-                tc_base = tc_base & ~(1); 
-                tc_base = tc_base & ~(1 << 1); 
-                tc_base = tc_base & ~(1 << 2); 
-                //Set bits based on i value
-                int newtc = tc_base | i;
-                newtc = newtc | (j<<1);
-                newtc = newtc | (k<<2);
-                
-                if ( !triggerTools_.validTriggerCell(newtc) ) {
-                  s.second.reject();
-                  continue;
-                }
-                
-                
-                l1t::HGCalTriggerCell triggerCell;
-                GlobalPoint point = triggerTools_.getTCPosition(newtc);
-                math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
-                
-                triggerCell.setPosition(point);     
-                triggerCell.setP4(p4);
-                triggerCell.setDetId(newtc);
-
-                s.second.addToList( triggerCell );                      
-                trigCellVecOutput.push_back ( triggerCell );
-                
-              }
-              
-            }
-            
-          }
-          
-        }
-        
-      }
-     
-
- 
     }
-
-        
- 
 }
 
 
@@ -315,8 +196,7 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
 { 
   std::unordered_map<unsigned,SuperTriggerCell> coarseTCs;
 
-
-  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecOutput) {
     if (tc.subdetId() != HGCHEB) {
       coarseTCs[getSuperTriggerCellId(tc.detId(),2)].add(tc);
     }
@@ -356,7 +236,6 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
 
   }
 
-
 }
 
 
@@ -372,7 +251,6 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
 
   // first pass, fill the "coarse" trigger cells
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
-    //    trigCellVecInputEnlarged.push_back ( tc );
     if (tc.subdetId() == HGCHEB) continue;
     STCs[getSuperTriggerCellId(tc.detId())].add(tc);
   }
@@ -381,15 +259,14 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
   //The missing trigger cells are needed to be created both for coarsening the existing TC
   // in the thick modules (for the fixed data size choice), or for any of the energy spread algorithms (except super TCs)
 
-  //  if ( fixedDataSize_ == true || energyDivisionType_!=superTriggerCell){
   createMissingTriggerCells( STCs, trigCellVecInputEnlarged);
-  //  }
 
 
   //Coarsen if needed
   std::vector<l1t::HGCalTriggerCell> trigCellVecInputCoarsened;
   if ( fixedDataSize_ == true ){
     coarsenTriggerCells( STCs, trigCellVecInputEnlarged, trigCellVecInputCoarsened);
+
   }
   else{
     trigCellVecInputCoarsened = trigCellVecInputEnlarged;
@@ -411,17 +288,21 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
       trigCellVecOutput.push_back( tc );
     } else {
       const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
-      if ( stc.rejected() ) continue;
     
-      if ( (energyDivisionType_!=superTriggerCell) || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) ) )  {
+      if ( (energyDivisionType_!=superTriggerCell && energyDivisionType_!=coarse2TriggerCell) 
+	   || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) )
+	   || ( energyDivisionType_==coarse2TriggerCell && (!(tc.detId() & 1))  )
+	   )  {
 
         trigCellVecOutput.push_back( tc );
         
-        if (energyDivisionType_==superTriggerCell)  stc.assignEnergy(trigCellVecOutput.back(), "STC");
+        if (energyDivisionType_==coarse2TriggerCell || energyDivisionType_==superTriggerCell)  stc.assignEnergy(trigCellVecOutput.back(), "STC");        
         if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
         if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
         
       }
+
+
             
     }
     

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -30,6 +30,22 @@ HGCalConcentratorSuperTriggerCellImpl::kSplit_ = {
 };
 
 int
+HGCalConcentratorSuperTriggerCellImpl::getCoarseTriggerCellId(int detid) const {
+
+  HGCalDetId TC_idV8(detid);
+  
+  if( triggerTools_.isScintillator(detid) ){
+    return TC_idV8.cell(); //scintillator
+  }
+  else{
+    int TC_wafer = TC_idV8.wafer();
+    int TC_split = ( TC_idV8.cell() & kSplit_.at( 2 ) );
+    return TC_wafer<<kWafer_offset_ | TC_split;
+  }
+
+}
+
+int
 HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid) const {
 
 
@@ -139,10 +155,16 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
 	      //Set bits based on i and j values
 	      int newtc = tc_base | i;
 	      newtc = newtc | (j<<2);
+
+		if ( !triggerTools_.validTriggerCell(newtc) ) {
+		  s.second.reject();
+		  continue;
+		}
 	      
 	      l1t::HGCalTriggerCell triggerCell;
 	      GlobalPoint point = triggerTools_.getTCPosition(newtc);
 	      math::PtEtaPhiMLorentzVector p4(0, point.eta(), point.phi(), 0.);
+
 	      triggerCell.setPosition(point);
 	      triggerCell.setP4(p4);
 	      triggerCell.setDetId(newtc);
@@ -237,8 +259,7 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
 		triggerCell.setP4(p4);
 		triggerCell.setDetId(newtc);
 		
-		s.second.add( triggerCell );
-		
+		s.second.add( triggerCell );		
 		trigCellVecOutput.push_back ( triggerCell );
 		
 	      }
@@ -259,10 +280,76 @@ createMissingTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, 
  
 }
 
+
+void 
+HGCalConcentratorSuperTriggerCellImpl::
+coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
+{ 
+  std::unordered_map<unsigned,SuperTriggerCell> coarseTCs;
+
+
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+    if (tc.subdetId() == HGCHEB) continue;
+    coarseTCs[getCoarseTriggerCellId(tc.detId())].add(tc);
+  }
+
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+     if (tc.subdetId() == HGCHEB) continue;
+
+     int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
+     if ( thickness > 0 ){
+
+      if (!(tc.detId() & 1)) { //if even
+	const auto & ctc = coarseTCs[getCoarseTriggerCellId(tc.detId())]; 
+	auto stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+	trigCellVecOutput.push_back( tc );
+	ctc.assignEnergy(trigCellVecOutput.back(), "STC");	
+	// 	  //reassign max id to the correct one;
+
+	if ( trigCellVecOutput.back().hwPt() >= stc.GetMaxHwPt() ){
+
+	  if ( stc.GetMaxId() != tc.detId() ){
+	    stc.SetMaxTC( trigCellVecOutput.back() );
+	  }
+
+	}
+
+
+      }
+
+    }
+    else{
+
+      trigCellVecOutput.push_back( tc );
+
+    }
+
+
+  }
+
+
+
+  //Scintialltor specific
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
+    if (tc.subdetId() == HGCHEB) {;
+      coarseTCs[getCoarseTriggerCellId(tc.detId())].add(tc);
+    }    
+  }
+
+
+  
+
+
+
+
+}
+
+
 void 
 HGCalConcentratorSuperTriggerCellImpl::
 superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput)
 { 
+
   
   std::unordered_map<unsigned,SuperTriggerCell> STCs;
   std::vector<l1t::HGCalTriggerCell> trigCellVecInputEnlarged;
@@ -273,80 +360,71 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
     trigCellVecInputEnlarged.push_back ( tc );
     if (tc.subdetId() == HGCHEB) continue;
     STCs[getSuperTriggerCellId(tc.detId())].add(tc);
-
-    //    thickness = triggerTools_.thicknessIndex(tc.detId(),true);
   }
 
-  // //  bool doCoarseTCs = false;
-  // bool doCoarseTCs = false; //Would have a configurable option if it was the correct way to go.
-  // //If we want to create the coarse TCs
-
-  
-  // if ( thickness = > 1 ){
-  //   doCoarseTCs = true;
-  // }
-
-  ///  if ( doCoarseTCs ){
-
-
   createMissingTriggerCells( STCs, trigCellVecInputEnlarged);
-    ///  }
 
+  //Coarsen if needed
+  std::vector<l1t::HGCalTriggerCell> trigCellVecInputCoarsened;
+  coarsenTriggerCells( STCs, trigCellVecInputEnlarged, trigCellVecInputCoarsened);
+  
+  // int choice = 0;//stc
+  //    int choice = 1;//equalshare
+    int choice = 2;//1 bit
+  
+  if ( choice == 2 ){
+    //Get the 1 bit fractions. There should be exactly 4 TCs per STC
+    for (const l1t::HGCalTriggerCell & tc : trigCellVecInputCoarsened) {
+      if (tc.subdetId() == HGCHEB) continue;
+      auto stc = STCs[getSuperTriggerCellId(tc.detId())]; 
+      STCs[getSuperTriggerCellId(tc.detId())].getFractionSum(tc);
 
-
-
-
-
+    }
+  }
 
     // second pass, write them out
-  for (const l1t::HGCalTriggerCell & tc : trigCellVecInputEnlarged) {
-    int thickness = triggerTools_.thicknessIndex(tc.detId(),true);
+  for (const l1t::HGCalTriggerCell & tc : trigCellVecInputCoarsened) {
     //If scintillator use a simple threshold cut
     if (tc.subdetId() == HGCHEB) {
       trigCellVecOutput.push_back( tc );
     } else {
       const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
-
-      //Easy case - STC
+      if ( stc.rejected() ) continue;
       
-      //If thick then coarsen 
-      if ( thickness > 1 ){
-	
-	
-	if (!(tc.detId() & 1)) { //if even	  
-	  if ( !stc.rejected() ) {
-	    
+      if ( (choice > 0) || ( choice == 0 && (tc.detId() == stc.GetMaxId()) ) )  {
 
-	    // if (  (tc.detId() == stc.GetMaxId())
-	    // 	  ||  ((tc.detId() | 1) == stc.GetMaxId()))
-	    //   {
-		
-		trigCellVecOutput.push_back( tc );
-		//		stc.assignEnergy(trigCellVecOutput.back(), "STC");
-		stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
-		
-		//	      }
-	   
-	  }
-	  
-	}
-      }
-      else{
+	trigCellVecOutput.push_back( tc );
 	
-	//	if (  tc.detId() == stc.GetMaxId()  ){
-	  
-	  trigCellVecOutput.push_back( tc );
-	  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
-	  
-	  //	}
-	
+	if (choice == 0)  stc.assignEnergy(trigCellVecOutput.back(), "STC");
+	if (choice == 1)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
+	if (choice == 2)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
+       	
       }
+      
       
     }
     
   }
-  //     //If not thick
 
+
+      //	}
+      
+      // }
+      // else{
+      
+      // 	if (  (choice > 0) || (choice == 0 && tc.detId() == stc.GetMaxId())  ){
+      
+      // 	  trigCellVecOutput.push_back( tc );
+      // 	  if (choice == 0)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
+      // 	  if (choice == 1)  stc.assignEnergy(trigCellVecOutput.back(), "STC");
+      // 	  if (choice == 2)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
+      
+      // 	}
+      
+      // }
+
+  //     //If not thick
+  
 
 
   //     if (tc.detId() == stc.GetMaxId() ) { //Standard selection

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -214,7 +214,7 @@ coarsenTriggerCells( std::unordered_map<unsigned,SuperTriggerCell>& STCs, const 
         const auto & ctc = coarseTCs[getSuperTriggerCellId(tc.detId(),2)]; 
         auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
         trigCellVecOutput.push_back( tc );
-        ctc.assignEnergy(trigCellVecOutput.back(), "STC");      
+        ctc.assignEnergy(trigCellVecOutput.back(), superTriggerCell);      
         //        //reassign max id to the correct one;
         if ( trigCellVecOutput.back().hwPt() >= stc.GetMaxHwPt() ){
 
@@ -289,9 +289,11 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
 
         trigCellVecOutput.push_back( tc );
         
-        if (energyDivisionType_==coarse2TriggerCell || energyDivisionType_==superTriggerCell)  stc.assignEnergy(trigCellVecOutput.back(), "STC");        
-        if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
-        if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
+	stc.assignEnergy(trigCellVecOutput.back(), energyDivisionType_);        
+
+        // if (energyDivisionType_==coarse2TriggerCell || energyDivisionType_==superTriggerCell)  
+        // if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
+        // if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
         
       }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -91,10 +91,6 @@ HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid, int STCs
 
       detid =  (detid & ~(TC_idV8.kHGCalCellMask ) ) | TC_split;
 
-      //      TC_idV8(detid);
-
-      //      return TC_wafer<<kWafer_offset_ | TC_split;
-      //      return TC_split;
       return detid;
     }
 
@@ -261,9 +257,12 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
 
   // first pass, fill the "coarse" trigger cells
   for (const l1t::HGCalTriggerCell & tc : trigCellVecInput) {
-    if (tc.subdetId() == HGCHEB) continue;
+    if (tc.subdetId() == HGCHEB){
+      trigCellVecInputEnlarged.push_back( tc );
+      continue;
+    }
     int stcid = getSuperTriggerCellId(tc.detId());
-    STCs[getSuperTriggerCellId(tc.detId())].add(tc, stcid);
+    STCs[stcid].add(tc, stcid);
   }
 
    //The missing trigger cells are needed to be created both for coarsening the existing TC
@@ -296,18 +295,13 @@ superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVec
     } else {
       const auto & stc = STCs[getSuperTriggerCellId(tc.detId())]; 
     
-      if ( (energyDivisionType_!=superTriggerCell && energyDivisionType_!=coarse2TriggerCell) 
+      if ( (energyDivisionType_!=superTriggerCell && energyDivisionType_!=coarse2TriggerCell)
            || ( energyDivisionType_==superTriggerCell && (tc.detId() == stc.GetMaxId()) )
            || ( energyDivisionType_==coarse2TriggerCell && (!(tc.detId() & 1))  )
            )  {
 
         trigCellVecOutput.push_back( tc );
-        
         stc.assignEnergy(trigCellVecOutput.back(), energyDivisionType_);        
-
-        // if (energyDivisionType_==coarse2TriggerCell || energyDivisionType_==superTriggerCell)  
-        // if (energyDivisionType_==equalShare)  stc.assignEnergy(trigCellVecOutput.back(), "EqualShare");
-        // if (energyDivisionType_==oneBitFraction)  stc.assignEnergy(trigCellVecOutput.back(), "1bit");
         
       }
 

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -6,13 +6,13 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 def create_supertriggercell(process, inputs,
                             stcSize=supertc_conc_proc.stcSize,
                             type_energy_division=supertc_conc_proc.type_energy_division,
-                            fixedDataSize=supertc_conc_proc.fixedDataSize
+                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC
                             ):
     producer = process.hgcalConcentratorProducer.clone()
     producer.ProcessorParameters = supertc_conc_proc.clone()
     producer.ProcessorParameters.stcSize = stcSize
     producer.ProcessorParameters.type_energy_division = type_energy_division
-    producer.ProcessorParameters.fixedDataSize = fixedDataSize
+    producer.ProcessorParameters.fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -4,11 +4,15 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc
 
 
 def create_supertriggercell(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize
+                            stcSize=supertc_conc_proc.stcSize,
+                            type_energy_division=supertc_conc_proc.type_energy_division,
+                            fixedDataSize=supertc_conc_proc.fixedDataSize
                             ):
     producer = process.hgcalConcentratorProducer.clone()
     producer.ProcessorParameters = supertc_conc_proc.clone()
     producer.ProcessorParameters.stcSize = stcSize
+    producer.ProcessorParameters.type_energy_division = type_energy_division
+    producer.ProcessorParameters.fixedDataSize = fixedDataSize
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     return producer


### PR DESCRIPTION
Enable the coarsening of TCs, and create "missing" TCs (those not originally created due to other thresholds).
Currently this is done in the super trigger cell implementation, but super trigger cells are rather a special case of coarse TCs, so some renaming and reordering might be needed in future.