### PR TITLE
[Backport 10_5_0] Handling correctly era changes in algo customizations and adapt FE and clustering thresholds to new calibration used on samples with V9 geometry

### DIFF
--- a/L1Trigger/L1THGCal/python/customClustering.py
+++ b/L1Trigger/L1THGCal/python/customClustering.py
@@ -1,232 +1,215 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, \
+                                                              distance_C2d_params, \
+                                                              topological_C2d_params, \
+                                                              constrTopological_C2d_params
+from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import distance_C3d_params, \
+                                                              dbscan_C3d_params, \
+                                                              histoMax_C3d_params, \
+                                                              histoMaxVariableDR_C3d_params, \
+                                                              histoSecondaryMax_C3d_params, \
+                                                              histoInterpolatedMax_C3d_params, \
+                                                              histoThreshold_C3d_params, \
+                                                              dr_layerbylayer, \
+                                                              dr_layerbylayer_Bcoefficient, \
+                                                              neighbour_weights_1stOrder, \
+                                                              neighbour_weights_2ndOrder
 
-binSums = cms.vuint32(13,               #0
-                      11, 11, 11,       # 1 - 3
-                      9, 9, 9,          # 4 - 6
-                      7, 7, 7, 7, 7, 7, # 7 - 12
-                      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
-                      3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
-                      )
+
+def set_threshold_params(pset, seed_threshold, cluster_threshold):
+    pset.seeding_threshold_silicon = seed_threshold
+    pset.seeding_threshold_scintillator = seed_threshold
+    pset.clustering_threshold_silicon = cluster_threshold
+    pset.clustering_threshold_scintillator = cluster_threshold
 
 
-def custom_2dclustering_distance(process, 
-        distance=6.,# cm
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    parameters_c2d = process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters
-    parameters_c2d.seeding_threshold_silicon = cms.double(seed_threshold) 
-    parameters_c2d.seeding_threshold_scintillator = cms.double(seed_threshold) 
-    parameters_c2d.clustering_threshold_silicon = cms.double(cluster_threshold) 
-    parameters_c2d.clustering_threshold_scintillator = cms.double(cluster_threshold) 
-    parameters_c2d.dR_cluster = cms.double(distance) 
-    parameters_c2d.clusterType = cms.string('dRC2d') 
+def custom_2dclustering_distance(process,
+                                 distance=distance_C2d_params.dR_cluster,  # cm
+                                 seed_threshold=distance_C2d_params.seeding_threshold_silicon,  # MipT
+                                 cluster_threshold=distance_C2d_params.clustering_threshold_silicon  # MipT
+                                 ):
+    parameters_c2d = distance_C2d_params.clone()
+    set_threshold_params(parameters_c2d, seed_threshold, cluster_threshold)
+    parameters_c2d.dR_cluster = distance
+    process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters = parameters_c2d
     return process
+
 
 def custom_2dclustering_topological(process,
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    parameters_c2d = process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters
-    parameters_c2d.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
-    parameters_c2d.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
-    parameters_c2d.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
-    parameters_c2d.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
-    parameters_c2d.clusterType = cms.string('NNC2d') 
+                                    seed_threshold=topological_C2d_params.seeding_threshold_silicon,  # MipT
+                                    cluster_threshold=topological_C2d_params.clustering_threshold_silicon  # MipT
+                                    ):
+    parameters_c2d = topological_C2d_params.clone()
+    set_threshold_params(parameters_c2d, seed_threshold, cluster_threshold)
+    process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters = parameters_c2d
     return process
+
 
 def custom_2dclustering_constrainedtopological(process,
-        distance=6.,# cm
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    parameters_c2d = process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters
-    parameters_c2d.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
-    parameters_c2d.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
-    parameters_c2d.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
-    parameters_c2d.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
-    parameters_c2d.dR_cluster = cms.double(distance) # cm
-    parameters_c2d.clusterType = cms.string('dRNNC2d') 
+                                               distance=constrTopological_C2d_params.dR_cluster,  # cm
+                                               seed_threshold=constrTopological_C2d_params.seeding_threshold_silicon,  # MipT
+                                               cluster_threshold=constrTopological_C2d_params.clustering_threshold_silicon  # MipT
+                                               ):
+    parameters_c2d = constrTopological_C2d_params.clone()
+    parameters_c2d.dR_cluster = distance
+    set_threshold_params(parameters_c2d, seed_threshold, cluster_threshold)
+    process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters = parameters_c2d
     return process
 
+
 def custom_2dclustering_dummy(process):
-    parameters_c2d = process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters
-    parameters_c2d.clusterType = cms.string('dummyC2d')
+    process.hgcalBackEndLayer1Producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
     return process
 
 
 def custom_3dclustering_distance(process,
-        distance=0.01
-        ):
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.dR_multicluster = cms.double(distance)
-    parameters_c3d.type_multicluster = cms.string('dRC3d')
+                                 distance=distance_C3d_params.dR_multicluster
+                                 ):
+    parameters_c3d = distance_C3d_params.clone()
+    parameters_c3d.dR_multicluster = distance
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
 
 def custom_3dclustering_dbscan(process,
-        distance=0.005,
-        min_points=3
-        ):
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.dist_dbscan_multicluster = cms.double(distance)
-    parameters_c3d.minN_dbscan_multicluster = cms.uint32(min_points)
-    parameters_c3d.type_multicluster = cms.string('DBSCANC3d')
+                               distance=dbscan_C3d_params.dist_dbscan_multicluster,
+                               min_points=dbscan_C3d_params.minN_dbscan_multicluster
+                               ):
+    parameters_c3d = dbscan_C3d_params.clone()
+    parameters_c3d.dist_dbscan_multicluster = distance
+    parameters_c3d.minN_dbscan_multicluster = min_points
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
+
+
+def set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold):
+    parameters_c3d.dR_multicluster = distance
+    parameters_c3d.nBins_R_histo_multicluster = nBins_R
+    parameters_c3d.nBins_Phi_histo_multicluster = nBins_Phi
+    parameters_c3d.binSumsHisto = binSumsHisto
+    parameters_c3d.threshold_histo_multicluster = seed_threshold
 
 
 def custom_3dclustering_histoMax(process,
-        distance = 0.03,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,                        
-        seed_threshold = 10,
-        ):
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.dR_multicluster = cms.double(distance)
-    parameters_c3d.nBins_R_histo_multicluster = cms.uint32(nBins_R)
-    parameters_c3d.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
-    parameters_c3d.binSumsHisto = binSumsHisto
-    parameters_c3d.threshold_histo_multicluster = seed_threshold
-    parameters_c3d.type_multicluster = cms.string('HistoMaxC3d')
+                                 distance=histoMax_C3d_params.dR_multicluster,
+                                 nBins_R=histoMax_C3d_params.nBins_R_histo_multicluster,
+                                 nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
+                                 binSumsHisto=histoMax_C3d_params.binSumsHisto,
+                                 seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
+                                 ):
+    parameters_c3d = histoMax_C3d_params.clone()
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
+
 
 def custom_3dclustering_histoSecondaryMax(process,
-        distance = 0.03, 
-        threshold = 5.,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        ):
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.dR_multicluster = cms.double(distance)
-    parameters_c3d.nBins_R_histo_multicluster = cms.uint32(nBins_R)
-    parameters_c3d.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
-    parameters_c3d.binSumsHisto = binSumsHisto
-    parameters_c3d.threshold_histo_multicluster = cms.double(threshold)
-    parameters_c3d.type_multicluster = cms.string('HistoSecondaryMaxC3d')
+                                          distance=histoSecondaryMax_C3d_params.dR_multicluster,
+                                          threshold=histoSecondaryMax_C3d_params.threshold_histo_multicluster,
+                                          nBins_R=histoSecondaryMax_C3d_params.nBins_R_histo_multicluster,
+                                          nBins_Phi=histoSecondaryMax_C3d_params.nBins_Phi_histo_multicluster,
+                                          binSumsHisto=histoSecondaryMax_C3d_params.binSumsHisto,
+                                          ):
+    parameters_c3d = histoSecondaryMax_C3d_params.clone()
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
-dr_layerbylayer = ([0] + # no layer 0
-        [0.015]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 + # EM
-        [0.040]*6 + [0.050]*6 + # FH
-        [0.050]*12) # BH
-
-
-dr_layerbylayer_Bcoefficient = ([0] + # no layer 0
-        [0.020]*7 + [0.020]*7 + [0.02]*7 + [0.020]*7 + # EM
-        [0.020]*6 + [0.020]*6 + # FH
-        [0.020]*12) # BH
 
 def custom_3dclustering_histoMax_variableDr(process,
-        distances = dr_layerbylayer,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,                        
-        seed_threshold = 10,
-        ):
-    process = custom_3dclustering_histoMax(process, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
+                                            distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+                                            nBins_R=histoMaxVariableDR_C3d_params.nBins_R_histo_multicluster,
+                                            nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
+                                            binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
+                                            seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                                            ):
+    parameters_c3d = histoMaxVariableDR_C3d_params.clone()
+    set_histomax_params(parameters_c3d, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
     parameters_c3d.dR_multicluster_byLayer_coefficientA = cms.vdouble(distances)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
 
-
-def custom_3dclustering_histoInterpolatedMax(process,
-        distance = 0.03,
-        seed_threshold = 5.,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        ):
-    process = custom_3dclustering_histoMax( process, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold )    
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.type_multicluster = cms.string('HistoInterpolatedMaxC3d')
-    return process
-
-def custom_3dclustering_histoInterpolatedMax1stOrder(process, distance = 0.03, seed_threshold = 5. ):
-
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.neighbour_weights=cms.vdouble(  0    , 0.25, 0   ,
-                                                   0.25 , 0   , 0.25,
-                                                   0    , 0.25, 0
-                                                )
-    process = custom_3dclustering_histoInterpolatedMax( process, distance, seed_threshold )    
+def custom_3dclustering_histoInterpolatedMax1stOrder(process,
+                                                     distance=histoInterpolatedMax_C3d_params.dR_multicluster,
+                                                     nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
+                                                     nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                                     binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster
+                                                     ):
+    parameters_c3d = histoInterpolatedMax_C3d_params.clone()
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    parameters_c3d.neighbour_weights = neighbour_weights_1stOrder
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
 
-
-def custom_3dclustering_histoInterpolatedMax2ndOrder(process, distance = 0.03, seed_threshold = 5.):
-
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.neighbour_weights=cms.vdouble( -0.25, 0.5, -0.25,
-                                                   0.5 , 0  ,  0.5 ,
-                                                  -0.25, 0.5, -0.25
-                                                )
-    process = custom_3dclustering_histoInterpolatedMax( process, distance, seed_threshold )    
+def custom_3dclustering_histoInterpolatedMax2ndOrder(process,
+                                                     distance=histoInterpolatedMax_C3d_params.dR_multicluster,
+                                                     nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
+                                                     nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                                     binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster):
+    parameters_c3d = histoInterpolatedMax_C3d_params.clone()
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    parameters_c3d.neighbour_weights = neighbour_weights_2ndOrder
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
-
 
 
 def custom_3dclustering_histoThreshold(process,
-        threshold = 20.,
-        distance = 0.03,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        ):
-    parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
-    parameters_c3d.threshold_histo_multicluster = cms.double(threshold)
-    parameters_c3d.dR_multicluster = cms.double(distance)
-    parameters_c3d.nBins_R_histo_multicluster = cms.uint32(nBins_R)
-    parameters_c3d.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
-    parameters_c3d.binSumsHisto = binSumsHisto
-    parameters_c3d.type_multicluster = cms.string('HistoThresholdC3d')
+                                       distance=histoThreshold_C3d_params.dR_multicluster,
+                                       nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
+                                       nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
+                                       binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
+                                       seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster
+                                       ):
+    parameters_c3d = histoThreshold_C3d_params.clone()
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
-def custom_3dclustering_clusteringRadiusLayerbyLayerVariableEta(process, distance_coefficientA = dr_layerbylayer, distance_coefficientB = dr_layerbylayer_Bcoefficient):
-    
+
+def custom_3dclustering_clusteringRadiusLayerbyLayerVariableEta(process,
+                                                                distance_coefficientA=dr_layerbylayer,
+                                                                distance_coefficientB=dr_layerbylayer_Bcoefficient):
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.dR_multicluster_byLayer_coefficientA = distance_coefficientA
     parameters_c3d.dR_multicluster_byLayer_coefficientB = distance_coefficientB
-
     return process
 
 
-def custom_3dclustering_clusteringRadiusLayerbyLayerFixedEta(process, distance_coefficientA = dr_layerbylayer):
-    
+def custom_3dclustering_clusteringRadiusLayerbyLayerFixedEta(process,
+                                                             distance_coefficientA=dr_layerbylayer):
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.dR_multicluster_byLayer_coefficientA = distance_coefficientA
-    parameters_c3d.dR_multicluster_byLayer_coefficientB = cms.vdouble( [0]*53 )
-
+    parameters_c3d.dR_multicluster_byLayer_coefficientB = cms.vdouble([0]*53)
     return process
 
-def custom_3dclustering_clusteringRadiusNoLayerDependenceFixedEta(process, distance_coefficientA = 0.03):
-    
+def custom_3dclustering_clusteringRadiusNoLayerDependenceFixedEta(process,
+                                                                  distance_coefficientA=0.03):
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.dR_multicluster_byLayer_coefficientA = cms.vdouble( [distance_coefficientA]*53 )
     parameters_c3d.dR_multicluster_byLayer_coefficientB = cms.vdouble( [0]*53 )
-
     return process
 
-def custom_3dclustering_clusteringRadiusNoLayerDependenceVariableEta(process, distance_coefficientA = 0.03, distance_coefficientB = 0.02):
-    
+def custom_3dclustering_clusteringRadiusNoLayerDependenceVariableEta(process,
+                                                                     distance_coefficientA=0.03,
+                                                                     distance_coefficientB=0.02):
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.dR_multicluster_byLayer_coefficientA = cms.vdouble( [distance_coefficientA]*53 )
     parameters_c3d.dR_multicluster_byLayer_coefficientB = cms.vdouble( [distance_coefficientB]*53 )
-
     return process
 
 
 def custom_3dclustering_nearestNeighbourAssociation(process):
-    
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.cluster_association = cms.string('NearestNeighbour')
 
     return process
 
 def custom_3dclustering_EnergySplitAssociation(process):
-    
+
     parameters_c3d = process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters
     parameters_c3d.cluster_association = cms.string('EnergySplit')
     return process

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -1,45 +1,32 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc
 
-def custom_triggercellselect_supertriggercell(process, 
-                                              stcSize = cms.vuint32(4,4,4)
+
+def custom_triggercellselect_supertriggercell(process,
+                                              stcSize=supertc_conc_proc.stcSize
                                               ):
-    
-    parameters = process.hgcalConcentratorProducer.ProcessorParameters
-    parameters.Method = cms.string('superTriggerCellSelect')
+    parameters = supertc_conc_proc.clone()
     parameters.stcSize = stcSize
-
+    process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 
 
 def custom_triggercellselect_threshold(process,
-        threshold=2. # in mipT
-        ):
-    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
-    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
-
-    parameters = process.hgcalConcentratorProducer.ProcessorParameters
-    parameters.Method = cms.string('thresholdSelect')
-    parameters.linLSB = cms.double(100./1024.)
-    parameters.adcsaturationBH = adcSaturationBH_MIP
-    parameters.adcnBitsBH = adcNbitsBH
-    parameters.TCThreshold_fC = cms.double(0.)
-    parameters.TCThresholdBH_MIP = cms.double(0.)
-    parameters.triggercell_threshold_silicon = cms.double(threshold) # MipT
-    parameters.triggercell_threshold_scintillator = cms.double(threshold) # MipT
+                                       threshold_silicon=threshold_conc_proc.triggercell_threshold_silicon,  # in mipT
+                                       threshold_scintillator=threshold_conc_proc.triggercell_threshold_scintillator  # in mipT
+                                       ):
+    parameters = threshold_conc_proc.clone()
+    parameters.triggercell_threshold_silicon = threshold_silicon
+    parameters.triggercell_threshold_scintillator = threshold_scintillator
+    process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 
 
 def custom_triggercellselect_bestchoice(process,
-       triggercells=12
-        ):
-    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
-    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
-
-    parameters = process.hgcalConcentratorProducer.ProcessorParameters
-    parameters.Method = cms.string('bestChoiceSelect')
-    parameters.NData = cms.uint32(triggercells)
-    parameters.linLSB = cms.double(100./1024.)
-    parameters.adcsaturationBH = adcSaturationBH_MIP
-    parameters.adcnBitsBH = adcNbitsBH
+                                        triggercells=best_conc_proc.NData
+                                        ):
+    parameters = best_conc_proc.clone()
+    parameters.NData = triggercells
+    process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -2,18 +2,64 @@ import FWCore.ParameterSet.Config as cms
 
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
-import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
-import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
+import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam
+from . import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
 
-C2d_parValues = cms.PSet( clusterType = cms.string('dummyC2d'),
-                          calibSF_cluster=cms.double(1.),
-                          layerWeights = layercalibparam.TrgLayer_weights,
-                          applyLayerCalibration = cms.bool(True)
-            )
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 
-be_proc = cms.PSet( ProcessorName  = cms.string('HGCalBackendLayer1Processor2DClustering'),
-                    C2d_parameters = C2d_parValues.clone()
-                  )
+c2d_calib_pset = cms.PSet(calibSF_cluster=cms.double(1.),
+                          layerWeights=layercalibparam.TrgLayer_weights,
+                          applyLayerCalibration=cms.bool(True))
+
+c2d_thresholds_pset = cms.PSet(seeding_threshold_silicon=cms.double(5.),
+                               seeding_threshold_scintillator=cms.double(5.),
+                               clustering_threshold_silicon=cms.double(2.),
+                               clustering_threshold_scintillator=cms.double(2.))
+
+# V9 samples have a different defintiion of the dEdx calibrations. To account for it
+# we reascale the thresholds for the clustering
+# (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
+# for more details)
+phase2_hgcalV9.toModify(c2d_thresholds_pset,
+                        seeding_threshold_silicon=cms.double(3.75),
+                        seeding_threshold_scintillator=cms.double(3.75),
+                        clustering_threshold_silicon=cms.double(1.5),
+                        clustering_threshold_scintillator=cms.double(1.5),
+                        )
+
+# we still don't have layer calibrations for V9 geometry. Switching this off we
+# use the dEdx calibrated energy of the TCs
+phase2_hgcalV9.toModify(c2d_calib_pset,
+                        applyLayerCalibration=cms.bool(False)
+                        )
+
+
+dummy_C2d_params = cms.PSet(c2d_calib_pset,
+                            clusterType=cms.string('dummyC2d')
+                            )
+
+
+distance_C2d_params = cms.PSet(c2d_calib_pset,
+                               c2d_thresholds_pset,
+                               clusterType=cms.string('dRC2d'),
+                               dR_cluster=cms.double(6.),
+                               )
+
+topological_C2d_params = cms.PSet(c2d_calib_pset,
+                                  c2d_thresholds_pset,
+                                  clusterType=cms.string('NNC2d'),
+                                  )
+
+constrTopological_C2d_params = cms.PSet(c2d_calib_pset,
+                                        c2d_thresholds_pset,
+                                        clusterType=cms.string('dRNNC2d'),
+                                        dR_cluster=cms.double(6.),
+                                        )
+
+
+be_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer1Processor2DClustering'),
+                   C2d_parameters = dummy_C2d_params.clone()
+                   )
 
 hgcalBackEndLayer1Producer = cms.EDProducer(
     "HGCalBackendLayer1Producer",

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -2,31 +2,105 @@ import FWCore.ParameterSet.Config as cms
 
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
-import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
+import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam
 
-from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_histomax
-from L1Trigger.L1THGCal.customClustering import binSums, dr_layerbylayer
+from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_cone, \
+                                                    egamma_identification_drnn_dbscan, \
+                                                    egamma_identification_histomax
 
-C3d_parValues = cms.PSet( type_multicluster = cms.string('HistoMaxC3d'),
-                          dR_multicluster = cms.double(0.),
-                          dR_multicluster_byLayer_coefficientA = cms.vdouble(dr_layerbylayer),
-                          dR_multicluster_byLayer_coefficientB = cms.vdouble( [0]*53 ),
-                          minPt_multicluster = cms.double(0.5), # minimum pt of the multicluster (GeV)
-                          nBins_R_histo_multicluster = cms.uint32(36),
-                          nBins_Phi_histo_multicluster = cms.uint32(216),
-                          binSumsHisto = binSums,
-                          threshold_histo_multicluster = cms.double(10.),
-                          cluster_association = cms.string("NearestNeighbour"),
-                          EGIdentification=egamma_identification_histomax.clone(),
-                          neighbour_weights=cms.vdouble(  0    , 0.25, 0   ,
-                                                          0.25 , 0  ,  0.25,
-                                                          0    , 0.25, 0
-                                                          )
- )
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 
-be_proc = cms.PSet( ProcessorName  = cms.string('HGCalBackendLayer2Processor3DClustering'),
-                    C3d_parameters = C3d_parValues.clone()
-                  )
+
+binSums = cms.vuint32(13,               # 0
+                      11, 11, 11,       # 1 - 3
+                      9, 9, 9,          # 4 - 6
+                      7, 7, 7, 7, 7, 7,  # 7 - 12
+                      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
+                      3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
+                      )
+
+
+dr_layerbylayer = ([0] +  # no layer 0
+                   [0.015]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +  # EM
+                   [0.040]*6 + [0.050]*6 +  # FH
+                   [0.050]*12)  # BH
+
+
+dr_layerbylayer_Bcoefficient = ([0] +  # no layer 0
+                                [0.020]*7 + [0.020]*7 + [0.02]*7 + [0.020]*7 +  # EM
+                                [0.020]*6 + [0.020]*6 +  # FH
+                                [0.020]*12)  # BH
+
+
+neighbour_weights_1stOrder = cms.vdouble(0, 0.25, 0,
+                                         0.25, 0, 0.25,
+                                         0, 0.25, 0)
+
+neighbour_weights_2ndOrder = cms.vdouble(-0.25, 0.5, -0.25,
+                                         0.5, 0,  0.5,
+                                         -0.25, 0.5, -0.25)
+
+
+distance_C3d_params = cms.PSet(type_multicluster=cms.string('dRC3d'),
+                               dR_multicluster=cms.double(0.01),
+                               minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
+                               dist_dbscan_multicluster=cms.double(0.),
+                               minN_dbscan_multicluster=cms.uint32(0),
+                               EGIdentification=egamma_identification_drnn_cone.clone(),
+                               )
+
+
+dbscan_C3d_params = cms.PSet(type_multicluster=cms.string('DBSCANC3d'),
+                             dR_multicluster=cms.double(0.),
+                             minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
+                             dist_dbscan_multicluster=cms.double(0.005),
+                             minN_dbscan_multicluster=cms.uint32(3),
+                             EGIdentification=egamma_identification_drnn_dbscan.clone())
+
+
+histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
+                               dR_multicluster=cms.double(0.03),
+                               dR_multicluster_byLayer_coefficientA=cms.vdouble(),
+                               dR_multicluster_byLayer_coefficientB=cms.vdouble(),
+                               minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
+                               nBins_R_histo_multicluster=cms.uint32(36),
+                               nBins_Phi_histo_multicluster=cms.uint32(216),
+                               binSumsHisto=binSums,
+                               threshold_histo_multicluster=cms.double(10.),
+                               cluster_association=cms.string("NearestNeighbour"),
+                               EGIdentification=egamma_identification_histomax.clone(),
+                               neighbour_weights=neighbour_weights_1stOrder
+                               )
+# V9 samples have a different defintiion of the dEdx calibrations. To account for it
+# we reascale the thresholds of the clustering seeds
+# (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
+# for more details)
+phase2_hgcalV9.toModify(histoMax_C3d_params,
+                        threshold_histo_multicluster=cms.double(7.5),  # MipT
+                        )
+
+
+histoMaxVariableDR_C3d_params = histoMax_C3d_params.clone()
+histoMaxVariableDR_C3d_params.dR_multicluster = cms.double(0.)
+histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA = cms.vdouble(dr_layerbylayer)
+histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientB = cms.vdouble([0]*53)
+
+
+histoSecondaryMax_C3d_params = histoMax_C3d_params.clone()
+histoSecondaryMax_C3d_params.type_multicluster = cms.string('HistoSecondaryMaxC3d')
+
+
+histoInterpolatedMax_C3d_params = histoMax_C3d_params.clone()
+histoInterpolatedMax_C3d_params.type_multicluster = cms.string('HistoInterpolatedMaxC3d')
+
+
+histoThreshold_C3d_params = histoMax_C3d_params.clone()
+histoThreshold_C3d_params.type_multicluster = cms.string('HistoThresholdC3d')
+
+
+be_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer2Processor3DClustering'),
+                   C3d_parameters = histoMaxVariableDR_C3d_params.clone()
+                   )
 
 hgcalBackEndLayer2Producer = cms.EDProducer(
     "HGCalBackendLayer2Producer",

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -5,22 +5,51 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
 adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
-conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                     Method = cms.string('thresholdSelect'),
-                     NData = cms.uint32(999),
-                     MaxCellsInModule = cms.uint32(288),
-                     linLSB = cms.double(100./1024.),
-                     adcsaturationBH = adcSaturationBH_MIP,
-                     adcnBitsBH = adcNbitsBH,
-                     TCThreshold_fC = cms.double(0.),
-                     TCThresholdBH_MIP = cms.double(0.),
-                     triggercell_threshold_silicon = cms.double(2.), # MipT
-                     triggercell_threshold_scintillator = cms.double(2.), # MipT
-                     )
+
+threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                               Method = cms.string('thresholdSelect'),
+                               NData = cms.uint32(999),
+                               MaxCellsInModule = cms.uint32(288),
+                               linLSB = cms.double(100./1024.),
+                               adcsaturationBH = adcSaturationBH_MIP,
+                               adcnBitsBH = adcNbitsBH,
+                               TCThreshold_fC = cms.double(0.),
+                               TCThresholdBH_MIP = cms.double(0.),
+                               triggercell_threshold_silicon = cms.double(2.), # MipT
+                               triggercell_threshold_scintillator = cms.double(2.), # MipT
+                               )
+
+
+best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                          Method = cms.string('bestChoiceSelect'),
+                          NData = cms.uint32(12),
+                          MaxCellsInModule = cms.uint32(288),
+                          linLSB = cms.double(100./1024.),
+                          adcsaturationBH = adcSaturationBH_MIP,
+                          adcnBitsBH = adcNbitsBH,
+                          )
+
+
+supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                             Method = cms.string('superTriggerCellSelect'),
+                             stcSize = cms.vuint32(4,4,4)
+                             )
+
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+# V9 samples have a different defintiion of the dEdx calibrations. To account for it
+# we reascale the thresholds of the FE selection
+# (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
+# for more details)
+phase2_hgcalV9.toModify(threshold_conc_proc,
+                        triggercell_threshold_silicon=cms.double(1.5),  # MipT
+                        triggercell_threshold_scintillator=cms.double(1.5),  # MipT
+                        )
+
 
 hgcalConcentratorProducer = cms.EDProducer(
     "HGCalConcentratorProducer",
     InputTriggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
     InputTriggerSums = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
-    ProcessorParameters = conc_proc.clone()
+    ProcessorParameters = threshold_conc_proc.clone()
     )

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -15,7 +15,6 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
 modifyHgcalTriggerPrimitivesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_geometry_V9)
-modifyHgcalTriggerPrimitivesCalibWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(lambda process : custom_cluster_calibration_global(process, factor=1))
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -1,51 +1,50 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, \
+                                                              distance_C2d_params, \
+                                                              topological_C2d_params, \
+                                                              constrTopological_C2d_params
+from L1Trigger.L1THGCal.customClustering import set_threshold_params
 
 
 def create_distance(process, inputs,
-        distance=6.,# cm
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    producer = process.hgcalBackEndLayer1Producer.clone() 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) 
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) 
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) 
-    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) 
-    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRC2d') 
+                    distance=distance_C2d_params.dR_cluster,  # cm
+                    seed_threshold=distance_C2d_params.seeding_threshold_silicon,  # MipT
+                    cluster_threshold=distance_C2d_params.clustering_threshold_silicon  # MipT
+                    ):
+    producer = process.hgcalBackEndLayer1Producer.clone()
+    producer.ProcessorParameters.C2d_parameters = distance_C2d_params.clone()
+    set_threshold_params(producer.ProcessorParameters.C2d_parameters, seed_threshold, cluster_threshold)
+    producer.ProcessorParameters.C2d_parameters.dR_cluster = distance
     producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
     return producer
+
 
 def create_topological(process, inputs,
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    producer = process.hgcalBackEndLayer1Producer.clone() 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('NNC2d') 
+                       seed_threshold=topological_C2d_params.seeding_threshold_silicon,  # MipT
+                       cluster_threshold=topological_C2d_params.clustering_threshold_silicon  # MipT
+                       ):
+    producer = process.hgcalBackEndLayer1Producer.clone()
+    producer.ProcessorParameters.C2d_parameters = topological_C2d_params.clone()
+    set_threshold_params(producer.ProcessorParameters.C2d_parameters, seed_threshold, cluster_threshold)
     producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
     return producer
+
 
 def create_constrainedtopological(process, inputs,
-        distance=6.,# cm
-        seed_threshold=5.,# MipT
-        cluster_threshold=2.# MipT
-        ):
-    producer = process.hgcalBackEndLayer1Producer.clone() 
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_silicon = cms.double(seed_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.seeding_threshold_scintillator = cms.double(seed_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_silicon = cms.double(cluster_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.clustering_threshold_scintillator = cms.double(cluster_threshold) # MipT
-    producer.ProcessorParameters.C2d_parameters.dR_cluster = cms.double(distance) # cm
-    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dRNNC2d') 
+                                  distance=constrTopological_C2d_params.dR_cluster,  # cm
+                                  seed_threshold=constrTopological_C2d_params.seeding_threshold_silicon,  # MipT
+                                  cluster_threshold=constrTopological_C2d_params.clustering_threshold_silicon  # MipT
+                                  ):
+    producer = process.hgcalBackEndLayer1Producer.clone()
+    producer.ProcessorParameters.C2d_parameters = constrTopological_C2d_params.clone()
+    set_threshold_params(producer.ProcessorParameters.C2d_parameters, seed_threshold, cluster_threshold)
+    producer.ProcessorParameters.C2d_parameters.dR_cluster = distance
     producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
     return producer
 
+
 def create_dummy(process, inputs):
-    producer = process.hgcalBackEndLayer1Producer.clone() 
-    producer.ProcessorParameters.C2d_parameters.clusterType = cms.string('dummyC2d')
+    producer = process.hgcalBackEndLayer1Producer.clone()
+    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
     producer.InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
     return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -1,106 +1,107 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import distance_C3d_params, \
+                                                              dbscan_C3d_params, \
+                                                              histoMax_C3d_params, \
+                                                              histoMaxVariableDR_C3d_params, \
+                                                              histoSecondaryMax_C3d_params, \
+                                                              histoInterpolatedMax_C3d_params, \
+                                                              histoThreshold_C3d_params, \
+                                                              neighbour_weights_1stOrder, \
+                                                              neighbour_weights_2ndOrder
 
-from L1Trigger.L1THGCal.customClustering import binSums, dr_layerbylayer
+from L1Trigger.L1THGCal.customClustering import set_histomax_params
 
 
 def create_distance(process, inputs,
-        distance=0.01
-        ):
-    producer = process.hgcalBackEndLayer2Producer.clone() 
-    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
-    producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster=cms.double(0.)
-    producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster=cms.uint32(0)
-    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('dRC3d')
+                    distance=distance_C3d_params.dR_multicluster
+                    ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = distance_C3d_params.clone()
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster = distance
     producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
 
 
 def create_dbscan(process, inputs,
-        distance=0.005,
-        min_points=3
-        ):
-    producer = process.hgcalBackEndLayer2Producer.clone() 
-    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(0.)
-    producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster = cms.double(distance)
-    producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster = cms.uint32(min_points)
-    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('DBSCANC3d')
+                  distance=dbscan_C3d_params.dist_dbscan_multicluster,
+                  min_points=dbscan_C3d_params.minN_dbscan_multicluster
+                  ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = dbscan_C3d_params.clone()
+    producer.ProcessorParameters.C3d_parameters.dist_dbscan_multicluster = distance
+    producer.ProcessorParameters.C3d_parameters.minN_dbscan_multicluster = min_points
     producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
 
 
 def create_histoMax(process, inputs,
-        distance = 0.03,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,                        
-        seed_threshold = 0,
-        ):
-    producer = process.hgcalBackEndLayer2Producer.clone() 
-    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
-    producer.ProcessorParameters.C3d_parameters.nBins_R_histo_multicluster = cms.uint32(nBins_R)
-    producer.ProcessorParameters.C3d_parameters.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
-    producer.ProcessorParameters.C3d_parameters.binSumsHisto = binSumsHisto
-    producer.ProcessorParameters.C3d_parameters.threshold_histo_multicluster = seed_threshold
-    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoMaxC3d')
+                    distance=histoMax_C3d_params.dR_multicluster,
+                    nBins_R=histoMax_C3d_params.nBins_R_histo_multicluster,
+                    nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
+                    binSumsHisto=histoMax_C3d_params.binSumsHisto,
+                    seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
+                    ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone()
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
     producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
 
 
 def create_histoMax_variableDr(process, inputs,
-        distances = dr_layerbylayer,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        seed_threshold = 0,
-        ):
-    producer = create_histoMax(process, inputs, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
-    producer.ProcessorParameters.C3d_parameters.dR_multicluster_byLayer = cms.vdouble(distances)
+                               distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+                               nBins_R=histoMaxVariableDR_C3d_params.nBins_R_histo_multicluster,
+                               nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
+                               binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
+                               seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                               ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone()
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    producer.ProcessorParameters.C3d_parameters.dR_multicluster_byLayer_coefficientA = distances
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
 
 
-def create_histoInterpolatedMax(process, inputs,
-        distance = 0.03,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        ):
-    producer = create_histoMax( process, inputs, distance, nBins_R, nBins_Phi, binSumsHisto )
-    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoInterpolatedMaxC3d')
-    return producer
-
-def create_histoInterpolatedMax1stOrder(process, inputs):
-    producer = create_histoInterpolatedMax( process, inputs )
-    producer.ProcessorParameters.C3d_parameters.neighbour_weights=cms.vdouble(  0    , 0.25, 0   ,
-                                                   0.25 , 0   , 0.25,
-                                                   0    , 0.25, 0
-                                                )
+def create_histoInterpolatedMax1stOrder(process, inputs,
+                                        distance=histoInterpolatedMax_C3d_params.dR_multicluster,
+                                        nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
+                                        nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone()
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    producer.ProcessorParameters.C3d_parameters.neighbour_weights = neighbour_weights_1stOrder
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
 
 
-
-def create_histoInterpolatedMax2ndOrder(process, inputs):
-    producer = create_histoInterpolatedMax( process,inputs )
-    producer.ProcessorParameters.C3d_parameters.neighbour_weights=cms.vdouble( -0.25, 0.5, -0.25,
-                                                   0.5 , 0  ,  0.5 ,
-                                                  -0.25, 0.5, -0.25
-                                                )
+def create_histoInterpolatedMax2ndOrder(process, inputs,
+                                        distance=histoInterpolatedMax_C3d_params.dR_multicluster,
+                                        nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
+                                        nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone()
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    producer.ProcessorParameters.C3d_parameters.neighbour_weights = neighbour_weights_2ndOrder
+    producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer
-
 
 
 def create_histoThreshold(process, inputs,
-        threshold = 20.,
-        distance = 0.03,
-        nBins_R = 36,
-        nBins_Phi = 216,
-        binSumsHisto = binSums,
-        ):
-    producer = process.hgcalBackEndLayer2Producer.clone() 
-    producer.ProcessorParameters.C3d_parameters.threshold_histo_multicluster = cms.double(threshold)
-    producer.ProcessorParameters.C3d_parameters.dR_multicluster = cms.double(distance)
-    producer.ProcessorParameters.C3d_parameters.nBins_R_histo_multicluster = cms.uint32(nBins_R)
-    producer.ProcessorParameters.C3d_parameters.nBins_Phi_histo_multicluster = cms.uint32(nBins_Phi)
-    producer.ProcessorParameters.C3d_parameters.binSumsHisto = binSumsHisto
-    producer.ProcessorParameters.C3d_parameters.type_multicluster = cms.string('HistoThresholdC3d')
+                          threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
+                          distance=histoThreshold_C3d_params.dR_multicluster,
+                          nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
+                          nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
+                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto
+                          ):
+    producer = process.hgcalBackEndLayer2Producer.clone()
+    producer.ProcessorParameters.C3d_parameters = histoThreshold_C3d_params.clone()
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, threshold)
     producer.InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
     return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,11 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc
+
 
 def create_supertriggercell(process, inputs,
-        stcSize = cms.vuint32(4,4,4) 
-        ):
-    producer = process.hgcalConcentratorProducer.clone()     
-    producer.ProcessorParameters.Method = cms.string('superTriggerCellSelect')
+                            stcSize=supertc_conc_proc.stcSize
+                            ):
+    producer = process.hgcalConcentratorProducer.clone()
+    producer.ProcessorParameters = supertc_conc_proc.clone()
     producer.ProcessorParameters.stcSize = stcSize
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
@@ -13,35 +15,24 @@ def create_supertriggercell(process, inputs,
 
 
 def create_threshold(process, inputs,
-        threshold=2. # in mipT
-        ):
-    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
-    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
+                     threshold_silicon=threshold_conc_proc.triggercell_threshold_silicon,  # in mipT
+                     threshold_scintillator=threshold_conc_proc.triggercell_threshold_scintillator  # in mipT
+                     ):
     producer = process.hgcalConcentratorProducer.clone()
-    producer.ProcessorParameters.Method = cms.string('thresholdSelect')
-    producer.ProcessorParameters.linLSB = cms.double(100./1024.)
-    producer.ProcessorParameters.adcsaturationBH = adcSaturationBH_MIP
-    producer.ProcessorParameters.adcnBitsBH = adcNbitsBH
-    producer.ProcessorParameters.TCThreshold_fC = cms.double(0.)
-    producer.ProcessorParameters.TCThresholdBH_MIP = cms.double(0.)
-    producer.ProcessorParameters.triggercell_threshold_silicon = cms.double(threshold) # MipT
-    producer.ProcessorParameters.triggercell_threshold_scintillator = cms.double(threshold) # MipT
+    producer.ProcessorParameters = threshold_conc_proc.clone()
+    producer.ProcessorParameters.triggercell_threshold_silicon = threshold_silicon  # MipT
+    producer.ProcessorParameters.triggercell_threshold_scintillator = threshold_scintillator  # MipT
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     return producer
 
 
 def create_bestchoice(process, inputs,
-       triggercells=12
-        ):
-    adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
-    adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
-    producer = process.hgcalConcentratorProducer.clone() 
-    producer.ProcessorParameters.Method = cms.string('bestChoiceSelect')
-    producer.ProcessorParameters.NData = cms.uint32(triggercells)
-    producer.ProcessorParameters.linLSB = cms.double(100./1024.)
-    producer.ProcessorParameters.adcsaturationBH = adcSaturationBH_MIP
-    producer.ProcessorParameters.adcnBitsBH = adcNbitsBH
+                      triggercells=best_conc_proc.NData
+                      ):
+    producer = process.hgcalConcentratorProducer.clone()
+    producer.ProcessorParameters = best_conc_proc.clone()
+    producer.ProcessorParameters.NData = triggercells
     producer.InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     producer.InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
     return producer


### PR DESCRIPTION
Backport of #318