### PR TITLE
Add seeding in x/z,y/z space

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -14,7 +14,8 @@
 class HGCalHistoSeedingImpl {
 private:
   struct Bin {
-    float sumMipPt = 0.;
+    enum Content { Sum, Ecal, Hcal };
+    std::array<float, 3> values = {{0., 0., 0.}};
     float weighted_x = 0.;
     float weighted_y = 0.;
   };
@@ -26,6 +27,7 @@ private:
     using const_iterator = typename Data::const_iterator;
 
   public:
+    HistogramT() : bins1_(0), bins2_(0), bins_(0) {}
     HistogramT(unsigned bins1, unsigned bins2)
         : bins1_(bins1), bins2_(bins2), bins_(bins1 * bins2), histogram_(bins_ * kSides_) {}
 
@@ -55,6 +57,54 @@ private:
   };
   using Histogram = HistogramT<Bin>;
 
+  class Navigator {
+  public:
+    enum AxisType { Bounded, Circular };
+
+    Navigator() : axis_types_({{Bounded, Bounded}}), bins_({{0, 0}}), home_({{0, 0}}) {}
+
+    Navigator(int bins1, AxisType type_axis1, int bins2, AxisType type_axis2)
+        : axis_types_({{type_axis1, type_axis2}}), bins_({{bins1, bins2}}), home_({{0, 0}}) {}
+
+    void setHome(int x1, int x2) {
+      if (x1 < 0 || x2 < 0 || x1 >= std::get<0>(bins_) || x2 >= std::get<1>(bins_)) {
+        throw cms::Exception("OutOfBound") << "Setting invalid navigator home position (" << x1 << "," << x2 << "\n)";
+      }
+      home_[0] = x1;
+      home_[1] = x2;
+    }
+
+    std::array<int, 2> move(int offset1, int offset2) { return {{offset<0>(offset1), offset<1>(offset2)}}; }
+
+    template <unsigned N>
+    int offset(int shift) {
+      int shifted = std::get<N>(home_);
+      int max = std::get<N>(bins_);
+      switch (std::get<N>(axis_types_)) {
+        case Bounded:
+          shifted += shift;
+          if (shifted < 0 || shifted >= max)
+            shifted = -1;
+          break;
+        case Circular:
+          shifted += shift;
+          while (shifted < 0)
+            shifted += max;
+          while (shifted >= max)
+            shifted -= max;
+          break;
+        default:
+          break;
+      }
+      return shifted;
+    }
+
+  private:
+    std::array<AxisType, 2> axis_types_;
+    std::array<int, 2> bins_;
+    std::array<int, 2> home_;
+  };
+
 public:
   HGCalHistoSeedingImpl(const edm::ParameterSet& conf);
 
@@ -67,12 +117,13 @@ public:
 
 private:
   enum SeedingType { HistoMaxC3d, HistoSecondaryMaxC3d, HistoThresholdC3d, HistoInterpolatedMaxC3d };
+  enum SeedingSpace { RPhi, XY };
   enum SeedingPosition { BinCentre, TCWeighted };
 
   Histogram fillHistoClusters(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs);
 
+  Histogram fillSmoothHistoClusters(const Histogram&, const vector<double>&, Bin::Content);
   Histogram fillSmoothPhiHistoClusters(const Histogram& histoClusters, const vector<unsigned>& binSums);
-
   Histogram fillSmoothRPhiHistoClusters(const Histogram& histoClusters);
 
   void setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
@@ -89,21 +140,28 @@ private:
 
   std::vector<std::pair<GlobalPoint, double>> computeThresholdSeeds(const Histogram& histoClusters);
 
+  std::array<double, 4> boundaries();
+
   std::string seedingAlgoType_;
   SeedingType seedingType_;
+  SeedingSpace seedingSpace_;
   SeedingPosition seedingPosition_;
 
-  unsigned nBinsRHisto_ = 42;
-  unsigned nBinsPhiHisto_ = 216;
+  unsigned nBins1_ = 42;
+  unsigned nBins2_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
   std::vector<double> neighbour_weights_;
+  std::vector<double> smoothing_ecal_;
+  std::vector<double> smoothing_hcal_;
 
   HGCalTriggerTools triggerTools_;
+  Navigator navigator_;
 
   static constexpr unsigned neighbour_weights_size_ = 9;
   static constexpr double kROverZMin_ = 0.076;
   static constexpr double kROverZMax_ = 0.58;
+  static constexpr double kXYMax_ = 0.6;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/python/customClustering.py
+++ b/L1Trigger/L1THGCal/python/customClustering.py
@@ -7,6 +7,7 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import distance_C3d_param
                                                               dbscan_C3d_params, \
                                                               histoMax_C3d_params, \
                                                               histoMaxVariableDR_C3d_params, \
+                                                              histoMaxXYVariableDR_C3d_params, \
                                                               histoSecondaryMax_C3d_params, \
                                                               histoInterpolatedMax_C3d_params, \
                                                               histoThreshold_C3d_params, \
@@ -83,15 +84,15 @@ def custom_3dclustering_dbscan(process,
 
 def set_histomax_params(parameters_c3d,
                         distance,
-                        nBins_R,
-                        nBins_Phi,
+                        nBins_X1,
+                        nBins_X2,
                         binSumsHisto,
                         seed_threshold,
                         shape_threshold
                         ):
     parameters_c3d.dR_multicluster = distance
-    parameters_c3d.nBins_R_histo_multicluster = nBins_R
-    parameters_c3d.nBins_Phi_histo_multicluster = nBins_Phi
+    parameters_c3d.nBins_X1_histo_multicluster = nBins_X1
+    parameters_c3d.nBins_X2_histo_multicluster = nBins_X2
     parameters_c3d.binSumsHisto = binSumsHisto
     parameters_c3d.threshold_histo_multicluster = seed_threshold
     parameters_c3d.shape_threshold = shape_threshold
@@ -99,14 +100,14 @@ def set_histomax_params(parameters_c3d,
 
 def custom_3dclustering_histoMax(process,
                                  distance=histoMax_C3d_params.dR_multicluster,
-                                 nBins_R=histoMax_C3d_params.nBins_R_histo_multicluster,
-                                 nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
+                                 nBins_X1=histoMax_C3d_params.nBins_X1_histo_multicluster,
+                                 nBins_X2=histoMax_C3d_params.nBins_X2_histo_multicluster,
                                  binSumsHisto=histoMax_C3d_params.binSumsHisto,
                                  seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
                                  shape_threshold=histoMax_C3d_params.shape_threshold,
                                  ):
     parameters_c3d = histoMax_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, distance, nBins_X1, nBins_X2, binSumsHisto,
                         seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
@@ -115,13 +116,13 @@ def custom_3dclustering_histoMax(process,
 def custom_3dclustering_histoSecondaryMax(process,
                                           distance=histoSecondaryMax_C3d_params.dR_multicluster,
                                           threshold=histoSecondaryMax_C3d_params.threshold_histo_multicluster,
-                                          nBins_R=histoSecondaryMax_C3d_params.nBins_R_histo_multicluster,
-                                          nBins_Phi=histoSecondaryMax_C3d_params.nBins_Phi_histo_multicluster,
+                                          nBins_X1=histoSecondaryMax_C3d_params.nBins_X1_histo_multicluster,
+                                          nBins_X2=histoSecondaryMax_C3d_params.nBins_X2_histo_multicluster,
                                           binSumsHisto=histoSecondaryMax_C3d_params.binSumsHisto,
                                           shape_threshold=histoSecondaryMax_C3d_params.shape_threshold,
                                           ):
     parameters_c3d = histoSecondaryMax_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, distance, nBins_X1, nBins_X2, binSumsHisto,
                         threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
@@ -129,8 +130,8 @@ def custom_3dclustering_histoSecondaryMax(process,
 
 def custom_3dclustering_histoMax_variableDr(process,
                                             distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                                            nBins_R=histoMaxVariableDR_C3d_params.nBins_R_histo_multicluster,
-                                            nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
+                                            nBins_X1=histoMaxVariableDR_C3d_params.nBins_X1_histo_multicluster,
+                                            nBins_X2=histoMaxVariableDR_C3d_params.nBins_X2_histo_multicluster,
                                             binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                             seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
                                             seed_position=histoMaxVariableDR_C3d_params.seed_position,
@@ -139,16 +140,33 @@ def custom_3dclustering_histoMax_variableDr(process,
     parameters_c3d = histoMaxVariableDR_C3d_params.clone(
             dR_multicluster_byLayer_coefficientA = cms.vdouble(distances)
             )
-    set_histomax_params(parameters_c3d, 0, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, 0, nBins_X1, nBins_X2, binSumsHisto,
                         seed_threshold, shape_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
+    return process
+
+def custom_3dclustering_XYHistoMax_variableDr(process,
+                                            distances=histoMaxXYVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+                                            nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
+                                            nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
+                                            seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
+                                            seed_position=histoMaxXYVariableDR_C3d_params.seed_position,
+                                            shape_threshold=histoMaxXYVariableDR_C3d_params.shape_threshold,
+                                            ):
+    parameters_c3d = histoMaxXYVariableDR_C3d_params.clone(
+            dR_multicluster_byLayer_coefficientA = cms.vdouble(distances)
+            )
+    set_histomax_params(parameters_c3d, 0, nBins_X1, nBins_X2,
+            histoMaxXYVariableDR_C3d_params.binSumsHisto,
+            seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
 
 def custom_3dclustering_histoInterpolatedMax1stOrder(process,
                                                      distance=histoInterpolatedMax_C3d_params.dR_multicluster,
-                                                     nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
-                                                     nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                                     nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+                                                     nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
                                                      binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                                      seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
                                                      shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
@@ -156,7 +174,7 @@ def custom_3dclustering_histoInterpolatedMax1stOrder(process,
     parameters_c3d = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_1stOrder
             )
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, distance, nBins_X1, nBins_X2, binSumsHisto,
                         seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
@@ -164,8 +182,8 @@ def custom_3dclustering_histoInterpolatedMax1stOrder(process,
 
 def custom_3dclustering_histoInterpolatedMax2ndOrder(process,
                                                      distance=histoInterpolatedMax_C3d_params.dR_multicluster,
-                                                     nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
-                                                     nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                                     nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+                                                     nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
                                                      binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                                      seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
                                                      shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
@@ -173,7 +191,7 @@ def custom_3dclustering_histoInterpolatedMax2ndOrder(process,
     parameters_c3d = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_2ndOrder
             )
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, distance, nBins_X1, nBins_X2, binSumsHisto,
                         seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
@@ -181,14 +199,14 @@ def custom_3dclustering_histoInterpolatedMax2ndOrder(process,
 
 def custom_3dclustering_histoThreshold(process,
                                        distance=histoThreshold_C3d_params.dR_multicluster,
-                                       nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
-                                       nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
+                                       nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
+                                       nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
                                        binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
                                        seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
                                        shape_threshold=histoThreshold_C3d_params.shape_threshold,
                                        ):
     parameters_c3d = histoThreshold_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(parameters_c3d, distance, nBins_X1, nBins_X2, binSumsHisto,
                         seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -46,6 +46,20 @@ neighbour_weights_2ndOrder = cms.vdouble(-0.25, 0.5, -0.25,
                                          -0.25, 0.5, -0.25)
 
 
+seed_smoothing_ecal = cms.vdouble(
+        1., 1., 1.,
+        1., 1.1, 1.,
+        1., 1., 1.,
+        )
+seed_smoothing_hcal = cms.vdouble(
+        1., 1., 1., 1., 1.,
+        1., 1., 1., 1., 1.,
+        1., 1., 2., 1., 1.,
+        1., 1., 1., 1., 1.,
+        1., 1., 1., 1., 1., 
+        )
+
+
 distance_C3d_params = cms.PSet(type_multicluster=cms.string('dRC3d'),
                                dR_multicluster=cms.double(0.01),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
@@ -69,14 +83,17 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                dR_multicluster_byLayer_coefficientB=cms.vdouble(),
                                shape_threshold=cms.double(1.),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
-                               nBins_R_histo_multicluster=cms.uint32(42), # bin size of about 0.012
-                               nBins_Phi_histo_multicluster=cms.uint32(216), # bin size of about 0.029
+                               nBins_X1_histo_multicluster=cms.uint32(42), # bin size of about 0.012
+                               nBins_X2_histo_multicluster=cms.uint32(216), # bin size of about 0.029
                                binSumsHisto=binSums,
                                threshold_histo_multicluster=cms.double(10.),
                                cluster_association=cms.string("NearestNeighbour"),
                                EGIdentification=egamma_identification_histomax.clone(),
                                neighbour_weights=neighbour_weights_1stOrder,
                                seed_position=cms.string("BinCentre"),#BinCentre, TCWeighted
+                               seeding_space=cms.string("RPhi"),# RPhi, XY
+                               seed_smoothing_ecal=seed_smoothing_ecal,
+                               seed_smoothing_hcal=seed_smoothing_hcal,
                                )
 # V9 samples have a different defintiion of the dEdx calibrations. To account for it
 # we reascale the thresholds of the clustering seeds
@@ -93,6 +110,12 @@ histoMaxVariableDR_C3d_params = histoMax_C3d_params.clone(
         dR_multicluster_byLayer_coefficientB = cms.vdouble([0]*(MAX_LAYERS+1))
         )
 
+
+histoMaxXYVariableDR_C3d_params = histoMaxVariableDR_C3d_params.clone(
+        seeding_space=cms.string("XY"),
+        nBins_X1_histo_multicluster=cms.uint32(192),
+        nBins_X2_histo_multicluster=cms.uint32(192)
+        )
 
 histoSecondaryMax_C3d_params = histoMax_C3d_params.clone(
         type_multicluster = cms.string('HistoSecondaryMaxC3d')

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -2,14 +2,17 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include <numeric>
 
 HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
-    : seedingAlgoType_(conf.getParameter<string>("type_multicluster")),
-      nBinsRHisto_(conf.getParameter<unsigned>("nBins_R_histo_multicluster")),
-      nBinsPhiHisto_(conf.getParameter<unsigned>("nBins_Phi_histo_multicluster")),
+    : seedingAlgoType_(conf.getParameter<std::string>("type_multicluster")),
+      nBins1_(conf.getParameter<unsigned>("nBins_X1_histo_multicluster")),
+      nBins2_(conf.getParameter<unsigned>("nBins_X2_histo_multicluster")),
       binsSumsHisto_(conf.getParameter<std::vector<unsigned>>("binSumsHisto")),
       histoThreshold_(conf.getParameter<double>("threshold_histo_multicluster")),
-      neighbour_weights_(conf.getParameter<std::vector<double>>("neighbour_weights")) {
+      neighbour_weights_(conf.getParameter<std::vector<double>>("neighbour_weights")),
+      smoothing_ecal_(conf.getParameter<std::vector<double>>("seed_smoothing_ecal")),
+      smoothing_hcal_(conf.getParameter<std::vector<double>>("seed_smoothing_hcal")) {
   if (seedingAlgoType_ == "HistoMaxC3d") {
     seedingType_ = HistoMaxC3d;
   } else if (seedingAlgoType_ == "HistoSecondaryMaxC3d") {
@@ -22,25 +25,37 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
     throw cms::Exception("HGCTriggerParameterError") << "Unknown Multiclustering type '" << seedingAlgoType_;
   }
 
-  if (conf.getParameter<string>("seed_position") == "BinCentre") {
+  if (conf.getParameter<std::string>("seeding_space") == "RPhi") {
+    seedingSpace_ = RPhi;
+    navigator_ = Navigator(nBins1_, Navigator::AxisType::Bounded, nBins2_, Navigator::AxisType::Circular);
+  } else if (conf.getParameter<std::string>("seeding_space") == "XY") {
+    seedingSpace_ = XY;
+    navigator_ = Navigator(nBins1_, Navigator::AxisType::Bounded, nBins2_, Navigator::AxisType::Bounded);
+  } else {
+    throw cms::Exception("HGCTriggerParameterError")
+        << "Unknown seeding space  '" << conf.getParameter<std::string>("seeding_space");
+  }
+
+  if (conf.getParameter<std::string>("seed_position") == "BinCentre") {
     seedingPosition_ = BinCentre;
-  } else if (conf.getParameter<string>("seed_position") == "TCWeighted") {
+  } else if (conf.getParameter<std::string>("seed_position") == "TCWeighted") {
     seedingPosition_ = TCWeighted;
   } else {
     throw cms::Exception("HGCTriggerParameterError")
-        << "Unknown Seed Position option '" << conf.getParameter<string>("seed_position");
+        << "Unknown Seed Position option '" << conf.getParameter<std::string>("seed_position");
   }
 
   edm::LogInfo("HGCalMulticlusterParameters")
-      << "\nMulticluster number of R-bins for the histo algorithm: " << nBinsRHisto_
-      << "\nMulticluster number of Phi-bins for the histo algorithm: " << nBinsPhiHisto_
+      << "\nMulticluster number of X1-bins for the histo algorithm: " << nBins1_
+      << "\nMulticluster number of X2-bins for the histo algorithm: " << nBins2_
       << "\nMulticluster MIPT threshold for histo threshold algorithm: " << histoThreshold_
       << "\nMulticluster type of multiclustering algortihm: " << seedingAlgoType_;
 
-  if (seedingAlgoType_.find("Histo") != std::string::npos && nBinsRHisto_ != binsSumsHisto_.size()) {
+  if (seedingAlgoType_.find("Histo") != std::string::npos && seedingSpace_ == RPhi &&
+      nBins1_ != binsSumsHisto_.size()) {
     throw cms::Exception("Inconsistent bin size")
-        << "Inconsistent nBins_R_histo_multicluster ( " << nBinsRHisto_ << " ) and binSumsHisto ( "
-        << binsSumsHisto_.size() << " ) size in HGCalMulticlustering\n";
+        << "Inconsistent nBins_X1_histo_multicluster ( " << nBins1_ << " ) and binSumsHisto ( " << binsSumsHisto_.size()
+        << " ) size in HGCalMulticlustering\n";
   }
 
   if (neighbour_weights_.size() != neighbour_weights_size_) {
@@ -52,39 +67,105 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
     const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs) {
-  Histogram histoClusters(nBinsRHisto_, nBinsPhiHisto_);
+  Histogram histoClusters(nBins1_, nBins2_);
+  std::array<double, 4> bounds = boundaries();
+  double minx1 = std::get<0>(bounds);
+  double maxx1 = std::get<1>(bounds);
+  double minx2 = std::get<2>(bounds);
+  double maxx2 = std::get<3>(bounds);
 
   for (auto& clu : clustersPtrs) {
-    float ROverZ = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
-    if (ROverZ < kROverZMin_ || ROverZ >= kROverZMax_) {
-      throw cms::Exception("OutOfBound") << "TC R/Z = " << ROverZ << " out of the seeding histogram bounds "
-                                         << kROverZMin_ << " - " << kROverZMax_;
+    float x1 = 0., x2 = 0;
+    switch (seedingSpace_) {
+      case RPhi:
+        x1 = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
+        x2 = reco::reduceRange(clu->phi());
+        break;
+      case XY:
+        x1 = clu->centreProj().x();
+        x2 = clu->centreProj().y();
+        break;
+    };
+    if (x1 < minx1 || x1 >= maxx1) {
+      throw cms::Exception("OutOfBound") << "TC X1 = " << x1 << " out of the seeding histogram bounds " << minx1
+                                         << " - " << maxx1;
     }
-    unsigned bin_R = unsigned((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
-    unsigned bin_phi = unsigned((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
+    if (x2 < minx2 || x2 >= maxx2) {
+      throw cms::Exception("OutOfBound") << "TC X2 = " << x2 << " out of the seeding histogram bounds " << minx2
+                                         << " - " << maxx2;
+    }
+    unsigned bin1 = unsigned((x1 - minx1) * nBins1_ / (maxx1 - minx1));
+    unsigned bin2 = unsigned((x2 - minx2) * nBins2_ / (maxx2 - minx2));
 
-    auto& bin = histoClusters.at(triggerTools_.zside(clu->detId()), bin_R, bin_phi);
-    bin.sumMipPt += clu->mipPt();
+    auto& bin = histoClusters.at(triggerTools_.zside(clu->detId()), bin1, bin2);
+    bin.values[Bin::Content::Sum] += clu->mipPt();
+    if (triggerTools_.isEm(clu->detId())) {
+      bin.values[Bin::Content::Ecal] += clu->mipPt();
+    } else {
+      bin.values[Bin::Content::Hcal] += clu->mipPt();
+    }
     bin.weighted_x += (clu->centreProj().x()) * clu->mipPt();
     bin.weighted_y += (clu->centreProj().y()) * clu->mipPt();
   }
 
   for (auto& bin : histoClusters) {
-    bin.weighted_x /= bin.sumMipPt;
-    bin.weighted_y /= bin.sumMipPt;
+    bin.weighted_x /= bin.values[Bin::Content::Sum];
+    bin.weighted_y /= bin.values[Bin::Content::Sum];
   }
 
   return histoClusters;
 }
 
+HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothHistoClusters(const Histogram& histoClusters,
+                                                                                const vector<double>& kernel,
+                                                                                Bin::Content binContent) {
+  Histogram histoSmooth(histoClusters);
+
+  unsigned kernel_size = std::sqrt(kernel.size());
+  if (kernel_size * kernel_size != kernel.size()) {
+    throw cms::Exception("HGCTriggerParameterError") << "Only square kernels can be used.";
+  }
+  if (kernel_size % 2 != 1) {
+    throw cms::Exception("HGCTriggerParameterError") << "The kernel size must be an odd value.";
+  }
+  int shift_max = (kernel_size - 1) / 2;
+  double normalization = std::accumulate(kernel.begin(), kernel.end(), 0.);
+  for (int z_side : {-1, 1}) {
+    for (unsigned x1 = 0; x1 < nBins1_; x1++) {
+      for (unsigned x2 = 0; x2 < nBins2_; x2++) {
+        const auto& bin_orig = histoClusters.at(z_side, x1, x2);
+        double smooth = 0.;
+        navigator_.setHome(x1, x2);
+        for (int x1_shift = -shift_max; x1_shift <= shift_max; x1_shift++) {
+          int index1 = x1_shift + shift_max;
+          for (int x2_shift = -shift_max; x2_shift <= shift_max; x2_shift++) {
+            auto shifted = navigator_.move(x1_shift, x2_shift);
+            int index2 = x2_shift + shift_max;
+            double kernel_value = kernel.at(index1 * kernel_size + index2);
+            bool out = shifted[0] == -1 || shifted[1] == -1;
+            double content = (out ? 0. : histoClusters.at(z_side, shifted[0], shifted[1]).values[binContent]);
+            smooth += content * kernel_value;
+          }
+        }
+        auto& bin = histoSmooth.at(z_side, x1, x2);
+        bin.values[binContent] = smooth / normalization;
+        bin.weighted_x = bin_orig.weighted_x;
+        bin.weighted_y = bin_orig.weighted_y;
+      }
+    }
+  }
+
+  return histoSmooth;
+}
+
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoClusters(const Histogram& histoClusters,
                                                                                    const vector<unsigned>& binSums) {
-  Histogram histoSumPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
+  Histogram histoSumPhiClusters(nBins1_, nBins2_);
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      int nBinsSide = (binSums[bin_R] - 1) / 2;
-      float R1 = kROverZMin_ + bin_R * (kROverZMax_ - kROverZMin_);
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      int nBinsSide = (binSums[bin1] - 1) / 2;
+      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_);
       float R2 = R1 + (kROverZMax_ - kROverZMin_);
       double area =
           0.5 * (pow(R2, 2) - pow(R1, 2)) *
@@ -94,25 +175,27 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
 
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
-        float content = bin_orig.sumMipPt;
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin1, bin2);
+        float content = bin_orig.values[Bin::Content::Sum];
 
-        for (int bin_phi2 = 1; bin_phi2 <= nBinsSide; bin_phi2++) {
-          int binToSumLeft = bin_phi - bin_phi2;
+        for (int bin22 = 1; bin22 <= nBinsSide; bin22++) {
+          int binToSumLeft = bin2 - bin22;
           if (binToSumLeft < 0)
-            binToSumLeft += nBinsPhiHisto_;
-          unsigned binToSumRight = bin_phi + bin_phi2;
-          if (binToSumRight >= nBinsPhiHisto_)
-            binToSumRight -= nBinsPhiHisto_;
+            binToSumLeft += nBins2_;
+          unsigned binToSumRight = bin2 + bin22;
+          if (binToSumRight >= nBins2_)
+            binToSumRight -= nBins2_;
 
-          content += histoClusters.at(z_side, bin_R, binToSumLeft).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+          content += histoClusters.at(z_side, bin1, binToSumLeft).values[Bin::Content::Sum] /
+                     pow(2, bin22);  // quadratic kernel
 
-          content += histoClusters.at(z_side, bin_R, binToSumRight).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+          content += histoClusters.at(z_side, bin1, binToSumRight).values[Bin::Content::Sum] /
+                     pow(2, bin22);  // quadratic kernel
         }
 
-        auto& bin = histoSumPhiClusters.at(z_side, bin_R, bin_phi);
-        bin.sumMipPt = content / area;
+        auto& bin = histoSumPhiClusters.at(z_side, bin1, bin2);
+        bin.values[Bin::Content::Sum] = content / area;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
       }
@@ -123,21 +206,21 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
 }
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClusters(const Histogram& histoClusters) {
-  Histogram histoSumRPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
+  Histogram histoSumRPhiClusters(nBins1_, nBins2_);
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
       float weight =
-          (bin_R == 0 || bin_R == nBinsRHisto_ - 1) ? 1.5 : 2.;  //Take into account edges with only one side up or down
+          (bin1 == 0 || bin1 == nBins1_ - 1) ? 1.5 : 2.;  //Take into account edges with only one side up or down
 
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
-        float content = bin_orig.sumMipPt;
-        float contentDown = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
-        float contentUp = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin1, bin2);
+        float content = bin_orig.values[Bin::Content::Sum];
+        float contentDown = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, bin2).values[Bin::Content::Sum] : 0;
+        float contentUp = bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, bin2).values[Bin::Content::Sum] : 0;
 
-        auto& bin = histoSumRPhiClusters.at(z_side, bin_R, bin_phi);
-        bin.sumMipPt = (content + 0.5 * contentDown + 0.5 * contentUp) / weight;
+        auto& bin = histoSumRPhiClusters.at(z_side, bin1, bin2);
+        bin.values[Bin::Content::Sum] = (content + 0.5 * contentDown + 0.5 * contentUp) / weight;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
       }
@@ -149,59 +232,88 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClust
 
 void HGCalHistoSeedingImpl::setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                                                      int z_side,
-                                                     unsigned bin_R,
-                                                     unsigned bin_phi,
+                                                     unsigned bin1,
+                                                     unsigned bin2,
                                                      const Bin& histBin) {
   float x_seed = 0;
   float y_seed = 0;
+  std::array<double, 4> bounds = boundaries();
+  double minx1 = std::get<0>(bounds);
+  double maxx1 = std::get<1>(bounds);
+  double minx2 = std::get<2>(bounds);
+  double maxx2 = std::get<3>(bounds);
 
   if (seedingPosition_ == BinCentre) {
-    float ROverZ_seed = kROverZMin_ + (bin_R + 0.5) * (kROverZMax_ - kROverZMin_) / nBinsRHisto_;
-    float phi_seed = -M_PI + (bin_phi + 0.5) * 2 * M_PI / nBinsPhiHisto_;
-    x_seed = ROverZ_seed * cos(phi_seed);
-    y_seed = ROverZ_seed * sin(phi_seed);
+    float x1_seed = minx1 + (bin1 + 0.5) * (maxx1 - minx1) / nBins1_;
+    float x2_seed = minx2 + (bin2 + 0.5) * (maxx2 - minx2) / nBins2_;
+    switch (seedingSpace_) {
+      case RPhi:
+        x_seed = x1_seed * cos(x2_seed);
+        y_seed = x1_seed * sin(x2_seed);
+        break;
+      case XY:
+        x_seed = x1_seed;
+        y_seed = x2_seed;
+    };
   } else if (seedingPosition_ == TCWeighted) {
     x_seed = histBin.weighted_x;
     y_seed = histBin.weighted_y;
   }
 
-  seedPositionsEnergy.emplace_back(GlobalPoint(x_seed, y_seed, z_side), histBin.sumMipPt);
+  seedPositionsEnergy.emplace_back(GlobalPoint(x_seed, y_seed, z_side), histBin.values[Bin::Content::Sum]);
 }
 
 std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeMaxSeeds(const Histogram& histoClusters) {
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        float MIPT_seed = histoClusters.at(z_side, bin1, bin2).values[Bin::Content::Sum];
         bool isMax = MIPT_seed > histoThreshold_;
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+        navigator_.setHome(bin1, bin2);
+        auto pos_N = navigator_.move(1, 0);
+        auto pos_S = navigator_.move(-1, 0);
+        auto pos_W = navigator_.move(0, -1);
+        auto pos_E = navigator_.move(0, 1);
+        auto pos_NW = navigator_.move(1, -1);
+        auto pos_NE = navigator_.move(1, 1);
+        auto pos_SW = navigator_.move(-1, -1);
+        auto pos_SE = navigator_.move(-1, 1);
 
-        int binLeft = bin_phi - 1;
-        if (binLeft < 0)
-          binLeft += nBinsPhiHisto_;
-        unsigned binRight = bin_phi + 1;
-        if (binRight >= nBinsPhiHisto_)
-          binRight -= nBinsPhiHisto_;
-
-        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
-        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
-        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
-        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
+        float MIPT_N = (pos_N[0] != -1 && pos_N[1] != -1)
+                           ? histoClusters.at(z_side, pos_N[0], pos_N[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_S = (pos_S[0] != -1 && pos_S[1] != -1)
+                           ? histoClusters.at(z_side, pos_S[0], pos_S[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_W = (pos_W[0] != -1 && pos_W[1] != -1)
+                           ? histoClusters.at(z_side, pos_W[0], pos_W[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_E = (pos_E[0] != -1 && pos_E[1] != -1)
+                           ? histoClusters.at(z_side, pos_E[0], pos_E[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_NW = (pos_NW[0] != -1 && pos_NW[1] != -1)
+                            ? histoClusters.at(z_side, pos_NW[0], pos_NW[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_NE = (pos_NE[0] != -1 && pos_NE[1] != -1)
+                            ? histoClusters.at(z_side, pos_NE[0], pos_NE[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_SW = (pos_SW[0] != -1 && pos_SW[1] != -1)
+                            ? histoClusters.at(z_side, pos_SW[0], pos_SW[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_SE = (pos_SE[0] != -1 && pos_SE[1] != -1)
+                            ? histoClusters.at(z_side, pos_SE[0], pos_SE[1]).values[Bin::Content::Sum]
+                            : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
-          setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
+          setSeedEnergyAndPosition(seedPositionsEnergy, z_side, bin1, bin2, histoClusters.at(z_side, bin1, bin2));
         }
       }
     }
@@ -215,26 +327,44 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
-        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        float MIPT_seed = histoClusters.at(z_side, bin1, bin2).values[Bin::Content::Sum];
 
-        int binLeft = bin_phi - 1;
-        if (binLeft < 0)
-          binLeft += nBinsPhiHisto_;
-        unsigned binRight = bin_phi + 1;
-        if (binRight >= nBinsPhiHisto_)
-          binRight -= nBinsPhiHisto_;
+        navigator_.setHome(bin1, bin2);
+        auto pos_N = navigator_.move(1, 0);
+        auto pos_S = navigator_.move(-1, 0);
+        auto pos_W = navigator_.move(0, -1);
+        auto pos_E = navigator_.move(0, 1);
+        auto pos_NW = navigator_.move(1, -1);
+        auto pos_NE = navigator_.move(1, 1);
+        auto pos_SW = navigator_.move(-1, -1);
+        auto pos_SE = navigator_.move(-1, 1);
 
-        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
-        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
-
-        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
-        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
-        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
+        float MIPT_N = (pos_N[0] != -1 && pos_N[1] != -1)
+                           ? histoClusters.at(z_side, pos_N[0], pos_N[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_S = (pos_S[0] != -1 && pos_S[1] != -1)
+                           ? histoClusters.at(z_side, pos_S[0], pos_S[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_W = (pos_W[0] != -1 && pos_W[1] != -1)
+                           ? histoClusters.at(z_side, pos_W[0], pos_W[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_E = (pos_E[0] != -1 && pos_E[1] != -1)
+                           ? histoClusters.at(z_side, pos_E[0], pos_E[1]).values[Bin::Content::Sum]
+                           : 0;
+        float MIPT_NW = (pos_NW[0] != -1 && pos_NW[1] != -1)
+                            ? histoClusters.at(z_side, pos_NW[0], pos_NW[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_NE = (pos_NE[0] != -1 && pos_NE[1] != -1)
+                            ? histoClusters.at(z_side, pos_NE[0], pos_NE[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_SW = (pos_SW[0] != -1 && pos_SW[1] != -1)
+                            ? histoClusters.at(z_side, pos_SW[0], pos_SW[1]).values[Bin::Content::Sum]
+                            : 0;
+        float MIPT_SE = (pos_SE[0] != -1 && pos_SE[1] != -1)
+                            ? histoClusters.at(z_side, pos_SE[0], pos_SE[1]).values[Bin::Content::Sum]
+                            : 0;
 
         float MIPT_pred = neighbour_weights_.at(0) * MIPT_NW + neighbour_weights_.at(1) * MIPT_N +
                           neighbour_weights_.at(2) * MIPT_NE + neighbour_weights_.at(3) * MIPT_W +
@@ -244,8 +374,7 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
         bool isMax = MIPT_seed >= (MIPT_pred + histoThreshold_);
 
         if (isMax) {
-          setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
+          setSeedEnergyAndPosition(seedPositionsEnergy, z_side, bin1, bin2, histoClusters.at(z_side, bin1, bin2));
         }
       }
     }
@@ -259,14 +388,13 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeThresh
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        float MIPT_seed = histoClusters.at(z_side, bin1, bin2).values[Bin::Content::Sum];
         bool isSeed = MIPT_seed > histoThreshold_;
 
         if (isSeed) {
-          setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
+          setSeedEnergyAndPosition(seedPositionsEnergy, z_side, bin1, bin2, histoClusters.at(z_side, bin1, bin2));
         }
       }
     }
@@ -279,56 +407,57 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
     const Histogram& histoClusters) {
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
-  HistogramT<uint8_t> primarySeedPositions(nBinsRHisto_, nBinsPhiHisto_);
-  HistogramT<uint8_t> vetoPositions(nBinsRHisto_, nBinsPhiHisto_);
+  HistogramT<uint8_t> primarySeedPositions(nBins1_, nBins2_);
+  HistogramT<uint8_t> vetoPositions(nBins1_, nBins2_);
 
   //Search for primary seeds
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
-        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
+        float MIPT_seed = histoClusters.at(z_side, bin1, bin2).values[Bin::Content::Sum];
         bool isMax = MIPT_seed > histoThreshold_;
 
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+        float MIPT_S = bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, bin2).values[Bin::Content::Sum] : 0;
+        float MIPT_N = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, bin2).values[Bin::Content::Sum] : 0;
 
-        int binLeft = bin_phi - 1;
+        int binLeft = bin2 - 1;
         if (binLeft < 0)
-          binLeft += nBinsPhiHisto_;
-        unsigned binRight = bin_phi + 1;
-        if (binRight >= nBinsPhiHisto_)
-          binRight -= nBinsPhiHisto_;
+          binLeft += nBins2_;
+        unsigned binRight = bin2 + 1;
+        if (binRight >= nBins2_)
+          binRight -= nBins2_;
 
-        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
-        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
-        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
-        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin1, binLeft).values[Bin::Content::Sum];
+        float MIPT_E = histoClusters.at(z_side, bin1, binRight).values[Bin::Content::Sum];
+        float MIPT_NW = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, binLeft).values[Bin::Content::Sum] : 0;
+        float MIPT_NE = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, binRight).values[Bin::Content::Sum] : 0;
+        float MIPT_SW =
+            bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, binLeft).values[Bin::Content::Sum] : 0;
+        float MIPT_SE =
+            bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, binRight).values[Bin::Content::Sum] : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
-          setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
+          setSeedEnergyAndPosition(seedPositionsEnergy, z_side, bin1, bin2, histoClusters.at(z_side, bin1, bin2));
 
-          primarySeedPositions.at(z_side, bin_R, bin_phi) = true;
+          primarySeedPositions.at(z_side, bin1, bin2) = true;
 
-          vetoPositions.at(z_side, bin_R, binLeft) = true;
-          vetoPositions.at(z_side, bin_R, binRight) = true;
-          if (bin_R > 0) {
-            vetoPositions.at(z_side, bin_R - 1, bin_phi) = true;
-            vetoPositions.at(z_side, bin_R - 1, binRight) = true;
-            vetoPositions.at(z_side, bin_R - 1, binLeft) = true;
+          vetoPositions.at(z_side, bin1, binLeft) = true;
+          vetoPositions.at(z_side, bin1, binRight) = true;
+          if (bin1 > 0) {
+            vetoPositions.at(z_side, bin1 - 1, bin2) = true;
+            vetoPositions.at(z_side, bin1 - 1, binRight) = true;
+            vetoPositions.at(z_side, bin1 - 1, binLeft) = true;
           }
-          if (bin_R < (nBinsRHisto_ - 1)) {
-            vetoPositions.at(z_side, bin_R + 1, bin_phi) = true;
-            vetoPositions.at(z_side, bin_R + 1, binRight) = true;
-            vetoPositions.at(z_side, bin_R + 1, binLeft) = true;
+          if (bin1 < (nBins1_ - 1)) {
+            vetoPositions.at(z_side, bin1 + 1, bin2) = true;
+            vetoPositions.at(z_side, bin1 + 1, binRight) = true;
+            vetoPositions.at(z_side, bin1 + 1, binLeft) = true;
           }
         }
       }
@@ -338,45 +467,45 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
   //Search for secondary seeds
 
   for (int z_side : {-1, 1}) {
-    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
-      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+    for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
+      for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
         //Cannot be a secondary seed if already a primary seed, or adjacent to primary seed
-        if (primarySeedPositions.at(z_side, bin_R, bin_phi) || vetoPositions.at(z_side, bin_R, bin_phi))
+        if (primarySeedPositions.at(z_side, bin1, bin2) || vetoPositions.at(z_side, bin1, bin2))
           continue;
 
-        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+        float MIPT_seed = histoClusters.at(z_side, bin1, bin2).values[Bin::Content::Sum];
         bool isMax = MIPT_seed > histoThreshold_;
 
-        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+        float MIPT_S = bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, bin2).values[Bin::Content::Sum] : 0;
+        float MIPT_N = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, bin2).values[Bin::Content::Sum] : 0;
 
-        int binLeft = bin_phi - 1;
+        int binLeft = bin2 - 1;
         if (binLeft < 0)
-          binLeft += nBinsPhiHisto_;
-        unsigned binRight = bin_phi + 1;
-        if (binRight >= nBinsPhiHisto_)
-          binRight -= nBinsPhiHisto_;
+          binLeft += nBins2_;
+        unsigned binRight = bin2 + 1;
+        if (binRight >= nBins2_)
+          binRight -= nBins2_;
 
-        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
-        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
-        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
-        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin1, binLeft).values[Bin::Content::Sum];
+        float MIPT_E = histoClusters.at(z_side, bin1, binRight).values[Bin::Content::Sum];
+        float MIPT_NW = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, binLeft).values[Bin::Content::Sum] : 0;
+        float MIPT_NE = bin1 > 0 ? histoClusters.at(z_side, bin1 - 1, binRight).values[Bin::Content::Sum] : 0;
+        float MIPT_SW =
+            bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, binLeft).values[Bin::Content::Sum] : 0;
+        float MIPT_SE =
+            bin1 < (nBins1_ - 1) ? histoClusters.at(z_side, bin1 + 1, binRight).values[Bin::Content::Sum] : 0;
 
-        isMax &=
-            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, bin_phi)) or MIPT_seed >= MIPT_S) &&
-            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, bin_phi)) or MIPT_seed > MIPT_N) &&
-            ((vetoPositions.at(z_side, bin_R, binRight)) or MIPT_seed >= MIPT_E) &&
-            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binRight)) or MIPT_seed >= MIPT_SE) &&
-            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binRight)) or MIPT_seed >= MIPT_NE) &&
-            ((vetoPositions.at(z_side, bin_R, binLeft)) or MIPT_seed > MIPT_W) &&
-            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binLeft)) or MIPT_seed > MIPT_SW) &&
-            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binLeft)) or MIPT_seed > MIPT_NW);
+        isMax &= (((bin1 < nBins1_ - 1) && vetoPositions.at(z_side, bin1 + 1, bin2)) or MIPT_seed >= MIPT_S) &&
+                 (((bin1 > 0) && vetoPositions.at(z_side, bin1 - 1, bin2)) or MIPT_seed > MIPT_N) &&
+                 ((vetoPositions.at(z_side, bin1, binRight)) or MIPT_seed >= MIPT_E) &&
+                 (((bin1 < nBins1_ - 1) && vetoPositions.at(z_side, bin1 + 1, binRight)) or MIPT_seed >= MIPT_SE) &&
+                 (((bin1 > 0) && vetoPositions.at(z_side, bin1 - 1, binRight)) or MIPT_seed >= MIPT_NE) &&
+                 ((vetoPositions.at(z_side, bin1, binLeft)) or MIPT_seed > MIPT_W) &&
+                 (((bin1 < nBins1_ - 1) && vetoPositions.at(z_side, bin1 + 1, binLeft)) or MIPT_seed > MIPT_SW) &&
+                 (((bin1 > 0) && vetoPositions.at(z_side, bin1 - 1, binLeft)) or MIPT_seed > MIPT_NW);
 
         if (isMax) {
-          setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
+          setSeedEnergyAndPosition(seedPositionsEnergy, z_side, bin1, bin2, histoClusters.at(z_side, bin1, bin2));
         }
       }
     }
@@ -390,19 +519,44 @@ void HGCalHistoSeedingImpl::findHistoSeeds(const std::vector<edm::Ptr<l1t::HGCal
   /* put clusters into an r/z x phi histogram */
   Histogram histoCluster = fillHistoClusters(clustersPtrs);
 
-  /* smoothen along the phi direction + normalize each bin to same area */
-  Histogram smoothPhiHistoCluster = fillSmoothPhiHistoClusters(histoCluster, binsSumsHisto_);
+  Histogram smoothHistoCluster;
+  if (seedingSpace_ == RPhi) {
+    /* smoothen along the phi direction + normalize each bin to same area */
+    Histogram smoothPhiHistoCluster = fillSmoothPhiHistoClusters(histoCluster, binsSumsHisto_);
 
-  /* smoothen along the r/z direction */
-  Histogram smoothRPhiHistoCluster = fillSmoothRPhiHistoClusters(smoothPhiHistoCluster);
+    /* smoothen along the r/z direction */
+    smoothHistoCluster = std::move(fillSmoothRPhiHistoClusters(smoothPhiHistoCluster));
+  } else if (seedingSpace_ == XY) {
+    smoothHistoCluster = std::move(fillSmoothHistoClusters(histoCluster, smoothing_ecal_, Bin::Content::Ecal));
+    smoothHistoCluster = std::move(fillSmoothHistoClusters(smoothHistoCluster, smoothing_hcal_, Bin::Content::Hcal));
+    // Update sum with smoothen ECAL + HCAL
+    for (int z_side : {-1, 1}) {
+      for (unsigned x1 = 0; x1 < nBins1_; x1++) {
+        for (unsigned x2 = 0; x2 < nBins2_; x2++) {
+          auto& bin = smoothHistoCluster.at(z_side, x1, x2);
+          bin.values[Bin::Content::Sum] = bin.values[Bin::Content::Ecal] + bin.values[Bin::Content::Hcal];
+        }
+      }
+    }
+  }
 
   /* seeds determined with local maximum criteria */
   if (seedingType_ == HistoMaxC3d)
-    seedPositionsEnergy = computeMaxSeeds(smoothRPhiHistoCluster);
+    seedPositionsEnergy = computeMaxSeeds(smoothHistoCluster);
   else if (seedingType_ == HistoThresholdC3d)
-    seedPositionsEnergy = computeThresholdSeeds(smoothRPhiHistoCluster);
+    seedPositionsEnergy = computeThresholdSeeds(smoothHistoCluster);
   else if (seedingType_ == HistoInterpolatedMaxC3d)
-    seedPositionsEnergy = computeInterpolatedMaxSeeds(smoothRPhiHistoCluster);
+    seedPositionsEnergy = computeInterpolatedMaxSeeds(smoothHistoCluster);
   else if (seedingType_ == HistoSecondaryMaxC3d)
-    seedPositionsEnergy = computeSecondaryMaxSeeds(smoothRPhiHistoCluster);
+    seedPositionsEnergy = computeSecondaryMaxSeeds(smoothHistoCluster);
+}
+
+std::array<double, 4> HGCalHistoSeedingImpl::boundaries() {
+  switch (seedingSpace_) {
+    case RPhi:
+      return {{kROverZMin_, kROverZMax_, -M_PI, M_PI}};
+    case XY:
+      return {{-kXYMax_, kXYMax_, -kXYMax_, kXYMax_}};
+  }
+  return {{0., 0., 0., 0.}};
 }

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -3,6 +3,7 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import distance_C3d_param
                                                               dbscan_C3d_params, \
                                                               histoMax_C3d_params, \
                                                               histoMaxVariableDR_C3d_params, \
+                                                              histoMaxXYVariableDR_C3d_params, \
                                                               histoSecondaryMax_C3d_params, \
                                                               histoInterpolatedMax_C3d_params, \
                                                               histoThreshold_C3d_params, \
@@ -40,8 +41,8 @@ def create_dbscan(process, inputs,
 
 def create_histoMax(process, inputs,
                     distance=histoMax_C3d_params.dR_multicluster,
-                    nBins_R=histoMax_C3d_params.nBins_R_histo_multicluster,
-                    nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
+                    nBins_X1=histoMax_C3d_params.nBins_X1_histo_multicluster,
+                    nBins_X2=histoMax_C3d_params.nBins_X2_histo_multicluster,
                     binSumsHisto=histoMax_C3d_params.binSumsHisto,
                     seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
                     shape_threshold=histoMax_C3d_params.shape_threshold,
@@ -50,15 +51,15 @@ def create_histoMax(process, inputs,
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_X1, nBins_X2, binSumsHisto,
             seed_threshold, shape_threshold)
     return producer
 
 
 def create_histoMax_variableDr(process, inputs,
                                distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                               nBins_R=histoMaxVariableDR_C3d_params.nBins_R_histo_multicluster,
-                               nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
+                               nBins_X1=histoMaxVariableDR_C3d_params.nBins_X1_histo_multicluster,
+                               nBins_X2=histoMaxVariableDR_C3d_params.nBins_X2_histo_multicluster,
                                binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
                                shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
@@ -69,15 +70,34 @@ def create_histoMax_variableDr(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone(
             dR_multicluster_byLayer_coefficientA = distances
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_X1, nBins_X2, binSumsHisto,
+            seed_threshold, shape_threshold)
+    return producer
+
+
+def create_histoMaxXY_variableDr(process, inputs,
+                               distances=histoMaxXYVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+                               nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
+                               nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
+                               seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
+                               shape_threshold=histoMaxXYVariableDR_C3d_params.shape_threshold,
+                               ):
+    producer = process.hgcalBackEndLayer2Producer.clone(
+            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+            )
+    producer.ProcessorParameters.C3d_parameters = histoMaxXYVariableDR_C3d_params.clone(
+            dR_multicluster_byLayer_coefficientA = distances
+            )
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_X1, nBins_X2,
+            histoMaxXYVariableDR_C3d_params.binSumsHisto,
             seed_threshold, shape_threshold)
     return producer
 
 
 def create_histoInterpolatedMax1stOrder(process, inputs,
                                         distance=histoInterpolatedMax_C3d_params.dR_multicluster,
-                                        nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
-                                        nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
                                         shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
@@ -88,15 +108,15 @@ def create_histoInterpolatedMax1stOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_1stOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_X1, nBins_X2, binSumsHisto,
             seed_threshold, shape_threshold)
     return producer
 
 
 def create_histoInterpolatedMax2ndOrder(process, inputs,
                                         distance=histoInterpolatedMax_C3d_params.dR_multicluster,
-                                        nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
-                                        nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
+                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
                                         shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
@@ -107,7 +127,7 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_2ndOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_X1, nBins_X2, binSumsHisto,
             seed_threshold, shape_threshold)
     return producer
 
@@ -115,8 +135,8 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
 def create_histoThreshold(process, inputs,
                           threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
                           distance=histoThreshold_C3d_params.dR_multicluster,
-                          nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
-                          nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
+                          nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
+                          nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
                           binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
                           shape_threshold=histoThreshold_C3d_params.shape_threshold,
                           ):
@@ -124,6 +144,6 @@ def create_histoThreshold(process, inputs,
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoThreshold_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_X1, nBins_X2, binSumsHisto,
             threshold, shape_threshold)
     return producer


### PR DESCRIPTION
- Generalize seeding for different histogram spaces (currently r-phi and x-y spaces are available)
- Add 2D histogram smoothing with the possibility to smooth independently ECAL and HCAL
- Improve histogram implementation and navigation
