### PR TITLE
Option to set seed position by energy-weighted average of TC positions in cell

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -24,14 +24,27 @@ public:
 
 private:
   enum SeedingType { HistoMaxC3d, HistoSecondaryMaxC3d, HistoThresholdC3d, HistoInterpolatedMaxC3d };
+  enum SeedingPosition { BinCentre, TCWeighted };
 
-  typedef std::map<std::array<int, 3>, float> Histogram;
+  struct Bin {
+    float sumMipPt;
+    float weighted_x;
+    float weighted_y;
+  };
+
+  typedef std::map<std::array<int, 3>, Bin> Histogram;
 
   Histogram fillHistoClusters(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs);
 
   Histogram fillSmoothPhiHistoClusters(const Histogram& histoClusters, const vector<unsigned>& binSums);
 
   Histogram fillSmoothRPhiHistoClusters(const Histogram& histoClusters);
+
+  void setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
+                                int z_side,
+                                int bin_R,
+                                int bin_phi,
+                                const Bin& histBin);
 
   std::vector<std::pair<GlobalPoint, double>> computeMaxSeeds(const Histogram& histoClusters);
 
@@ -43,6 +56,7 @@ private:
 
   std::string seedingAlgoType_;
   SeedingType seedingType_;
+  SeedingPosition seedingPosition_;
 
   unsigned nBinsRHisto_ = 36;
   unsigned nBinsPhiHisto_ = 216;

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -74,7 +74,8 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                threshold_histo_multicluster=cms.double(10.),
                                cluster_association=cms.string("NearestNeighbour"),
                                EGIdentification=egamma_identification_histomax.clone(),
-                               neighbour_weights=neighbour_weights_1stOrder
+                               neighbour_weights=neighbour_weights_1stOrder,
+                               seed_position=cms.string("BinCentre"),#BinCentre, TCWeighted
                                )
 # V9 samples have a different defintiion of the dEdx calibrations. To account for it
 # we reascale the thresholds of the clustering seeds


### PR DESCRIPTION
Adding the option to set the Histogram seeding position by the energy-weighted average of the constituent trigger cells in a Histogram bin.

An unrelated observation is that `fillSmoothPhiHistoClusters` is not currently being used anywhere. Is this intended, and if not can it be removed?