### PR TITLE
Seeding optimization

### DIFF
--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -52,33 +52,22 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
     const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs) {
-  Histogram histoClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
-
-  for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin = histoClusters[{{z_side, bin_R, bin_phi}}];
-        bin.sumMipPt = 0;
-        bin.weighted_x = 0;
-        bin.weighted_y = 0;
-      }
-    }
-  }
+  Histogram histoClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (auto& clu : clustersPtrs) {
     float ROverZ = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
-    int bin_R = int((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
-    int bin_phi = int((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
+    unsigned bin_R = unsigned((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
+    unsigned bin_phi = unsigned((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
 
-    auto& bin = histoClusters[{{triggerTools_.zside(clu->detId()), bin_R, bin_phi}}];
+    auto& bin = histoClusters.at(triggerTools_.zside(clu->detId()), bin_R, bin_phi);
     bin.sumMipPt += clu->mipPt();
     bin.weighted_x += (clu->centreProj().x()) * clu->mipPt();
     bin.weighted_y += (clu->centreProj().y()) * clu->mipPt();
   }
 
   for (auto& bin : histoClusters) {
-    bin.second.weighted_x /= bin.second.sumMipPt;
-    bin.second.weighted_y /= bin.second.sumMipPt;
+    bin.weighted_x /= bin.sumMipPt;
+    bin.weighted_y /= bin.sumMipPt;
   }
 
   return histoClusters;
@@ -86,10 +75,10 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoClusters(const Histogram& histoClusters,
                                                                                    const vector<unsigned>& binSums) {
-  Histogram histoSumPhiClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
+  Histogram histoSumPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
       int nBinsSide = (binSums[bin_R] - 1) / 2;
       float R1 = kROverZMin_ + bin_R * (kROverZMax_ - kROverZMin_);
       float R2 = R1 + (kROverZMax_ - kROverZMin_);
@@ -101,24 +90,24 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
 
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin_orig = histoClusters.at({{z_side, bin_R, bin_phi}});
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
         float content = bin_orig.sumMipPt;
 
         for (int bin_phi2 = 1; bin_phi2 <= nBinsSide; bin_phi2++) {
           int binToSumLeft = bin_phi - bin_phi2;
           if (binToSumLeft < 0)
             binToSumLeft += nBinsPhiHisto_;
-          int binToSumRight = bin_phi + bin_phi2;
-          if (binToSumRight >= int(nBinsPhiHisto_))
+          unsigned binToSumRight = bin_phi + bin_phi2;
+          if (binToSumRight >= nBinsPhiHisto_)
             binToSumRight -= nBinsPhiHisto_;
 
-          content += histoClusters.at({{z_side, bin_R, binToSumLeft}}).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
-          content +=
-              histoClusters.at({{z_side, bin_R, binToSumRight}}).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+          content += histoClusters.at(z_side, bin_R, binToSumLeft).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+
+          content += histoClusters.at(z_side, bin_R, binToSumRight).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
         }
 
-        auto& bin = histoSumPhiClusters[{{z_side, bin_R, bin_phi}}];
+        auto& bin = histoSumPhiClusters.at(z_side, bin_R, bin_phi);
         bin.sumMipPt = content / area;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
@@ -130,22 +119,20 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
 }
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClusters(const Histogram& histoClusters) {
-  Histogram histoSumRPhiClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
+  Histogram histoSumRPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      float weight = (bin_R == 0 || bin_R == int(nBinsRHisto_) - 1)
-                         ? 1.5
-                         : 2.;  //Take into account edges with only one side up or down
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      float weight =
+          (bin_R == 0 || bin_R == nBinsRHisto_ - 1) ? 1.5 : 2.;  //Take into account edges with only one side up or down
 
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin_orig = histoClusters.at({{z_side, bin_R, bin_phi}});
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
         float content = bin_orig.sumMipPt;
-        float contentDown = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
-        float contentUp =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
+        float contentDown = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+        float contentUp = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
 
-        auto& bin = histoSumRPhiClusters[{{z_side, bin_R, bin_phi}}];
+        auto& bin = histoSumRPhiClusters.at(z_side, bin_R, bin_phi);
         bin.sumMipPt = (content + 0.5 * contentDown + 0.5 * contentUp) / weight;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
@@ -158,8 +145,8 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClust
 
 void HGCalHistoSeedingImpl::setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                                                      int z_side,
-                                                     int bin_R,
-                                                     int bin_phi,
+                                                     unsigned bin_R,
+                                                     unsigned bin_phi,
                                                      const Bin& histBin) {
   float x_seed = 0;
   float y_seed = 0;
@@ -181,37 +168,36 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeMaxSee
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -225,27 +211,26 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
 
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         float MIPT_pred = neighbour_weights_.at(0) * MIPT_NW + neighbour_weights_.at(1) * MIPT_N +
                           neighbour_weights_.at(2) * MIPT_NE + neighbour_weights_.at(3) * MIPT_W +
@@ -256,7 +241,7 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -270,14 +255,14 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeThresh
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isSeed = MIPT_seed > histoThreshold_;
 
         if (isSeed) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -290,57 +275,56 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
     const Histogram& histoClusters) {
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
-  std::map<std::tuple<int, int, int>, bool> primarySeedPositions;
-  std::map<std::tuple<int, int, int>, bool> vetoPositions;
+  HistogramT<uint8_t> primarySeedPositions(nBinsRHisto_, nBinsPhiHisto_);
+  HistogramT<uint8_t> vetoPositions(nBinsRHisto_, nBinsPhiHisto_);
 
   //Search for primary seeds
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
 
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
 
-          primarySeedPositions[std::make_tuple(bin_R, bin_phi, z_side)] = true;
+          primarySeedPositions.at(z_side, bin_R, bin_phi) = true;
 
-          vetoPositions[std::make_tuple(bin_R, binLeft, z_side)] = true;
-          vetoPositions[std::make_tuple(bin_R, binRight, z_side)] = true;
+          vetoPositions.at(z_side, bin_R, binLeft) = true;
+          vetoPositions.at(z_side, bin_R, binRight) = true;
           if (bin_R > 0) {
-            vetoPositions[std::make_tuple(bin_R - 1, bin_phi, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R - 1, binRight, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R - 1, binLeft, z_side)] = true;
+            vetoPositions.at(z_side, bin_R - 1, bin_phi) = true;
+            vetoPositions.at(z_side, bin_R - 1, binRight) = true;
+            vetoPositions.at(z_side, bin_R - 1, binLeft) = true;
           }
-          if (bin_R < (int(nBinsRHisto_) - 1)) {
-            vetoPositions[std::make_tuple(bin_R + 1, bin_phi, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R + 1, binRight, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R + 1, binLeft, z_side)] = true;
+          if (bin_R < (nBinsRHisto_ - 1)) {
+            vetoPositions.at(z_side, bin_R + 1, bin_phi) = true;
+            vetoPositions.at(z_side, bin_R + 1, binRight) = true;
+            vetoPositions.at(z_side, bin_R + 1, binLeft) = true;
           }
         }
       }
@@ -350,46 +334,45 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
   //Search for secondary seeds
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
         //Cannot be a secondary seed if already a primary seed, or adjacent to primary seed
-        if (primarySeedPositions[std::make_tuple(bin_R, bin_phi, z_side)] ||
-            vetoPositions[std::make_tuple(bin_R, bin_phi, z_side)])
+        if (primarySeedPositions.at(z_side, bin_R, bin_phi) || vetoPositions.at(z_side, bin_R, bin_phi))
           continue;
 
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
-        isMax &= (vetoPositions[std::make_tuple(bin_R + 1, bin_phi, z_side)] or MIPT_seed >= MIPT_S) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, bin_phi, z_side)] or MIPT_seed > MIPT_N) &&
-                 (vetoPositions[std::make_tuple(bin_R, binRight, z_side)] or MIPT_seed >= MIPT_E) &&
-                 (vetoPositions[std::make_tuple(bin_R + 1, binRight, z_side)] or MIPT_seed >= MIPT_SE) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, binRight, z_side)] or MIPT_seed >= MIPT_NE) &&
-                 (vetoPositions[std::make_tuple(bin_R, binLeft, z_side)] or MIPT_seed > MIPT_W) &&
-                 (vetoPositions[std::make_tuple(bin_R + 1, binLeft, z_side)] or MIPT_seed > MIPT_SW) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, binLeft, z_side)] or MIPT_seed > MIPT_NW);
+        isMax &=
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, bin_phi)) or MIPT_seed >= MIPT_S) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, bin_phi)) or MIPT_seed > MIPT_N) &&
+            ((vetoPositions.at(z_side, bin_R, binRight)) or MIPT_seed >= MIPT_E) &&
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binRight)) or MIPT_seed >= MIPT_SE) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binRight)) or MIPT_seed >= MIPT_NE) &&
+            ((vetoPositions.at(z_side, bin_R, binLeft)) or MIPT_seed > MIPT_W) &&
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binLeft)) or MIPT_seed > MIPT_SW) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binLeft)) or MIPT_seed > MIPT_NW);
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -402,7 +385,6 @@ void HGCalHistoSeedingImpl::findHistoSeeds(const std::vector<edm::Ptr<l1t::HGCal
                                            std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy) {
   /* put clusters into an r/z x phi histogram */
   Histogram histoCluster = fillHistoClusters(clustersPtrs);
-  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi, content = MIPTs summed along depth
 
   /* smoothen along the phi direction + normalize each bin to same area */
   Histogram smoothPhiHistoCluster = fillSmoothPhiHistoClusters(histoCluster, binsSumsHisto_);


### PR DESCRIPTION
- Encapsulate seeding histograms in dedicated class
- Change underlying histogram type from map to flat vector to optimize performance (a bit more than 50%  gain in CPU time for the `hgcalBackEndLayer2Producer`)