### PR TITLE
Topic caloparticle triggercells

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -91,6 +91,7 @@ namespace l1t {
     double mipPt() const { return mipPt_; }
     double seedMipPt() const { return seedMipPt_; }
     uint32_t detId() const { return detId_.rawId(); }
+    void setDetId(uint32_t id) { detId_ = id; }
     void setPt(double pt) { setP4(math::PtEtaPhiMLorentzVector(pt, eta(), phi(), mass())); }
     double sumPt() const { return sumPt_; }
     /* distance in 'cm' */

--- a/L1Trigger/L1THGCalUtilities/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="FWCore/Framework"/>
+<use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1THGCal"/>
 <use   name="CommonTools/Utils"/>
 <export>

--- a/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
@@ -22,4 +22,14 @@
   <use   name="roottmva"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
-
+<library   name="L1TriggerL1THGCalUtilitiesPlugins_calotruth" file="CaloTruthCellsProducer.cc">
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/PluginManager"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="Geometry/Records"/>
+  <use   name="SimDataFormats/CaloAnalysis"/>
+  <use   name="SimDataFormats/CaloTest"/>
+  <use   name="DataFormats/L1THGCal"/>
+  <use   name="L1Trigger/L1THGCal"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
@@ -1,0 +1,285 @@
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/OneToMany.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+class CaloTruthCellsProducer : public edm::stream::EDProducer<> {
+public:
+  explicit CaloTruthCellsProducer(edm::ParameterSet const&);
+  ~CaloTruthCellsProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+  std::unordered_map<uint32_t, double> makeHitMap(edm::Event const&,
+                                                  edm::EventSetup const&,
+                                                  HGCalTriggerGeometryBase const&) const;
+
+  typedef edm::AssociationMap<edm::OneToMany<CaloParticleCollection, l1t::HGCalTriggerCellBxCollection>> CaloToCellsMap;
+
+  bool makeCellsCollection_;
+  edm::EDGetTokenT<CaloParticleCollection> caloParticlesToken_;
+  edm::EDGetTokenT<l1t::HGCalTriggerCellBxCollection> triggerCellsToken_;
+  edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenEE_;
+  edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEfront_;
+  edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEback_;
+
+  HGCalClusteringDummyImpl dummyClustering_;
+  HGCalShowerShape showerShape_;
+
+  HGCalTriggerTools triggerTools_;
+};
+
+CaloTruthCellsProducer::CaloTruthCellsProducer(edm::ParameterSet const& config)
+    : makeCellsCollection_(config.getParameter<bool>("makeCellsCollection")),
+      caloParticlesToken_(consumes<CaloParticleCollection>(config.getParameter<edm::InputTag>("caloParticles"))),
+      triggerCellsToken_(
+          consumes<l1t::HGCalTriggerCellBxCollection>(config.getParameter<edm::InputTag>("triggerCells"))),
+      simHitsTokenEE_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsEE"))),
+      simHitsTokenHEfront_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsHEfront"))),
+      simHitsTokenHEback_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsHEback"))),
+      dummyClustering_(config.getParameterSet("dummyClustering")) {
+  produces<CaloToCellsMap>();
+  produces<l1t::HGCalClusterBxCollection>();
+  produces<l1t::HGCalMulticlusterBxCollection>();
+  if (makeCellsCollection_)
+    produces<l1t::HGCalTriggerCellBxCollection>();
+}
+
+CaloTruthCellsProducer::~CaloTruthCellsProducer() {}
+
+void CaloTruthCellsProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
+  edm::Handle<CaloParticleCollection> caloParticlesHandle;
+  event.getByToken(caloParticlesToken_, caloParticlesHandle);
+  auto const& caloParticles(*caloParticlesHandle);
+
+  edm::Handle<l1t::HGCalTriggerCellBxCollection> triggerCellsHandle;
+  event.getByToken(triggerCellsToken_, triggerCellsHandle);
+  auto const& triggerCells(*triggerCellsHandle);
+
+  dummyClustering_.eventSetup(setup);
+  showerShape_.eventSetup(setup);
+  triggerTools_.eventSetup(setup);
+
+  edm::ESHandle<HGCalTriggerGeometryBase> geometryHandle;
+  setup.get<CaloGeometryRecord>().get(geometryHandle);
+  auto const& geometry(*geometryHandle);
+
+  std::unordered_map<uint32_t, CaloParticleRef> tcToCalo;
+
+  std::unordered_map<uint32_t, double> hitToEnergy(makeHitMap(event, setup, geometry));  // cellId -> sim energy
+  std::unordered_map<uint32_t, std::pair<double, double>>
+      tcToEnergies;  // tcId -> {total sim energy, fractioned sim energy}
+
+  for (auto const& he : hitToEnergy) {
+    DetId hitId(he.first);
+    uint32_t tcId;
+    try {
+      tcId = geometry.getTriggerCellFromCell(hitId);
+    } catch (cms::Exception const& ex) {
+      edm::LogError("CaloTruthCellsProducer") << ex.what();
+      continue;
+    }
+
+    tcToEnergies[tcId].first += he.second;
+  }
+
+  // used later to order multiclusters
+  std::map<int, CaloParticleRef> orderedCaloRefs;
+
+  for (unsigned iP(0); iP != caloParticles.size(); ++iP) {
+    auto const& caloParticle(caloParticles.at(iP));
+    if (caloParticle.g4Tracks().at(0).eventId().event() != 0)  // pileup
+      continue;
+
+    CaloParticleRef ref(caloParticlesHandle, iP);
+
+    SimClusterRefVector const& simClusters(caloParticle.simClusters());
+    for (auto const& simCluster : simClusters) {
+      for (auto const& hAndF : simCluster->hits_and_fractions()) {
+        DetId hitId(hAndF.first);
+        uint32_t tcId;
+        try {
+          tcId = geometry.getTriggerCellFromCell(hitId);
+        } catch (cms::Exception const& ex) {
+          edm::LogError("CaloTruthCellsProducer") << ex.what();
+          continue;
+        }
+
+        tcToCalo.emplace(tcId, ref);
+        tcToEnergies[tcId].second += hitToEnergy[hAndF.first] * hAndF.second;
+      }
+    }
+
+    // ordered by the gen particle index
+    int genIndex(caloParticle.g4Tracks().at(0).genpartIndex() - 1);
+    orderedCaloRefs[genIndex] = ref;
+  }
+
+  auto outMap(std::make_unique<CaloToCellsMap>(caloParticlesHandle, triggerCellsHandle));
+  std::unique_ptr<l1t::HGCalTriggerCellBxCollection> outCollection;
+  if (makeCellsCollection_)
+    outCollection = std::make_unique<l1t::HGCalTriggerCellBxCollection>();
+
+  typedef edm::Ptr<l1t::HGCalTriggerCell> TriggerCellPtr;
+  typedef edm::Ptr<l1t::HGCalCluster> ClusterPtr;
+
+  // ClusteringDummyImpl only considers BX 0, so we dump all cells to one vector
+  std::vector<TriggerCellPtr> triggerCellPtrs;
+
+  // loop through all bunch crossings
+  for (int bx(triggerCells.getFirstBX()); bx <= triggerCells.getLastBX(); ++bx) {
+    for (auto cItr(triggerCells.begin(bx)); cItr != triggerCells.end(bx); ++cItr) {
+      auto const& cell(*cItr);
+
+      auto mapElem(tcToCalo.find(cell.detId()));
+      if (mapElem == tcToCalo.end())
+        continue;
+
+      outMap->insert(mapElem->second,
+                     edm::Ref<l1t::HGCalTriggerCellBxCollection>(triggerCellsHandle, triggerCells.key(cItr)));
+
+      if (makeCellsCollection_) {
+        auto const& simEnergies(tcToEnergies.at(cell.detId()));
+        if (simEnergies.first > 0.) {
+          double eFraction(simEnergies.second / simEnergies.first);
+
+          outCollection->push_back(bx, cell);
+          auto& newCell((*outCollection)[outCollection->size() - 1]);
+
+          newCell.setMipPt(cell.mipPt() * eFraction);
+          newCell.setP4(cell.p4() * eFraction);
+        }
+      }
+
+      triggerCellPtrs.emplace_back(triggerCellsHandle, triggerCells.key(cItr));
+    }
+  }
+
+  event.put(std::move(outMap));
+  if (makeCellsCollection_)
+    event.put(std::move(outCollection));
+
+  auto outClusters(std::make_unique<l1t::HGCalClusterBxCollection>());
+
+  auto sortCellPtrs(
+      [](TriggerCellPtr const& lhs, TriggerCellPtr const& rhs) -> bool { return lhs->mipPt() > rhs->mipPt(); });
+
+  std::sort(triggerCellPtrs.begin(), triggerCellPtrs.end(), sortCellPtrs);
+  dummyClustering_.clusterizeDummy(triggerCellPtrs, *outClusters);
+
+  std::unordered_map<unsigned, std::vector<unsigned>> caloToClusterIndices;
+  for (unsigned iC(0); iC != outClusters->size(); ++iC) {
+    auto const& cluster((*outClusters)[iC]);
+    // cluster detId and cell detId are identical
+    auto caloRef(tcToCalo.at(cluster.detId()));
+    caloToClusterIndices[caloRef.key()].push_back(iC);
+  }
+
+  auto clustersHandle(event.put(std::move(outClusters)));
+
+  auto outMulticlusters(std::make_unique<l1t::HGCalMulticlusterBxCollection>());
+
+  for (auto const& ocr : orderedCaloRefs) {
+    auto const& ref(ocr.second);
+
+    if (ref.isNull())  // shouldn't happen
+      continue;
+
+    auto const& caloParticle(*ref);
+
+    l1t::HGCalMulticluster multicluster;
+
+    for (unsigned iC : caloToClusterIndices[ref.key()]) {
+      ClusterPtr clPtr(clustersHandle, iC);
+      multicluster.addConstituent(clPtr, true, 1.);
+    }
+
+    // Set the gen particle index as the DetId
+    multicluster.setDetId(caloParticle.g4Tracks().at(0).genpartIndex() - 1);
+
+    auto const& centre(multicluster.centre());
+    math::PtEtaPhiMLorentzVector multiclusterP4(multicluster.sumPt(), centre.eta(), centre.phi(), 0.);
+    multicluster.setP4(multiclusterP4);
+
+    showerShape_.fillShapes(multicluster, geometry);
+
+    // not setting the quality flag
+    // multicluster.setHwQual(id_->decision(multicluster));
+    // fill H/E
+    multicluster.saveHOverE();
+
+    outMulticlusters->push_back(0, multicluster);
+  }
+
+  event.put(std::move(outMulticlusters));
+}
+
+std::unordered_map<uint32_t, double> CaloTruthCellsProducer::makeHitMap(
+    edm::Event const& event, edm::EventSetup const& setup, HGCalTriggerGeometryBase const& geometry) const {
+  std::unordered_map<uint32_t, double> hitMap;  // cellId -> sim energy
+
+  typedef std::function<DetId(DetId const&)> DetIdMapper;
+  typedef std::pair<edm::EDGetTokenT<std::vector<PCaloHit>> const*, DetIdMapper> SimHitSpec;
+
+  SimHitSpec specs[3] = {{&simHitsTokenEE_,
+                          [this, &geometry](DetId const& simId) -> DetId {
+                            return this->triggerTools_.simToReco(simId, geometry.eeTopology());
+                          }},
+                         {&simHitsTokenHEfront_,
+                          [this, &geometry](DetId const& simId) -> DetId {
+                            return this->triggerTools_.simToReco(simId, geometry.fhTopology());
+                          }},
+                         {&simHitsTokenHEback_, nullptr}};
+  if (geometry.isV9Geometry())
+    specs[2].second = [this, &geometry](DetId const& simId) -> DetId {
+      return this->triggerTools_.simToReco(simId, geometry.hscTopology());
+    };
+  else
+    specs[2].second = [this, &geometry](DetId const& simId) -> DetId {
+      return this->triggerTools_.simToReco(simId, geometry.bhTopology());
+    };
+
+  for (auto const& tt : specs) {
+    edm::Handle<std::vector<PCaloHit>> handle;
+    event.getByToken(*tt.first, handle);
+    auto const& simhits(*handle);
+
+    for (auto const& simhit : simhits)
+      hitMap.emplace(tt.second(simhit.id()), simhit.energy());
+  }
+
+  return hitMap;
+}
+
+void CaloTruthCellsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(CaloTruthCellsProducer);

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -49,19 +49,28 @@ void HGCalTriggerNtupleHGCClusters::initialize(TTree& tree,
   multiclusters_token_ =
       collector.consumes<l1t::HGCalMulticlusterBxCollection>(conf.getParameter<edm::InputTag>("Multiclusters"));
 
-  tree.Branch("cl_n", &cl_n_, "cl_n/I");
-  tree.Branch("cl_id", &cl_id_);
-  tree.Branch("cl_mipPt", &cl_mipPt_);
-  tree.Branch("cl_pt", &cl_pt_);
-  tree.Branch("cl_energy", &cl_energy_);
-  tree.Branch("cl_eta", &cl_eta_);
-  tree.Branch("cl_phi", &cl_phi_);
-  tree.Branch("cl_layer", &cl_layer_);
-  tree.Branch("cl_subdet", &cl_subdet_);
-  tree.Branch("cl_cells_n", &cl_cells_n_);
-  tree.Branch("cl_cells_id", &cl_cells_id_);
-  tree.Branch("cl_multicluster_id", &cl_multicluster_id_);
-  tree.Branch("cl_multicluster_pt", &cl_multicluster_pt_);
+  std::string prefix(conf.getUntrackedParameter<std::string>("Prefix", "cl"));
+
+  std::string bname;
+  auto withPrefix([&prefix, &bname](char const* vname) -> char const* {
+    bname = prefix + "_" + vname;
+    return bname.c_str();
+  });
+
+  // note: can't use withPrefix() twice within a same statement because bname gets overwritten
+  tree.Branch(withPrefix("n"), &cl_n_, (prefix + "_n/I").c_str());
+  tree.Branch(withPrefix("id"), &cl_id_);
+  tree.Branch(withPrefix("mipPt"), &cl_mipPt_);
+  tree.Branch(withPrefix("pt"), &cl_pt_);
+  tree.Branch(withPrefix("energy"), &cl_energy_);
+  tree.Branch(withPrefix("eta"), &cl_eta_);
+  tree.Branch(withPrefix("phi"), &cl_phi_);
+  tree.Branch(withPrefix("layer"), &cl_layer_);
+  tree.Branch(withPrefix("subdet"), &cl_subdet_);
+  tree.Branch(withPrefix("cells_n"), &cl_cells_n_);
+  tree.Branch(withPrefix("cells_id"), &cl_cells_id_);
+  tree.Branch(withPrefix("multicluster_id"), &cl_multicluster_id_);
+  tree.Branch(withPrefix("multicluster_pt"), &cl_multicluster_pt_);
 }
 
 void HGCalTriggerNtupleHGCClusters::fill(const edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -60,31 +60,39 @@ void HGCalTriggerNtupleHGCMulticlusters::initialize(TTree& tree,
       HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT")};
   id_->initialize(conf.getParameter<edm::ParameterSet>("EGIdentification"));
 
-  tree.Branch("cl3d_n", &cl3d_n_, "cl3d_n/I");
-  tree.Branch("cl3d_id", &cl3d_id_);
-  tree.Branch("cl3d_pt", &cl3d_pt_);
-  tree.Branch("cl3d_energy", &cl3d_energy_);
-  tree.Branch("cl3d_eta", &cl3d_eta_);
-  tree.Branch("cl3d_phi", &cl3d_phi_);
-  tree.Branch("cl3d_clusters_n", &cl3d_clusters_n_);
-  tree.Branch("cl3d_clusters_id", &cl3d_clusters_id_);
+  std::string prefix(conf.getUntrackedParameter<std::string>("Prefix", "cl3d"));
+
+  std::string bname;
+  auto withPrefix([&prefix, &bname](char const* vname) -> char const* {
+    bname = prefix + "_" + vname;
+    return bname.c_str();
+  });
+
+  tree.Branch(withPrefix("n"), &cl3d_n_, (prefix + "_n/I").c_str());
+  tree.Branch(withPrefix("id"), &cl3d_id_);
+  tree.Branch(withPrefix("pt"), &cl3d_pt_);
+  tree.Branch(withPrefix("energy"), &cl3d_energy_);
+  tree.Branch(withPrefix("eta"), &cl3d_eta_);
+  tree.Branch(withPrefix("phi"), &cl3d_phi_);
+  tree.Branch(withPrefix("clusters_n"), &cl3d_clusters_n_);
+  tree.Branch(withPrefix("clusters_id"), &cl3d_clusters_id_);
   if (fill_layer_info_)
-    tree.Branch("cl3d_layer_pt", &cl3d_layer_pt_);
-  tree.Branch("cl3d_showerlength", &cl3d_showerlength_);
-  tree.Branch("cl3d_coreshowerlength", &cl3d_coreshowerlength_);
-  tree.Branch("cl3d_firstlayer", &cl3d_firstlayer_);
-  tree.Branch("cl3d_maxlayer", &cl3d_maxlayer_);
-  tree.Branch("cl3d_seetot", &cl3d_seetot_);
-  tree.Branch("cl3d_seemax", &cl3d_seemax_);
-  tree.Branch("cl3d_spptot", &cl3d_spptot_);
-  tree.Branch("cl3d_sppmax", &cl3d_sppmax_);
-  tree.Branch("cl3d_szz", &cl3d_szz_);
-  tree.Branch("cl3d_srrtot", &cl3d_srrtot_);
-  tree.Branch("cl3d_srrmax", &cl3d_srrmax_);
-  tree.Branch("cl3d_srrmean", &cl3d_srrmean_);
-  tree.Branch("cl3d_emaxe", &cl3d_emaxe_);
-  tree.Branch("cl3d_bdteg", &cl3d_bdteg_);
-  tree.Branch("cl3d_quality", &cl3d_quality_);
+    tree.Branch(withPrefix("layer_pt"), &cl3d_layer_pt_);
+  tree.Branch(withPrefix("showerlength"), &cl3d_showerlength_);
+  tree.Branch(withPrefix("coreshowerlength"), &cl3d_coreshowerlength_);
+  tree.Branch(withPrefix("firstlayer"), &cl3d_firstlayer_);
+  tree.Branch(withPrefix("maxlayer"), &cl3d_maxlayer_);
+  tree.Branch(withPrefix("seetot"), &cl3d_seetot_);
+  tree.Branch(withPrefix("seemax"), &cl3d_seemax_);
+  tree.Branch(withPrefix("spptot"), &cl3d_spptot_);
+  tree.Branch(withPrefix("sppmax"), &cl3d_sppmax_);
+  tree.Branch(withPrefix("szz"), &cl3d_szz_);
+  tree.Branch(withPrefix("srrtot"), &cl3d_srrtot_);
+  tree.Branch(withPrefix("srrmax"), &cl3d_srrmax_);
+  tree.Branch(withPrefix("srrmean"), &cl3d_srrmean_);
+  tree.Branch(withPrefix("emaxe"), &cl3d_emaxe_);
+  tree.Branch(withPrefix("bdteg"), &cl3d_bdteg_);
+  tree.Branch(withPrefix("quality"), &cl3d_quality_);
 }
 
 void HGCalTriggerNtupleHGCMulticlusters::fill(const edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -36,15 +36,23 @@ void HGCalTriggerNtupleHGCTowers::initialize(TTree& tree,
                                              edm::ConsumesCollector&& collector) {
   towers_token_ = collector.consumes<l1t::HGCalTowerBxCollection>(conf.getParameter<edm::InputTag>("Towers"));
 
-  tree.Branch("tower_n", &tower_n_, "tower_n/I");
-  tree.Branch("tower_pt", &tower_pt_);
-  tree.Branch("tower_energy", &tower_energy_);
-  tree.Branch("tower_eta", &tower_eta_);
-  tree.Branch("tower_phi", &tower_phi_);
-  tree.Branch("tower_etEm", &tower_etEm_);
-  tree.Branch("tower_etHad", &tower_etHad_);
-  tree.Branch("tower_iEta", &tower_iEta_);
-  tree.Branch("tower_iPhi", &tower_iPhi_);
+  std::string prefix(conf.getUntrackedParameter<std::string>("Prefix", "tower"));
+
+  std::string bname;
+  auto withPrefix([&prefix, &bname](char const* vname) -> char const* {
+    bname = prefix + "_" + vname;
+    return bname.c_str();
+  });
+
+  tree.Branch(withPrefix("n"), &tower_n_, (prefix + "_n/I").c_str());
+  tree.Branch(withPrefix("pt"), &tower_pt_);
+  tree.Branch(withPrefix("energy"), &tower_energy_);
+  tree.Branch(withPrefix("eta"), &tower_eta_);
+  tree.Branch(withPrefix("phi"), &tower_phi_);
+  tree.Branch(withPrefix("etEm"), &tower_etEm_);
+  tree.Branch(withPrefix("etHad"), &tower_etHad_);
+  tree.Branch(withPrefix("iEta"), &tower_iEta_);
+  tree.Branch(withPrefix("iPhi"), &tower_iPhi_);
 }
 
 void HGCalTriggerNtupleHGCTowers::fill(const edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1THGCalUtilities/python/caloTruthCellsNtuples_cff.py
+++ b/L1Trigger/L1THGCalUtilities/python/caloTruthCellsNtuples_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCalUtilities.caloTruthCellsProducer_cfi import caloTruthCellsProducer
+from L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cfi import *
+
+ntuple_multiclusters_fulltruth = ntuple_multiclusters.clone(
+    Multiclusters = cms.InputTag('caloTruthCellsProducer'),
+    Prefix = cms.untracked.string('cl3dfulltruth')
+)
+hgcalTriggerNtuplizer.Ntuples.append(ntuple_multiclusters_fulltruth)
+
+# If caloTruthCellsProducer.makeCellsCollection is True, can run the clustering algorithm over output cells too
+
+if caloTruthCellsProducer.makeCellsCollection:
+    ## ntuplize clusters and towers
+
+    ntuple_triggercells.caloParticlesToCells = cms.InputTag('caloTruthCellsProducer')
+    ntuple_triggercells.FillTruthMap = cms.bool(True)
+    
+    ntuple_triggercells_truth = ntuple_triggercells.clone(
+        TriggerCells = cms.InputTag('caloTruthCellsProducer'),
+        Multiclusters = cms.InputTag('hgcalTruthBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'),
+        Prefix = cms.untracked.string('tctruth'),
+        FillTruthMap = cms.bool(False)
+    )
+    
+    ntuple_clusters_truth = ntuple_clusters.clone(
+        Clusters = cms.InputTag('hgcalTruthBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
+        Prefix = cms.untracked.string('cltruth')
+    )
+    
+    ntuple_multiclusters_truth = ntuple_multiclusters.clone(
+        Multiclusters = cms.InputTag('hgcalTruthBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'),
+        Prefix = cms.untracked.string('cl3dtruth')
+    )
+    
+    ntuple_towers_truth = ntuple_towers.clone(
+        Towers = cms.InputTag('hgcalTruthTowerProducer:HGCalTowerProcessor'),
+        Prefix = cms.untracked.string('towertruth')
+    )
+
+    hgcalTriggerNtuplizer.Ntuples.append(ntuple_triggercells_truth)
+    hgcalTriggerNtuplizer.Ntuples.append(ntuple_multiclusters_truth)
+    hgcalTriggerNtuplizer.Ntuples.append(ntuple_towers_truth)

--- a/L1Trigger/L1THGCalUtilities/python/caloTruthCellsProducer_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/caloTruthCellsProducer_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params
+
+caloTruthCellsProducer = cms.EDProducer('CaloTruthCellsProducer',
+    caloParticles = cms.InputTag('mix', 'MergedCaloTruth'),
+    triggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
+    simHitsEE = cms.InputTag('g4SimHits:HGCHitsEE'),
+    simHitsHEfront = cms.InputTag('g4SimHits:HGCHitsHEfront'),
+    simHitsHEback = cms.InputTag('g4SimHits:HcalHits'),
+    makeCellsCollection = cms.bool(True),
+    dummyClustering = dummy_C2d_params.clone()
+)

--- a/L1Trigger/L1THGCalUtilities/python/caloTruthCells_cff.py
+++ b/L1Trigger/L1THGCalUtilities/python/caloTruthCells_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCalUtilities.caloTruthCellsProducer_cfi import caloTruthCellsProducer
+
+caloTruthCells = cms.Sequence(caloTruthCellsProducer)
+
+if caloTruthCellsProducer.makeCellsCollection:
+    ## cluster and tower sequence
+
+    from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import hgcalConcentratorProducer
+    from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import hgcalBackEndLayer1Producer
+    from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import hgcalBackEndLayer2Producer
+    from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import hgcalTowerMapProducer
+    from L1Trigger.L1THGCal.hgcalTowerProducer_cfi import hgcalTowerProducer
+    
+    hgcalTruthConcentratorProducer = hgcalConcentratorProducer.clone(
+        InputTriggerCells = cms.InputTag('caloTruthCellsProducer')
+    )
+    
+    hgcalTruthBackEndLayer1Producer = hgcalBackEndLayer1Producer.clone(
+        InputTriggerCells = cms.InputTag('hgcalTruthConcentratorProducer:HGCalConcentratorProcessorSelection')
+    )
+    
+    hgcalTruthBackEndLayer2Producer = hgcalBackEndLayer2Producer.clone(
+        InputCluster = cms.InputTag('hgcalTruthBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering')
+    )
+    
+    hgcalTruthTowerMapProducer = hgcalTowerMapProducer.clone(
+        InputTriggerCells = cms.InputTag('caloTruthCellsProducer')
+    )
+    
+    hgcalTruthTowerProducer = hgcalTowerProducer.clone(
+        InputTowerMaps = cms.InputTag('hgcalTruthTowerMapProducer:HGCalTowerMapProcessor')
+    )
+    
+    caloTruthCells += cms.Sequence(
+        hgcalTruthConcentratorProducer *
+        hgcalTruthBackEndLayer1Producer *
+        hgcalTruthBackEndLayer2Producer *
+        hgcalTruthTowerMapProducer *
+        hgcalTruthTowerProducer
+    )

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -61,6 +61,7 @@ ntuple_triggercells = cms.PSet(
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
     FillSimEnergy = cms.bool(False),
+    FillTruthMap = cms.bool(False),
     fcPerMip = fcPerMip,
     keV2fC = keV2fC,
     layerWeights = layerWeights,

--- a/L1Trigger/L1THGCalUtilities/src/classes.h
+++ b/L1Trigger/L1THGCalUtilities/src/classes.h
@@ -1,0 +1,17 @@
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/OneToMany.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+
+namespace L1Trigger_L1THGCalUtilities {
+  struct dictionary {
+    edm::RefProd<BXVector<l1t::HGCalTriggerCell> > dummyRefProd;
+    edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >, edm::RefProd<BXVector<l1t::HGCalTriggerCell> > >
+        dummyKeyVal;
+    edm::AssociationMap<edm::OneToMany<std::vector<CaloParticle>, BXVector<l1t::HGCalTriggerCell>, unsigned int> >
+        dummyMap;
+    edm::Wrapper<
+        edm::AssociationMap<edm::OneToMany<std::vector<CaloParticle>, BXVector<l1t::HGCalTriggerCell>, unsigned int> > >
+        dummyMapWrapper;
+  };
+}  // namespace L1Trigger_L1THGCalUtilities

--- a/L1Trigger/L1THGCalUtilities/src/classes_def.xml
+++ b/L1Trigger/L1THGCalUtilities/src/classes_def.xml
@@ -1,0 +1,8 @@
+<lcgdict>
+  <class name="edm::RefProd<BXVector<l1t::HGCalTriggerCell> >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<BXVector<l1t::HGCalTriggerCell> > >"/>
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<CaloParticle>,BXVector<l1t::HGCalTriggerCell>,unsigned int> >">
+    <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<CaloParticle>,BXVector<l1t::HGCalTriggerCell>,unsigned int> > >"/>
+</lcgdict>

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
@@ -68,6 +68,12 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+# To add truth-matched calo cells and downstream objects
+#process.load('L1Trigger.L1THGCalUtilities.caloTruthCells_cff')
+#process.hgcalTriggerPrimitives += process.caloTruthCells
+#process.load('L1Trigger.L1THGCalUtilities.caloTruthCellsNtuples_cff')
+
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 # To test V9Imp2
 #from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9


### PR DESCRIPTION
#### PR description:

Adds a new EDProducer CaloTruthCellsProducer, which selects trigger cells (made by the existing VFE producer) who has at least one constituent cell matched to the MC-truth energy deposit obtained from CaloParticles. Only the hard-scattering particles are considered. The EDProducer outputs are a map of CaloParticle -> trigger cells (in the existing collection) and a clone trigger cell collection.
The latter collection is used to create a separate set of clusters and towers in caloTruthCells_cff.py. Ntuple modules are reused to read these new collections (with new branch names).

#### PR validation:

Ran with V9 and V8 geometry RelVal DIGI-RECO configurations.