### PR TITLE
newly trained egid for v9 clusters (3.7.0)

### DIFF
--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_370_higheta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_370_higheta_v0.xml
@@ -1,0 +1,2188 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     3.746166E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     2.192126E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.393994E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.170466E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.026437E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.478578E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.106281E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.645454E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.883117E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.457486E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.514945E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.725806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.901640E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.184137E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.818182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.808511E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     2.299928E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.714286E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.192308E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.294118E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.840450E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.978934E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.272728E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.285715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.171875E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.263158E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     2.052519E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     6.103320E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.818182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.384616E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.333334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.684211E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.600557E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.101681E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.314286E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.843197E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.400000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     2.659727E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.478261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.844426E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="4" Cut="     1.031922E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.144666E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.543364E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.425717E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.333334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.225807E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.397163E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.400000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.635514E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.050840E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.333334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.093023E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.929515E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.800000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.667578E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.644575E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.540266E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.153846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.857143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     5.435301E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.111111E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     5.511760E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.769231E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.846636E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.065033E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.338144E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.541833E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.219268E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.580645E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.346521E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.153494E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.870243E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.304012E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.882756E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.469388E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.584906E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.667821E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.437209E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.266148E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.530121E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.674301E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.867282E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     3.737170E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     2.059409E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.222012E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.746106E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.132209E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.951972E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.603340E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.506191E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.563089E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.780752E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.296597E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.318948E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.933228E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.923033E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.365037E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.796043E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.211510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.537100E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.692110E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.539953E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.986792E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.902109E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     2.052519E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     6.103320E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.169751E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.231436E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.825677E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.432571E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.252104E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     6.386620E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.788865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.212784E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.610690E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.291617E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.249142E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     2.659727E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.213404E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.730318E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.072881E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.517863E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.447076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="4" Cut="     1.290360E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.978093E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.681438E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.255668E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.293934E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.857172E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.692606E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.371080E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.583955E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.421929E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.150526E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.403373E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.215320E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     8.715328E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.062982E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.159285E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.804206E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     7.417170E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     8.640213E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.403350E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.325940E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.489555E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.235199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.411906E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.544580E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.721882E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.031160E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.494457E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.486426E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.054470E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.972137E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.024035E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.768354E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.366858E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     8.574494E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.345503E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.374177E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     7.229345E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.594788E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.443573E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.443203E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     3.737170E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.026483E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.746025E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     6.506306E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.302150E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.070760E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.401576E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.692912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.755983E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     7.071491E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.284222E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.364848E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.068321E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.216622E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.672425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.276476E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.873631E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.603556E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.145109E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.292360E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.480963E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.340858E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.955854E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.418900E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.823557E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.321769E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     2.131996E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     6.103320E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.361861E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.626055E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.323455E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.129834E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.082375E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.012839E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.760460E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.046436E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.117024E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.101681E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.054510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.820638E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.837847E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.027833E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.092235E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.207175E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.044707E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.500381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="4" Cut="     1.335621E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.141826E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.005631E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.762760E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.366580E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.291288E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.782177E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.779125E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.807808E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.302276E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.490138E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.764255E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.607464E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.470817E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.666601E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.568750E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     5.431290E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.465710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.248830E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.087801E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.482156E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.925798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     5.511760E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.471610E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.932859E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.405077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.702357E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.607826E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.568010E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.804422E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.877425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.341629E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.372576E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.602691E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.980279E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.689823E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.894222E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.916711E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.934360E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     7.229345E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.955390E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.230076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.229770E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.084015E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     3.873697E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     6.613958E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.452372E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.280740E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.691629E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.917080E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.144157E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.280666E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     9.989829E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.960280E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.998750E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.159981E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.134000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.842264E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.514086E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.697264E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="4" Cut="     7.074358E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.138437E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     6.296465E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     6.133542E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.030934E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.141256E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.181535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.261992E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.064105E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.701410E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.185912E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.334705E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.864481E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     1.979054E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.368871E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.036137E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.730214E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.119016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.649860E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.431274E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.031357E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.966022E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     3.974084E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.111655E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.499787E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.263689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.020689E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.566248E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.434494E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.216778E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.275294E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.832122E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.706343E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.509124E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.338997E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     2.385471E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     1.134570E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.868806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.077885E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.159409E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.366574E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.679827E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     2.909627E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.390866E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.642082E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.501928E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.530845E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.023392E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.439286E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.848518E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.490210E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.869751E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.065494E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.199086E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.878576E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.161532E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.140353E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.646300E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.521065E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.146038E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     5.952221E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.021347E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.178765E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.042700E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.403103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.222634E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.333283E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.465167E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.036688E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.734498E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.659720E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     3.737170E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     9.618069E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     3.767797E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     1.823168E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     9.007265E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.451053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.382335E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.996802E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.184689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     4.662584E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.447314E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.504717E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.241256E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.557088E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.911113E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.752718E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.494271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.653921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.984900E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.986985E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.600114E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.340858E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.045084E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.067929E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.235626E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.537424E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.225564E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.918109E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     2.183607E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.369148E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     7.383410E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.886725E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.058003E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     1.140261E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.403740E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.028334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.142726E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.026040E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.260697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.440251E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.590025E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.282868E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.804668E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.295325E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.920962E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.913364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.381662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.636282E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.227475E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.335100E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="4" Cut="     1.577885E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.278704E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     8.310318E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.032236E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.399896E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.037842E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.148302E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.312792E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.361086E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.241781E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.032965E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     2.300000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.539689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.637258E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.666601E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     6.584627E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.671317E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.864798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.160324E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.002340E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.070038E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.458469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     5.511760E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.845257E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.303921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.024035E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.605056E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.919914E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.551885E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.202164E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.837256E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.659563E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.410136E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.756528E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.100878E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.707833E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.066249E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.731519E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.769086E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.090609E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.035041E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.780645E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.143645E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.298107E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.402632E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.084015E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     3.739648E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     6.506306E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.302150E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.452372E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.245571E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.999932E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.324113E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.260711E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.802527E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     9.608585E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.561852E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.082558E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.455332E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.055586E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.346434E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.277691E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.203408E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     2.854039E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     7.082230E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.060699E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.536742E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.651590E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.461714E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.548253E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.073828E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.023017E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.973350E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.535624E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.953994E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.919947E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.167095E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     8.295530E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     2.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.802671E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.887096E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.525703E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.967532E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.260946E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.578291E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.725094E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.632078E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="5" Cut="     3.761977E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.779485E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.777330E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.755131E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.692110E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.893431E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.749851E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.842478E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.910910E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.521433E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.355178E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.914536E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     2.385471E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     1.134570E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.297973E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.460416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.210416E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.390359E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.192802E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.231781E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.524039E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.971709E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.244651E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.152102E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.934806E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.111657E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.602691E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.519731E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.391065E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.861581E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.659456E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.369556E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.149394E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.883866E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.756316E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.552629E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.302639E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.048307E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.966768E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.451782E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.137154E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.849953E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.282104E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.607617E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.848934E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.138119E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.501692E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.366732E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.529332E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.277369E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.458211E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     3.739648E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     2.992257E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.302983E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.383168E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.014223E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.566052E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.323621E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.742348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.327126E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.801599E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.576945E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.934687E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.225195E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.016836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.382499E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.218021E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.153301E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.328170E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.659976E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.416751E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.666601E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     8.296942E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.586420E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.180260E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.297582E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.354984E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.320867E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.118771E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.922306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.351069E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.225875E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.903855E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     5.511760E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.168251E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.084434E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.018181E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.017322E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.906870E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.625952E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.636348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="5" Cut="     3.827890E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     4.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.851538E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.576210E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.230381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.992282E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.104023E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.399456E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.610635E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.684739E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.106320E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.798695E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.211106E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.187287E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.051379E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     2.704094E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.986820E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.732584E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.060371E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.782710E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.864781E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.109507E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     6.499208E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.278080E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.578396E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.937104E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.836822E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.013700E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     5.952221E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.155219E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.278789E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.047717E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.065675E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.250172E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.274837E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.096000E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.536023E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.212780E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.043140E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.033240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.854266E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     5.196346E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.817427E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.571044E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.299467E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.374418E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.868119E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.165433E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.515245E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="7" Cut="     3.607618E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     9.245311E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.444787E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.792393E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.861429E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.269618E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.445017E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.709418E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.998102E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     9.486057E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.924503E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.452617E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.260516E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.123024E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.258127E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.847102E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.959776E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     5.465544E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.455932E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.171949E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.969426E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.622788E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.095306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.327849E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.441417E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.347832E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.560107E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     7.261464E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.994455E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.642455E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.643004E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.558666E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.972510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.610336E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     8.870097E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.720846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.442887E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.408631E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.441334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.403834E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.302899E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.658644E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.360608E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.400240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.117904E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.154203E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.174025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.098499E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.664765E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.964380E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.831663E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.024035E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.801980E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.392583E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.320545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.799873E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.381016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.140182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.546697E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.182598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.938765E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.365737E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.135985E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.407257E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.715242E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.610330E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.727886E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.657489E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.823516E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.722667E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.540548E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.831982E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.027268E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.814289E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.652757E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     3.014178E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     3.268485E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.564308E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.709642E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.302396E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.827905E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.466295E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.352741E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.497527E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.394592E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.005178E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     6.500855E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.278080E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.999314E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.960221E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.865441E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.960305E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.956244E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     4.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.821931E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.038438E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     9.615147E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     3.443282E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.280597E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.949604E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.420665E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.906746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     2.921628E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.419897E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.311706E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.890334E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.424410E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.685866E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.602695E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.527268E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.238213E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.850244E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     1.856936E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.868624E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.091879E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     7.186714E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.060689E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.429097E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.897251E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.072649E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.769414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.577305E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.471925E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.037603E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.931924E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.728226E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.459281E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.901064E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.853924E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.720865E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.456375E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.616423E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.466574E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.265511E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     9.335836E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.412791E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.302108E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.473521E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.182486E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.571190E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.579273E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.755170E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.983876E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.569712E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.661582E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.662541E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.888589E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.440111E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.769907E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.804103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.982433E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.326396E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.933861E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.068101E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.964027E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.128053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.535910E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.035391E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.309423E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.091962E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.752461E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.229297E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     2.902937E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     1.032412E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.204684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.213528E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.826495E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.555784E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.318381E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.368289E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.039615E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.617837E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.021017E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     6.500855E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.119032E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.715672E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.685983E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.152931E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.749595E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.939702E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     4.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.749074E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.870781E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     4.157920E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.190725E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     3.556098E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.525203E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.932850E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.157710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.749345E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.167692E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.018011E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.986348E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.946804E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.685956E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.926114E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.046044E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.506306E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.341748E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.302150E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.019417E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.665271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.930994E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.979337E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.310119E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     2.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.226944E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.413059E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.067735E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.075796E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.744564E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.878271E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.323609E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.237356E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.132723E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.040638E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.389416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.410144E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.021662E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.454557E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.143698E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.815355E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.039979E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     8.220115E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.100000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     5.511760E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.014654E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.745354E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.593216E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.860665E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.860905E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     5.593339E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.028307E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.287054E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.833244E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.528732E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.001096E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     3.418836E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.949598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     8.961371E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.417292E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.882006E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     6.015157E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     4.031813E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.606960E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.797252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.187801E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     2.991296E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     2.982487E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.927334E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.122833E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.962766E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.417623E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.195670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.706427E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.970300E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.300025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.637622E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.738919E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.786636E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.858070E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.143326E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.912703E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.596371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.148879E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.502090E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.558479E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.149785E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.062286E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.816540E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_370_loweta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_370_loweta_v0.xml
@@ -1,0 +1,2132 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     5.377414E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.781338E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.427335E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.723228E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.688564E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.766605E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.431597E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.867103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.755467E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.076416E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.070175E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.932817E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.724324E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.915493E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.108040E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.937787E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.000443E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.274510E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.903044E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.127795E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.927336E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.499316E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.996367E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.129412E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.972376E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.866610E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.444444E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.195335E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.637439E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.536512E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.142373E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.607755E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.028936E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.037288E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.757829E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.251256E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.080730E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.626374E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.918310E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.319991E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.666667E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.699793E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.160989E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.893125E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.374531E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.132265E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.891892E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.261790E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.982487E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.600740E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.919491E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.079442E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.051948E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.341624E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.270564E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.881061E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     9.262961E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.246386E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.875000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.981381E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.853591E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.760000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.666667E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.454546E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.640209E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.736843E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.588236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.075026E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.105263E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.195515E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.153847E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.897290E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.977048E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.285715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.478261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     5.254892E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.786714E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.339613E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.566353E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.965223E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.317648E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.665867E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.503466E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.960488E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.499476E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.509059E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.064516E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.212205E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.301050E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.458653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     9.472955E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.078259E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.155233E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.943436E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.680082E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.133926E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.463846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.906469E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.829702E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.773182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.249460E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.832800E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.959239E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.610333E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.712186E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.142373E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.248252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.417620E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.309029E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.604404E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.179173E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.816008E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.556057E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.884806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.385673E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.917297E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.318361E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.200220E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.392493E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.073072E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.801039E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.763275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.294945E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.085363E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.239604E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.718269E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.176564E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.101524E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.152407E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.595535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.859018E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.229139E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.804974E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.127990E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.930516E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.466426E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.605452E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.098852E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.054675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.078511E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.152167E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.825548E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.523887E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.712547E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.832716E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.236627E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     7.584033E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.795312E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.206202E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     6.115516E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.680921E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.331033E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.359047E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.593158E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     9.240942E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.927217E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.127213E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.881453E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.063924E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.613229E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.640209E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.489091E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.533079E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.625277E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.492275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.612004E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.294187E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     5.208285E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.748581E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.308459E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.077530E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.466359E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.284524E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.668601E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.560358E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.469703E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.117035E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.950746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.857892E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.591619E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.954340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     9.731112E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.330703E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.612799E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.843600E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.566134E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.986983E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.891250E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.707547E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.267893E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.636371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.094548E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.358054E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.782473E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.385284E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.413441E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.428372E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.554451E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.328459E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.659256E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.751208E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.601008E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.844875E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.052946E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.674573E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.342536E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.813301E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.716537E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.384816E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.568305E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.008905E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.327697E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.842545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.229515E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.212458E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.261469E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.034301E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.759276E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.275762E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.118003E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.957488E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     9.262961E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.246386E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.549429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.720794E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.669492E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.723600E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.982213E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.419161E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.408660E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.362233E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.640209E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.357192E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.787142E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.394302E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.726962E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.992967E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.381707E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.092885E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.629786E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.727273E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.087353E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.024983E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.946852E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.157381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.147689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.917009E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.185782E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.943641E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.013880E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.991405E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.313299E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.687155E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     5.037529E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.463320E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.077530E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.709236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.330533E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.641932E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.661508E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.477995E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.113422E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.389506E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.004743E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.549144E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.293917E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.067637E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.185806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.032660E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.154482E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.720595E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.826914E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.949201E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.363842E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.071662E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.270189E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.717540E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.783409E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.155437E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.479393E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.663631E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.081405E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.583740E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.936180E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.837885E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.078599E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.932610E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.394773E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.122332E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.371953E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.159132E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.239604E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.295042E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.456372E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.683930E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.113619E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.486307E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.013819E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.180975E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.446372E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.043225E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.469556E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.345420E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.108828E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.617287E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.859018E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.229139E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.685766E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.748308E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.501735E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.631034E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.415049E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.046858E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.637215E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.225644E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.117080E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.181537E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.240912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     7.288538E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     1.622801E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.996918E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.539162E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.148793E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.141347E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.471746E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.734689E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.500594E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.679590E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.036208E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.532221E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.716313E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.252847E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.238713E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.757508E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.860807E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.536325E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.094642E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.092878E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.208653E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.618832E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.496092E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.756019E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.093804E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.662922E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.664058E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.632774E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.791020E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.467818E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.079580E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.936836E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.616471E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.225785E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.645406E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.477076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.906286E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.968711E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.234374E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.195443E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.504060E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.893489E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.488114E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.066774E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     9.301404E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.878746E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.299831E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.365974E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.301031E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.019376E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.606725E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     7.241942E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.746560E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.789780E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.501930E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.872124E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.457749E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.877374E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.050992E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.491448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.381819E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.794588E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.535735E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.398520E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.911665E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.557044E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.479389E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.220137E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.227863E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.427499E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.159587E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.826983E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.085363E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.130141E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.657306E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.497391E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.028422E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.006297E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.551312E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.337591E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.108014E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.207131E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.157891E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     7.879357E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.910239E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.460996E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.075026E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.246386E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.305469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.346016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.512027E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.689031E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.845797E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.480345E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.981381E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.523888E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.090220E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.805902E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.479415E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.768420E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.195515E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.232210E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.288623E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.575823E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.824690E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.536063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.089296E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.315238E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.223846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.982706E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.425273E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.474773E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.247980E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.263175E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.086811E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.372712E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.353841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.716024E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.068620E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     5.756349E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.463320E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     9.120142E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.419271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.503289E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.680165E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.244723E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.723487E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.107130E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.051127E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.916127E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.640594E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.085841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.220630E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.479393E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.937295E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.111244E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.451928E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.891536E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.711732E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.189504E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.190870E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.093327E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.281860E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.996902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.377022E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.785242E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     2.546813E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     9.074924E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.920440E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.231246E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.441097E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.036427E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.497494E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.972514E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.270385E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.331837E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.501557E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.024885E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.489559E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.774557E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.355358E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.691516E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.760585E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.569077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.825272E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.345869E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.127222E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.115150E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     7.879357E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.831214E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.433080E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.772747E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.767999E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.361435E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.291451E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.021886E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.246386E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     4.494357E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.256190E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.516212E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     7.378674E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.319907E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.843267E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.899494E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.524754E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.115367E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.206326E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.260315E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.333854E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.440167E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.992967E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.158433E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.751754E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.289806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.657705E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.527221E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.735573E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.277683E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.330989E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.247980E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.512896E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.360142E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.062091E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.278597E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.718442E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.124728E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.673114E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.986071E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.832362E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     9.120142E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.560098E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     2.881217E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.660816E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.011786E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.764320E-04" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.735313E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.842015E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.921763E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.906575E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.038280E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.116077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.930011E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     7.820575E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.095274E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     8.308379E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.636356E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.845964E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.320968E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.865701E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.497435E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.530281E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.054751E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.358474E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.236592E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.022526E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.867251E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.874004E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.063722E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.911933E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.494731E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.996558E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.129180E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.856119E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.674809E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.340850E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.912919E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.869821E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.293459E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.125099E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.512699E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.965539E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.953884E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.798135E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.662449E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.898500E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.064918E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.326220E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.965003E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.184849E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.158041E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.614579E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.758399E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.199107E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.481606E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.523882E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.018106E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.294956E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.724395E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.054963E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.075583E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.302092E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.895443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     7.589689E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     5.814386E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     7.272506E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.223535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.737898E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.277095E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.794873E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.019736E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.460459E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.173286E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.718974E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.572709E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.261767E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.915326E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.804524E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.225598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.477593E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.711115E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.094653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.636944E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.895181E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.616840E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.178762E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.915480E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.442540E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.642296E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     9.624386E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.494576E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.146808E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.762473E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.446345E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.684909E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.820149E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.551670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     8.762391E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.473708E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.071478E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.336722E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.920224E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.728345E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.105730E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.657887E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     1.940075E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     5.336047E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.791929E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.680717E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.738142E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.102926E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.288552E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.862455E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.500037E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.636011E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.872120E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.476667E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.114067E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     7.495890E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.526276E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.096240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.291147E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.369463E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.478934E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     9.968201E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.736631E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.700807E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.489359E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.765876E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.066519E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.007286E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.388413E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.707317E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.944032E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.040934E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.553719E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.884712E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.694199E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     8.826584E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.176261E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.670508E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     7.020974E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.036616E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.735064E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     5.278195E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.625537E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.167658E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.888026E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.263648E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.603697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.467102E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.226994E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     7.363640E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.571039E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.992967E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.680574E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.731408E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.935253E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.723792E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.062118E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.111469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.160056E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.477593E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.498438E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.772871E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.447011E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.462415E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.350544E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.116605E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.315976E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.895275E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.630261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.884086E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.089045E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="4" Cut="     8.812016E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.553647E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.126426E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.115125E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.513670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.800310E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.743708E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     7.549259E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.725348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.165630E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.514383E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.662466E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.137025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     7.241942E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.946893E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.004272E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.387382E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.052704E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.819998E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     8.051627E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.287791E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.383561E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.025844E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.149287E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.061679E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.474226E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.599395E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.253968E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.162997E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.425743E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.933860E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.003550E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.749255E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.269970E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.066912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.069381E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.412276E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.231995E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.125632E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.323971E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.022312E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.386467E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.773150E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.950172E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.978871E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.337591E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.660376E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.369291E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.952101E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.032687E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.094907E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     7.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.516710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.337319E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.269984E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="4" Cut="     1.413212E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.646981E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.984474E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.294751E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     9.517971E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.980675E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.899264E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.165647E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.489528E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.739876E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     3.704150E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.896949E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.899464E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.443574E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.352305E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.606761E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.042436E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.463320E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     5.303257E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.747771E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.248537E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.202022E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.357671E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.815873E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.433589E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.976804E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     1.789495E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.648570E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.129283E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.487124E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.979585E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     6.822510E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.873581E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.838051E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.788900E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.791535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.634087E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.166971E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.089670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.358577E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.455385E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.319101E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.394223E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.235756E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.076030E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.239223E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.284565E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.360168E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.773217E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.525030E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.376833E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.341451E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.247213E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.701633E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.132450E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.997044E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.268851E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.817252E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.680082E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.988678E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.415222E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.757463E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.285352E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.616438E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     8.836750E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.134814E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.419773E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.987549E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="2" Cut="     3.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.401631E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.050389E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.893120E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.044764E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="4" Cut="     1.437267E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.835764E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.726103E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.179790E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.861188E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.646981E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.955588E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.724532E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.374378E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.394516E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.112232E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.679408E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.385307E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.073913E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.895275E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.330564E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.259245E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.220055E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     1.430696E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.051023E-04" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.685731E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.001038E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     5.243549E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.144555E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.853514E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml
@@ -1,0 +1,2432 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.648278E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.320279E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.480050E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.536804E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.183099E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.777714E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.886284E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.983314E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.933446E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.121315E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.381295E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.746709E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.098592E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.538462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.973581E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.633862E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.275358E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.036675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.377359E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.069343E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.478261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.619048E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.610514E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.631854E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.265306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.458716E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.953399E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.209302E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.548872E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.010055E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.107240E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.285715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.857143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.642088E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.377981E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.454546E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.387755E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.741935E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.818182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     2.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.567318E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.852495E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.520000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.538462E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.394313E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.764706E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.670044E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.995560E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.142857E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.295577E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.478261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     6.523885E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.290097E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.533202E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.359988E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.576271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.102041E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.342643E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.941748E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.941019E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.472368E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.597283E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.906977E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.512563E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.288337E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.266667E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.767742E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.150463E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.104837E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.200000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.472642E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.666667E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.773719E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.825242E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.039495E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.081633E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.678689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.499679E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.973684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.106384E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.302912E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.285775E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.571429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.200000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.805883E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.555265E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.959526E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.660079E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.320923E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.200000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.901505E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.881300E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.052739E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.795021E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.571429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.958328E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.689208E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.191682E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     6.129013E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.557645E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.101363E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.473684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.151237E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.938155E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.014491E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.869840E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     6.712958E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.606888E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.452016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.057395E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.181295E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.345543E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.886854E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.125270E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.889328E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.512931E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.244580E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.905253E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.413500E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.420469E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.243911E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.567850E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.858759E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.540602E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.622189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.273060E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.686617E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.362863E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     3.530919E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.439241E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.303344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.609088E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.952377E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.722907E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.481752E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.664205E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.137363E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.664222E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.982591E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.506846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.784489E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.174314E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.053147E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.686425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.367953E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.155397E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.637963E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.698907E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.783874E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.079798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.135332E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     6.600713E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.152980E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.861077E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.512931E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.414795E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.217402E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.782435E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.018111E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.307093E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.350962E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.532503E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.158494E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.185302E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.302682E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.339820E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.175344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     7.315516E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.523262E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.717340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.806820E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.412346E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.322546E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     3.300000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.457647E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.966728E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.257716E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.007846E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.244083E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.524983E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.353222E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.715325E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.454904E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.302912E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.284859E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.481387E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.828906E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.965580E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.477417E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.031856E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     7.356776E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.421689E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.496505E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.601097E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.103425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.356454E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.668967E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.541472E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.984815E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.301464E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.431821E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.549777E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.570638E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     5.349443E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.383287E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.291944E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.279595E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.843177E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.586718E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.023748E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.157862E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.974640E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.336535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.103902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.820588E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.967403E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.529405E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.925891E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.857170E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.684084E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.550885E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.859320E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.833917E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.023949E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.544707E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.982830E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.860020E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.945689E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.390090E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.470913E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.907846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.010055E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     4.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.162961E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.703311E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.851252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.142043E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.447051E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.568066E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.602198E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.992528E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.205370E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.253604E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.392095E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.220965E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.494828E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.728520E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     2.394313E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.698832E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.830873E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.231526E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.030326E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     6.243612E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.329502E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.417943E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.937991E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.294772E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.426098E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.843041E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.186596E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.392383E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.700502E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.875957E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.691016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.342768E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.430302E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.964029E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.235654E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.024623E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.577390E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.313874E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     6.234411E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.758810E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.093879E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.964595E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.863370E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.693545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     5.077729E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.050614E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.046796E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.275065E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.163401E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.352826E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.721626E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.780546E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     6.922878E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.581444E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.127826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.441606E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.928999E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.945175E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.112884E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.289902E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.429409E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.268076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.552378E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.237422E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.989533E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.411287E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.006828E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.086450E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.547725E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.004579E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.765270E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.123978E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.101363E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     3.298438E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.677646E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.464487E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.392865E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.917995E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.406353E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.935879E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.810579E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.529570E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.867114E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.990913E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.995029E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.894405E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.605278E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.743610E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.433536E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.361542E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.069343E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.217215E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.739171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.722151E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.044670E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.050560E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.535557E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.588975E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.838375E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.244605E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.362863E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.107240E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.430816E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.319137E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.479218E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.185051E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.416443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.197954E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.552494E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.624028E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.696889E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.624528E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.861896E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.386049E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.263370E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.854987E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.621094E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.701156E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.218789E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.355149E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.328354E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.600311E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.393431E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.612500E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     6.755437E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.289749E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.999015E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.256380E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.073829E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.845503E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.414210E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.518725E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.551104E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.466901E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.710126E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.864299E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.228807E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.621221E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.869025E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     6.005739E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.640080E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.228155E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.407186E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.718760E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.735099E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.799342E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.153291E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.869301E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.105492E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.517746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.825242E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.499679E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.139111E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.944821E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.007904E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.173632E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.023990E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.302912E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.271439E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.563949E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.823260E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.421682E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.467003E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     7.820786E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.552435E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.758141E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.545343E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.626714E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.007411E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.469818E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.525390E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.587229E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.329701E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.785904E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.181959E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.035034E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.605062E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.323857E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.851200E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.322970E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.188327E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.581890E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.060650E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.428311E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.395802E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.036012E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.041702E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.939882E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.261594E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.065201E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.516078E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.322213E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.938194E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.552561E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.467561E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.479119E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.592011E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.822623E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     3.850189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.439241E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.198820E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.819469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.519433E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.396447E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.381803E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.372797E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.706818E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.523901E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.330164E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.516861E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.662111E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.900036E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.000592E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     5.323142E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.042912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.157509E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.995560E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.400688E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.836771E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.272487E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.617564E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     6.755437E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.853703E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.354230E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.297761E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.795291E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.266101E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.267894E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.428849E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.659783E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.401878E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.836908E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.167887E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.889572E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.637686E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.155954E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.614424E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.291570E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     1.889480E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.131081E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.342556E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.230428E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     6.161276E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.879653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.328784E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.267991E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.615353E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.351690E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     5.549695E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.324730E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.080374E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.470445E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.806731E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.805774E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.777625E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.945789E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.379636E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.297280E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.802062E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.330511E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.441155E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.018131E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.328333E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.054475E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.996176E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.189611E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.107319E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.357706E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.276284E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.913865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.642030E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.417638E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.150624E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.872674E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.197245E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.844633E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.576288E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.167355E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.334172E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.296259E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.481188E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.255343E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.656628E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.849830E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.532432E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.225000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.644557E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.758795E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.525756E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.431730E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.114614E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.974626E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.893783E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.341873E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     3.300229E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.501802E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.399781E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.713428E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.434113E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.157907E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.362863E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     2.580183E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.904002E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.512265E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     1.955072E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.103059E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.221417E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.642088E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.276432E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.292342E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.683348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.907785E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     2.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.849035E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.908010E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.425068E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.114381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.625426E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.295577E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.905940E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.766058E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     5.312162E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.610479E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.731340E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.671401E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.158640E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.063012E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.110630E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.117956E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.991939E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.623204E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.107451E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.919206E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.951544E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.830863E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.038948E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     1.252327E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.954170E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.557865E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.075979E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.118580E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.877970E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.455394E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.720386E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.942706E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.317635E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     6.576556E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.915950E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.909169E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.883218E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.776457E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.188621E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.087199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.599276E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.795232E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.872949E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.128073E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.259093E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.749483E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.306587E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.190940E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.868599E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.720739E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.222425E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.167866E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.373741E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.246865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.138865E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="4" Cut="     1.872674E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.126362E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.617516E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.948902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.065703E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.084340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.081710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.223742E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.504576E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.016088E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.702243E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.159561E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.555243E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.021778E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.104550E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.546663E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.240876E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.870493E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.296135E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.739527E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.012827E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.786957E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.764645E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.601369E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.389683E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     4.727512E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     3.044291E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.580447E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.254954E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.001809E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.371064E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.803620E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.749751E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.875982E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.558779E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.599685E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.717206E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.977995E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.387145E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.959756E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     3.175729E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.368739E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.683735E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.772382E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.866678E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.144173E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.904481E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.070971E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.442524E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.015075E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.774506E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.814333E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     7.247008E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.367805E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.032653E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.767751E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.698787E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.089649E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.118455E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.203846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.495855E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.277512E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.441801E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.400010E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.285578E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.000232E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.798998E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.484463E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.664577E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.936401E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.826675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.388886E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.614424E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     1.889480E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.584922E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.367033E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     7.461786E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.339897E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.068439E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     3.195419E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.250222E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.687673E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.305590E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.833185E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.708869E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.110132E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     8.156118E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.894438E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.955525E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.668849E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.362961E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.309075E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.205843E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.301100E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.701300E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.825659E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.987187E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.149779E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.317443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     5.868716E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="8" Cut="     4.573256E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     2.014305E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.182721E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.363929E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.842422E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.083790E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.863080E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.003644E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.064272E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.672170E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.620991E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.759371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.310236E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.497683E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.114813E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.062956E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.709824E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.896548E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.945813E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.480055E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.334301E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.511505E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.682077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.460837E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.644300E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.065347E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.807316E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.449828E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.207597E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.742865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.253227E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.228653E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.575700E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.783406E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.907485E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.108769E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.223208E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.959832E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.649184E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.224305E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.079800E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.044522E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.040796E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.903899E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.810947E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.328909E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.744697E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.635218E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.353476E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.904773E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.200539E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.490551E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.047228E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     5.867625E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.610479E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.685456E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.312189E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.714389E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.908215E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.716836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.331715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.589471E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.569694E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.389085E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.889517E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.693770E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.023843E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.869350E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.673850E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.488103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.027002E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.874533E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.808758E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.533626E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.755574E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.784648E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.063294E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.930591E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.880545E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.071142E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.678315E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.933384E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.933935E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.998309E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.849911E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.312169E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.288744E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.983471E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.205281E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.037396E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.657853E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.930763E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     1.114188E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.377423E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.305292E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     5.981149E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     5.960876E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.654252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.346131E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.059841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="7" Cut="     6.141384E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="4" Cut="     1.636089E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.056239E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.476432E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.028985E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.851140E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.202754E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.185386E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.875879E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.595894E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.029265E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.054464E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.158824E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.086043E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.380826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.277580E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.143854E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.647866E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.848118E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.340772E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     5.038510E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.139371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.691099E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.959391E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.497387E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.819856E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.051865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.910718E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.166474E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.306936E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.656557E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.020893E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.316106E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.918558E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.407424E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.453727E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     2.573835E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.900280E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.470539E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.021425E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.985814E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.251525E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.891901E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.742589E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.224344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.923874E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.045582E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.497501E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.345808E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     7.360156E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     5.888620E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.695721E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.450246E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.397128E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.000504E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.566746E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.211061E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.890921E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.316090E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.328506E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.924579E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     6.255971E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.411585E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.922224E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.758754E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.990769E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.941879E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.610608E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.219041E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.090804E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.136611E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     6.289966E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.215888E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.080308E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.309471E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     1.013303E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.703662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.280048E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     8.156118E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.511304E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.410793E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.032232E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.956461E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.494322E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.666365E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.973947E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.411351E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.881198E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.100302E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.094641E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.965246E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.522192E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.447217E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.470161E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.300000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.561140E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.646679E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     5.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.544060E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.586761E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.955986E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.718453E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.412153E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.579811E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="5" Cut="     4.499776E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.223625E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.058891E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.363765E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.529626E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.794462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.333438E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     7.827348E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.760997E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.496179E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.838669E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.343017E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.874574E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.862372E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.606747E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.806665E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.015233E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.562968E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.477248E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.938675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.939530E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     8.730881E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.953681E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.991042E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     4.974462E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.718295E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.656766E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.771521E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.515975E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.320402E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.864817E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.231910E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.853562E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.172614E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.058654E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.235747E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.953128E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     5.136975E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.489428E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.278328E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.001766E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.658779E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     8.920039E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.257845E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.392913E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.072114E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     5.727557E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.751541E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.188227E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.378876E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.851605E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.726589E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.041518E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.096095E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.174351E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.229159E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.674511E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.455664E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.197588E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     2.293799E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.991939E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.546671E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.217813E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.838671E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.198787E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.691874E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.385713E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.699472E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.231678E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.368984E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.441514E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.670086E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.290046E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.263333E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.788272E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.050696E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.577274E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.714171E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.408402E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     6.258857E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.215128E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.177330E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.846230E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.955631E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.213140E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.960461E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.497690E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.882661E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.593121E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.112888E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.973907E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.104194E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.853848E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.838172E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.753515E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.357019E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.448762E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.062704E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml
@@ -1,0 +1,2216 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     7.883843E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.034261E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.126710E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.485137E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.769042E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.888082E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.195392E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.725485E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.149254E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.714286E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.819407E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.662488E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.085107E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.686438E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.242719E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.222222E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.618627E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.292924E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.926539E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.769231E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.631575E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.325581E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.913044E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.405222E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.666276E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.029039E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.352014E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.308344E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.515478E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.758596E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.905200E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.026860E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.074736E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.438481E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.696683E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.934621E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.677419E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     9.341903E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.605738E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.566820E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.889680E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.446158E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.258883E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.612009E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.046153E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.560953E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.615385E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.307692E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     9.251464E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.028846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.331565E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.727273E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     8.159092E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.676602E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.786088E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     6.812422E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.638821E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.100000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.697608E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.527559E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.344366E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.172414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.337923E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     7.920675E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.910888E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.571429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.818182E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.015682E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.200000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.545455E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.737421E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.729352E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.529412E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.040000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.923384E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.934755E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.000000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.285715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     8.022767E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     4.026862E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.994233E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.793238E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.364088E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.331942E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.527559E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.607798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.889915E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.675279E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.395155E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.098507E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.720936E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.232241E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.824124E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.295655E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.920243E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.831120E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.766987E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.789246E-04" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.419573E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.847398E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     6.586788E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.583252E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.654545E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.295181E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.213200E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.782264E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.446788E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.629148E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.739792E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.517156E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.538495E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.399011E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.013910E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.583106E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.098155E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.477995E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.749451E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.975476E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.171520E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.758139E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     1.001146E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.102012E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.258049E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.048739E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.957461E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.680357E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.634909E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.848995E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.080333E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.580972E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.261672E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.796275E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.124877E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.272668E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     8.069858E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.037377E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.562145E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     6.812422E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.638821E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.935083E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.494420E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.879018E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.227199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.344366E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.714901E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.089432E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.337923E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     7.920675E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.734524E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.187662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.529470E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.015682E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.863845E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.521838E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.737421E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.700027E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.157955E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.430545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.580252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.648600E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.789682E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.250115E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.077826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.111533E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.442866E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.627306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.296103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.492275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     7.513926E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.993014E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.405968E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.431919E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.217881E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.449376E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.940746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.740334E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.513879E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.923063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.664634E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.055977E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.230531E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.166648E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.297836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.416763E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.481999E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.371444E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.131746E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.431821E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.296677E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.768246E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.877080E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.169807E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.734742E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.341988E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.445554E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.770779E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.496593E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.917686E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.850547E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.897434E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     9.728868E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.544739E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.961443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.090356E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.429363E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.177494E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.423011E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     1.009678E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.825180E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.666680E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.677102E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.362433E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.589806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.676494E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.650599E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.161383E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.323849E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.510964E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.739004E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.596490E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.871093E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.413801E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.159336E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.695745E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.850380E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     5.040569E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.033319E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.349087E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.332674E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     7.033870E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.753422E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.186449E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.425595E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.817503E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.077801E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.618541E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.230029E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.510389E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.078900E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.812578E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.153852E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.951156E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.480570E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.609620E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.078116E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.737421E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.729352E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.145336E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.590136E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.957865E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.030914E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.789682E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.917682E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.045833E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.111333E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.808657E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.007679E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.832851E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.991405E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     7.458298E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.913777E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.707969E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.425364E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     8.904102E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.517030E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.698547E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.054820E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.606673E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.264400E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.393204E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.285691E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.663501E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.899007E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.875336E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.404310E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.932320E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.201284E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.084819E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.492040E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.839074E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.165194E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.273662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.939558E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.389794E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.514653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.804053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.482899E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.339800E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.547750E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.712249E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.569063E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     1.073122E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.581223E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.081452E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.184536E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.103952E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.991522E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.128379E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.249889E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.723067E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.661243E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.821991E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.784619E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.746143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.085377E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.566702E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.992157E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.191295E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.479479E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.512639E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.497482E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.400534E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.492939E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.635698E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.065683E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.275572E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.413801E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.071653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.627599E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     7.630558E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.681672E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.665945E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.156406E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.358628E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.008294E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.236995E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.677306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.385327E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.289173E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.854944E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.808915E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.260925E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.307786E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.830618E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.893004E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.046830E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.947176E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.013839E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.155729E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.693637E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.323784E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     5.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.292955E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.855840E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     8.267242E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.418373E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.642301E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     5.999534E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.519045E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.715829E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.552338E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.437172E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.082973E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.382901E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.320733E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.759548E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.616155E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.034446E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.224647E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.605972E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.683042E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.841108E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.248555E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.610045E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.494218E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.632774E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     7.120779E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.908217E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.876151E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.831889E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.330017E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.594108E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.718270E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.028727E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.359324E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.407037E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.238721E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.020917E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.545263E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.514486E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.816558E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.719011E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.343861E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.995810E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.449392E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.534328E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.303660E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.888699E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.797128E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.082305E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.329651E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.702134E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.863940E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     5.057269E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.857019E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.613561E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.606124E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.577309E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.500846E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.013988E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.377322E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     9.391630E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.977008E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.603444E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.121318E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.069896E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.226158E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.297371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     6.377891E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.152404E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.980398E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.628842E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.609544E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.404392E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.472763E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.293559E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.567705E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     8.968042E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.061469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.276408E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     6.924593E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.154063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.576339E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     6.839895E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.395663E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.785169E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.273062E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.621553E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.002366E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.197646E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.970207E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.122812E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.250757E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.102320E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.455657E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.964340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.228970E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.550953E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.650744E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     8.516084E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.109046E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.398921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.106495E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.132669E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.321442E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     7.626722E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.134717E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.807918E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.336774E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.331707E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.653171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.569350E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     6.301019E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.519045E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.245375E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.181677E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.643741E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.604071E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.163496E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.391440E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.358071E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.087785E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.371900E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.465194E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.841108E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.926552E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.369670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.228620E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.353841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     7.066911E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.793238E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.195250E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.311691E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.206286E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.642235E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.321956E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.916684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.217806E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.021630E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.139311E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.415198E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.527391E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.755135E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     6.200176E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.045804E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.385600E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.621699E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.558778E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.020953E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.685831E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.385010E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.139078E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.547380E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.934554E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.560591E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.770964E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.856851E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.591545E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.522682E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.482038E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.743237E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.742516E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.355861E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     1.183558E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.013054E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.430355E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.349252E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.335476E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.257205E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.698531E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     9.323444E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.179752E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.050859E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     8.853608E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.152404E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.889493E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.881134E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.992512E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.141772E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.024697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.756411E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.651362E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.937129E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.157344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.864532E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     5.875941E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.350788E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.200240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.332674E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.900061E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.136112E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.706041E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.162450E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.008692E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.432074E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.683703E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.015682E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.701129E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.991651E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.680892E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.584113E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.936484E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.279329E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.707879E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.847288E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.983383E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.709208E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.468418E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.273453E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.319405E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.010288E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.124728E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.191105E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.456876E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.286403E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.356414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.382818E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.443488E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.696371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.665121E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.036239E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.115011E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.280258E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.270963E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     6.769042E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.817164E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.630619E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.665918E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.123084E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.759642E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.272376E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.495812E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.227620E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.635069E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.217353E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.230777E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.659785E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.243366E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.007381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.960185E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.203282E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.889741E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     7.679684E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.720729E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.571657E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.830907E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.534043E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.671899E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.035849E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.912544E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.248090E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.632610E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.075587E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.887326E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.568401E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.333621E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.881585E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.723222E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.845408E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.924147E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.529918E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.709116E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.853249E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.464361E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.695115E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.665585E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.413662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     8.615162E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.405222E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.970697E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.565398E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.257396E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.739004E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.551624E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.022381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.223980E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.129891E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.251242E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.216861E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.431368E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.214232E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.052100E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     6.087648E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.940945E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.976798E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.696553E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.566232E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.754250E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     9.621553E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.311803E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.023548E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.995418E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.389682E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     8.885606E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.208701E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.489468E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.897196E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.237158E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.115712E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.149382E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.394806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.067736E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.635538E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.659731E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.669915E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     5.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.133253E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.898560E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.217351E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.804251E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.825266E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.929902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.789682E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.080189E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.920510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.057458E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.166743E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.450500E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.111333E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.395474E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.301124E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.012086E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.141446E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.158872E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.238132E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     6.531076E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.722210E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.962422E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.425364E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.760614E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.940460E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.248577E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.300892E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.256518E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.137000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.562825E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.562829E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.782014E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.155498E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.099218E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.763400E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.446940E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.861219E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.268615E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.462894E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.733167E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.528141E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.094990E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.602018E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.637476E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.750077E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.079120E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.978662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     5.242096E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.260856E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     9.728448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.357576E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.244750E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.513290E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.195747E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.754568E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.391870E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.272403E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.387025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     8.090921E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.431146E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.883236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     6.823964E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.339900E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.909504E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.475423E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     7.507241E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.074815E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.993208E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     7.187589E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.559411E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.042965E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.816095E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     7.257986E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.629542E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.109171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.680892E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.109922E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.734524E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.900118E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.067997E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.936836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.285382E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.127396E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.901329E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.821449E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.709208E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.761175E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.050993E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.140685E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.429457E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.874046E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.459786E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.247974E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.154185E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.062804E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.119457E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.229443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.733006E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.605423E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.850566E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.151974E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.328109E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.192051E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.993251E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="4" Cut="     1.358029E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.683245E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     6.054820E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.671515E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.595230E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.545452E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.990011E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.037724E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.753928E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.064891E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.372200E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.144440E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.996641E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.116460E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.164451E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.164508E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.483731E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.819397E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.307331E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.059849E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.098294E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.301874E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.831218E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.943132E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.383058E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.469546E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.926816E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.223242E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.158785E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.568681E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.584231E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     9.249270E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.189229E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.708303E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.114478E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.555064E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.149384E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.149255E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     8.799603E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.389922E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.759132E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.514665E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.610847E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.476782E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.543266E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.249857E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.842299E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.879975E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.660506E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.071479E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.018295E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.696074E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.314903E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.582869E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.603636E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.401969E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.398696E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     7.734835E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.801343E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.548008E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.010189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.453225E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.690368E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.598178E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.139058E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.491792E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     4.496140E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.445076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.560842E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.455478E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.448501E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.662988E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.438942E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.364267E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.802449E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.200696E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.954620E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.690837E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.709463E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.028679E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     9.580139E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.496888E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.878973E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.323053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.105140E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.144765E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.927587E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.395383E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.012143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.388545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.479912E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.792510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.358460E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.066152E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     6.246216E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     3.670328E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     2.453957E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.707258E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.961072E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.593889E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.172397E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.934625E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.440763E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.765244E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.487937E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.642565E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.101636E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.022067E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.227519E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.150467E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.334340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.351751E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.666676E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.903410E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.412428E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.081338E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.751894E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.546807E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.332833E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.959278E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.899561E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     5.854692E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.523177E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.577523E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.372879E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.560493E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.519952E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.941126E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.019694E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.989755E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.169393E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.841883E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.623897E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.739120E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.932178E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.615422E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     6.823964E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     4.212201E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.036448E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.117445E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.404387E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.727787E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.951378E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     5.849066E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     5.846599E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.269845E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.680943E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.510425E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.490658E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.087661E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     6.003335E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     2.970207E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.976798E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.180149E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.555668E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.543223E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.144123E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     9.554103E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.213705E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.488305E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.104924E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.561666E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.832540E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.224014E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.414937E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.386767E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.533189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.570743E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.981381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     9.929721E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.281437E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.127309E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.740038E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.431508E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.637113E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.025337E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     2.453753E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     9.580139E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.334902E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.778645E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.351143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     1.660654E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.071588E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.954909E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.166796E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.227797E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.694096E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.883210E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.342963E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.931346E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.822128E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.589596E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.966900E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     7.744058E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.912535E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.302004E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+
 
 class Category:
     def __init__(self, eta_min, eta_max, pt_min, pt_max):
@@ -67,30 +69,84 @@ working_points_drnn_dbscan = [
         },
         ]
 
-# Identification for 3D HistoMax clustering (as in 3.5.2)
-bdt_weights_histomax = [
-        # Low eta
-        'L1Trigger/L1THGCal/data/egamma_id_histomax_352_loweta_v0.xml',
-        # High eta
-        'L1Trigger/L1THGCal/data/egamma_id_histomax_352_higheta_v0.xml',
-        ]
+# Identification for 3D HistoMax clustering: switch between configurations for v8 and v9 geometry
+input_features_histomax = {
+        "v8_352":['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'],
+        "v9_370":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot'],
+        "v9_394":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
+        }
 
-working_points_histomax = [
-        # Low eta
-        {
-        '900':0.19146989,
-        '950':0.1379665 ,
-        '975':0.03496629,
-        '995':-0.24383164,
-        },
-        # High eta
-        {
-        '900':0.13347613,
-        '950':0.04267797,
-        '975':-0.03698097,
-        '995':-0.23077505,
-        },
-        ]
+bdt_weights_histomax = {
+        "v8_352":[ #trained using TPG software version 3.5.2
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_352_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_352_higheta_v0.xml'
+                ],
+        "v9_370":[ #trained using TPG software version 3.7.0
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_370_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_370_higheta_v0.xml'
+                ],
+        "v9_394":[ #trained using TPG software version 3.9.4
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml'
+                ]
+        }
+
+working_points_histomax = {
+        "v8_352":[
+                # Low eta
+                {
+                '900':0.19146989,
+                '950':0.1379665,
+                '975':0.03496629,
+                '995':-0.24383164,
+                },
+                # High eta
+                {
+                '900':0.13347613,
+                '950':0.04267797,
+                '975':-0.03698097,
+                '995':-0.23077505,
+                }
+             ],
+        "v9_370":[
+                # Low eta
+                {
+                '900':0.8815851, # epsilon_b = 2.5%
+                '950':0.5587649, # epsilon_b = 4.0%
+                '975':-0.1937952, # epsilon_b = 5.5%
+                '995':-0.9394884, # epsilon_b = 10.1%
+                },
+                # High eta
+                {
+                '900':0.7078400, #epsilon_b = 3.5%
+                '950':-0.0239623, #epsilon_b = 6.9%
+                '975':-0.7045071, #epsilon_b = 11.6% 
+                '995':-0.9811426, #epsilon_b = 26.1%
+                }
+             ],
+        "v9_394":[
+                # Low eta
+                {
+                '900':0.9794103, # epsilon_b = 1.9%
+                '950':0.9052764, # epsilon_b = 3.9%
+                '975':0.5276631, # epsilon_b = 6.6%
+                '995':-0.9153535, # epsilon_b = 20.4%
+                },
+                # High eta
+                {
+                '900':0.8825340, #epsilon_b = 1.0%
+                '950':0.2856039, #epsilon_b = 1.7%
+                '975':-0.5274948, #epsilon_b = 2.8% 
+                '995':-0.9864445, #epsilon_b = 7.6%
+                }
+             ]
+        }
 
 tight_wp = ['975', '900']
 loose_wp = ['995', '950']
@@ -117,11 +173,20 @@ egamma_identification_drnn_dbscan = cms.PSet(
         )
 
 egamma_identification_histomax = cms.PSet(
-        Inputs=cms.vstring('cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'),
+        Inputs=cms.vstring(input_features_histomax['v8_352']),
         CategoriesEtaMin=cms.vdouble([cat.eta_min for cat in categories]),
         CategoriesEtaMax=cms.vdouble([cat.eta_max for cat in categories]),
         CategoriesPtMin=cms.vdouble([cat.pt_min for cat in categories]),
         CategoriesPtMax=cms.vdouble([cat.pt_max for cat in categories]),
-        Weights=cms.vstring(bdt_weights_histomax),
-        WorkingPoints=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax,tight_wp)]),
+        Weights=cms.vstring(bdt_weights_histomax['v8_352']),
+        WorkingPoints=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v8_352'],tight_wp)]),
+        )
+
+# Era Modification for HGCal v9: use correct training and WPs
+phase2_hgcalV9.toModify(egamma_identification_histomax,
+        Inputs=cms.vstring(input_features_histomax['v9_394']),
+        Weights=cms.vstring(bdt_weights_histomax['v9_394']),
+        WorkingPoints=cms.vdouble(
+                [wps[eff] for wps,eff in zip(working_points_histomax['v9_394'],tight_wp)]
+                )
         )


### PR DESCRIPTION
#### PR description:

Integrated newly trained eg-ID into TPG software. The new eg-ID builds upon the old by using a more complete set of input features (which has no direct effect on the latency in firmware). The BDT was trained using HGCal v9 geometry samples using v3.7.0 of the TPG software.

Still to do: add the training code in a suitable repository (TBD).

#### PR validation:

- Generated ntuples from the TPG software successfully, with the new egID.
- Passes the basic test procedures, suggested in https://cms-sw.github.io/PRWorkflow.html