### PR TITLE
Update FE threshold for V9

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -44,8 +44,8 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 # (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
 # for more details)
 phase2_hgcalV9.toModify(threshold_conc_proc,
-                        threshold_silicon=1.5,  # MipT
-                        threshold_scintillator=1.5,  # MipT
+                        threshold_silicon=1.35,  # MipT
+                        threshold_scintillator=1.35,  # MipT
                         )
 
 


### PR DESCRIPTION
Change FE threshold for V9 from 1.5 to 1.35 mipT to be more consistent with the available bandwidth.  