### PR TITLE
Bug fix for energy-weighted seed positions

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -217,7 +217,7 @@ namespace l1t {
         centre_ = GlobalPoint(clusterCentre);
 
         if (clusterCentre.z() != 0) {
-          centreProj_ = GlobalPoint(clusterCentre / clusterCentre.z());
+          centreProj_ = GlobalPoint(clusterCentre / std::abs(clusterCentre.z()));
         }
       }
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -32,9 +32,7 @@ HGCalHistoClusteringImpl::HGCalHistoClusteringImpl(const edm::ParameterSet& conf
 }
 
 float HGCalHistoClusteringImpl::dR(const l1t::HGCalCluster& clu, const GlobalPoint& seed) const {
-  Basic3DVector<float> seed_3dv(seed);
-  GlobalPoint seed_proj(seed_3dv / seed.z());
-  return (seed_proj - clu.centreProj()).mag();
+  return (seed - clu.centreProj()).mag();
 }
 
 std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticluster(


### PR DESCRIPTION
In the case where z=-1, the sign of the energy weighted x, and y were incorrect.