### PR TITLE
Fixes in seeding and configs

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -45,7 +45,13 @@ private:
     unsigned bins_ = 0;
     Data histogram_;
 
-    unsigned index(int zside, unsigned x1, unsigned x2) const { return x2 + bins2_ * x1 + bins_ * (zside > 0 ? 1 : 0); }
+    unsigned index(int zside, unsigned x1, unsigned x2) const {
+      if (x1 >= bins1_ || x2 >= bins2_) {
+        throw cms::Exception("OutOfBound") << "Trying to access bin (" << x1 << "," << x2
+                                           << ") in seeding histogram of size (" << bins1_ << "," << bins2_ << ")";
+      }
+      return x2 + bins2_ * x1 + bins_ * (zside > 0 ? 1 : 0);
+    }
   };
   using Histogram = HistogramT<Bin>;
 
@@ -87,7 +93,7 @@ private:
   SeedingType seedingType_;
   SeedingPosition seedingPosition_;
 
-  unsigned nBinsRHisto_ = 36;
+  unsigned nBinsRHisto_ = 41;
   unsigned nBinsPhiHisto_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
@@ -97,7 +103,7 @@ private:
 
   static constexpr unsigned neighbour_weights_size_ = 9;
   static constexpr double kROverZMin_ = 0.09;
-  static constexpr double kROverZMax_ = 0.52;
+  static constexpr double kROverZMax_ = 0.58;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -16,7 +16,7 @@ binSums = cms.vuint32(13,               # 0
                       9, 9, 9,          # 4 - 6
                       7, 7, 7, 7, 7, 7,  # 7 - 12
                       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
-                      3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
+                      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 40
                       )
 
 EE_DR_GROUP = 7
@@ -69,8 +69,8 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                dR_multicluster_byLayer_coefficientB=cms.vdouble(),
                                shape_threshold=cms.double(1.),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
-                               nBins_R_histo_multicluster=cms.uint32(36),
-                               nBins_Phi_histo_multicluster=cms.uint32(216),
+                               nBins_R_histo_multicluster=cms.uint32(41), # bin size of about 0.012
+                               nBins_Phi_histo_multicluster=cms.uint32(216), # bin size of about 0.029
                                binSumsHisto=binSums,
                                threshold_histo_multicluster=cms.double(10.),
                                cluster_association=cms.string("NearestNeighbour"),

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -56,6 +56,10 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
 
   for (auto& clu : clustersPtrs) {
     float ROverZ = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
+    if (ROverZ < kROverZMin_ || ROverZ >= kROverZMax_) {
+      throw cms::Exception("OutOfBound") << "TC R/Z = " << ROverZ << " out of the seeding histogram bounds "
+                                         << kROverZMin_ << " - " << kROverZMax_;
+    }
     unsigned bin_R = unsigned((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
     unsigned bin_phi = unsigned((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
 

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -44,12 +44,14 @@ def create_histoMax(process, inputs,
                     nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
                     binSumsHisto=histoMax_C3d_params.binSumsHisto,
                     seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
+                    shape_threshold=histoMax_C3d_params.shape_threshold,
                     ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -59,6 +61,7 @@ def create_histoMax_variableDr(process, inputs,
                                nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
                                binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
                                ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -66,7 +69,8 @@ def create_histoMax_variableDr(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone(
             dR_multicluster_byLayer_coefficientA = distances
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -76,6 +80,7 @@ def create_histoInterpolatedMax1stOrder(process, inputs,
                                         nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
                                         ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -83,7 +88,8 @@ def create_histoInterpolatedMax1stOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_1stOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -93,6 +99,7 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
                                         nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
                                         ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -100,7 +107,8 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_2ndOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -109,11 +117,13 @@ def create_histoThreshold(process, inputs,
                           distance=histoThreshold_C3d_params.dR_multicluster,
                           nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
                           nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
-                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto
+                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
+                          shape_threshold=histoThreshold_C3d_params.shape_threshold,
                           ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoThreshold_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            threshold, shape_threshold)
     return producer


### PR DESCRIPTION
- Fix out-of-bound access to the seeding histograms. Impacted the seeding in the outer boundary of the HCAL in the V9 geometry. And caused crashes since the optimization in #348 .
- Fix producer generators in `clustering3d.py`: add missing `shape_threshold` parameter