### PR TITLE
adding calo truth chains

### DIFF
--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -54,3 +54,10 @@ def create_dummy(process, inputs):
             )
     producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
     return producer
+
+def create_truth_dummy(process, inputs):
+    producer = process.hgcalBackEndLayer1Producer.clone(
+            InputTriggerCells = cms.InputTag('{}'.format(inputs))
+            )
+    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
+    return producer

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
@@ -4,17 +4,22 @@ class HGCalTriggerChains:
     def __init__(self):
         self.vfe = {}
         self.concentrator = {}
+        self.truth_prod = {}
         self.backend1 = {}
         self.backend2 = {}
         self.selector = {}
         self.ntuple = {}
         self.chain = []
+        self.truth_chain = []
 
     def register_vfe(self, name, generator):
         self.vfe[name] = generator
 
     def register_concentrator(self, name, generator):
         self.concentrator[name] = generator
+
+    def register_truth_prod(self, name, generator): # for truth-matched trigger cells
+        self.truth_prod[name] = generator
 
     def register_backend1(self, name, generator):
         self.backend1[name] = generator
@@ -42,7 +47,21 @@ class HGCalTriggerChains:
         if ntuple!='' and not ntuple in self.ntuple: 
             raise KeyError('{} not registered as ntuplizer'.format(ntuple))
         self.chain.append( (vfe, concentrator, backend1, backend2, selector, ntuple) )
-    
+
+    def register_truth_chain(self, vfe, truth_prod, backend1='', backend2='', selector='', ntuple=''): 
+        if not vfe in self.vfe: 
+            raise KeyError('{} not registered as VFE producer'.format(vfe))
+        if not truth_prod in self.truth_prod: 
+            raise KeyError('{} not registered as truth producer'.format(truth_prod))
+        if backend1!='' and not backend1 in self.backend1: 
+            raise KeyError('{} not registered as backend1 producer'.format(backend1))
+        if backend2!='' and not backend2 in self.backend2: 
+            raise KeyError('{} not registered as backend2 producer'.format(backend2))
+        if selector!='' and not selector in self.selector:
+            raise KeyError('{} not registered as selector'.format(selector))
+        if ntuple!='' and not ntuple in self.ntuple: 
+            raise KeyError('{} not registered as ntuplizer'.format(ntuple))
+        self.truth_chain.append( (vfe, truth_prod, backend1, backend2, selector, ntuple) )
 
     def create_sequences(self, process):
         if not hasattr(process, 'hgcalTriggerSelector'):
@@ -98,6 +117,88 @@ class HGCalTriggerChains:
         ntuple_sequence.remove(tmpseq)
         process.globalReplace('hgcalVFE', vfe_task)
         process.globalReplace('hgcalConcentrator', concentrator_task)
+        process.globalReplace('hgcalBackEndLayer1', backend1_task)
+        process.globalReplace('hgcalBackEndLayer2', backend2_task)
+        process.globalReplace('hgcalTriggerSelector', selector_sequence)
+        process.globalReplace('hgcalTriggerNtuples', ntuple_sequence)
+        return process
+    
+    def create_truth_sequences(self, process):
+        if not hasattr(process, 'caloTruthCellsProducer'):
+            from L1Trigger.L1THGCalUtilities.caloTruthCellsProducer_cfi import caloTruthCellsProducer
+            process.load('L1Trigger.L1THGCalUtilities.caloTruthCells_cff')
+            process.truthCellsProd = cms.Task(caloTruthCellsProducer)
+            hgcalTriggerPrimitivesTask = cms.Task(process.hgcalVFE, process.truthCellsProd, process.hgcalBackEndLayer1, process.hgcalBackEndLayer2, process.hgcalTowerMap, process.hgcalTower)
+            process.hgcalTriggerPrimitivesTruth = cms.Sequence(hgcalTriggerPrimitivesTask)
+        if not hasattr(process, 'hgcalTriggerSelector'):
+            process.load('L1Trigger.L1THGCalUtilities.HGC3DClusterGenMatchSelector_cff')
+        tmp = cms.TaskPlaceholder("tmp")
+        tmpseq = cms.SequencePlaceholder("tmp")
+        vfe_task = cms.Task(tmp)
+        truth_prod_task = cms.Task(tmp)
+        backend1_task = cms.Task(tmp)
+        backend2_task = cms.Task(tmp)
+        selector_sequence = cms.Sequence(tmpseq)
+        ntuple_sequence = cms.Sequence(tmpseq)
+        for vfe,truth_prod,backend1,backend2,selector,ntuple in self.truth_chain:
+            truth_prod_name = '{0}{1}'.format(vfe, truth_prod)
+            backend1_name = '{0}{1}{2}'.format(vfe, truth_prod, backend1)
+            backend2_name = '{0}{1}{2}{3}'.format(vfe, truth_prod, backend1, backend2)
+            selector_name = '{0}{1}{2}{3}{4}'.format(vfe, truth_prod, backend1, backend2, selector)
+            ntuple_name = '{0}{1}{2}{3}{4}{5}'.format(vfe, truth_prod, backend1, backend2, selector, ntuple)
+            if selector=='':
+                if backend2=='':
+                    if backend1=='':
+                        ntuple_inputs = [
+                                truth_prod_name,
+                                truth_prod_name,
+                                truth_prod_name
+                                ]
+                    else:
+                        ntuple_inputs = [
+                                truth_prod_name,
+                                backend1_name+':HGCalBackendLayer1Processor2DClustering',
+                                truth_prod_name
+                                ]
+                else:
+                    ntuple_inputs = [
+                            truth_prod_name,
+                            backend1_name+':HGCalBackendLayer1Processor2DClustering',
+                            backend2_name+':HGCalBackendLayer2Processor3DClustering'
+                            ]
+            else:
+                ntuple_inputs = [
+                        truth_prod_name,
+                        backend1_name+':HGCalBackendLayer1Processor2DClustering',
+                        selector_name
+                        ]
+
+            if not hasattr(process, vfe):
+                setattr(process, vfe, self.vfe[vfe](process))
+                vfe_task.add(getattr(process, vfe))
+            if not hasattr(process, truth_prod_name):
+                setattr(process, truth_prod_name, self.truth_prod[truth_prod](process, vfe))
+                truth_prod_task.add(getattr(process, truth_prod_name))
+            if not hasattr(process, backend1_name):
+                setattr(process, backend1_name, self.backend1[backend1](process, truth_prod_name))
+                backend1_task.add(getattr(process, backend1_name))
+            if backend2!='' and not hasattr(process, backend2_name):
+                setattr(process, backend2_name, self.backend2[backend2](process, backend1_name))
+                backend2_task.add(getattr(process, backend2_name))
+            if selector!='' and not hasattr(process, selector_name):
+                setattr(process, selector_name, self.selector[selector](process, backend2_name))
+                selector_sequence *= getattr(process, selector_name)
+            if ntuple!='' and not hasattr(process, ntuple_name):
+                setattr(process, ntuple_name, self.ntuple[ntuple](process, ntuple_inputs))
+                ntuple_sequence *= getattr(process, ntuple_name)
+        vfe_task.remove(tmp)
+        truth_prod_task.remove(tmp)
+        backend1_task.remove(tmp)
+        backend2_task.remove(tmp)
+        selector_sequence.remove(tmpseq)
+        ntuple_sequence.remove(tmpseq)
+        process.globalReplace('hgcalVFE', vfe_task)
+        process.globalReplace('truthCellsProd', truth_prod_task)
         process.globalReplace('hgcalBackEndLayer1', backend1_task)
         process.globalReplace('hgcalBackEndLayer2', backend2_task)
         process.globalReplace('hgcalTriggerSelector', selector_sequence)

--- a/L1Trigger/L1THGCalUtilities/python/truth_prod.py
+++ b/L1Trigger/L1THGCalUtilities/python/truth_prod.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCalUtilities.caloTruthCellsProducer_cfi import caloTruthCellsProducer
+
+def create_truth_prod(process, inputs):
+    producer = process.caloTruthCellsProducer.clone(
+            triggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+            )
+    return producer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_with_truth_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_with_truth_cfg.py
@@ -1,0 +1,123 @@
+import FWCore.ParameterSet.Config as cms 
+from Configuration.StandardSequences.Eras import eras
+from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
+
+# For old samples use the digi converter
+process = cms.Process('DIGI',eras.Phase2C4)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023D35Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D35_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(50)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring('/store/mc/PhaseIIMTDTDRAutumn18DR/SinglePion_FlatPt-2to100/FEVT/NoPU_103X_upgrade2023_realistic_v2-v1/70000/60B619EA-9EC7-A744-B3E5-5369820F26CB.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
+           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+process.load('L1Trigger.L1THGCalUtilities.HGC3DClusterGenMatchSelector_cff')
+process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
+from L1Trigger.L1THGCalUtilities.hgcalTriggerChains import HGCalTriggerChains
+import L1Trigger.L1THGCalUtilities.vfe as vfe
+import L1Trigger.L1THGCalUtilities.concentrator as concentrator
+import L1Trigger.L1THGCalUtilities.truth_prod as truth_prod
+import L1Trigger.L1THGCalUtilities.clustering2d as clustering2d
+import L1Trigger.L1THGCalUtilities.clustering3d as clustering3d
+import L1Trigger.L1THGCalUtilities.selectors as selectors
+import L1Trigger.L1THGCalUtilities.customNtuples as ntuple
+
+chains = HGCalTriggerChains()
+# Register algorithms
+## VFE
+chains.register_vfe("Floatingpoint8", lambda p : vfe.create_compression(p, 4, 4, True))
+## TRUTH PRODUCER
+chains.register_truth_prod("TruthProd", truth_prod.create_truth_prod)
+## BE1
+chains.register_backend1("TruthDummy", clustering2d.create_truth_dummy)
+## BE2
+chains.register_backend2("Histomax", clustering3d.create_histoMax)
+chains.register_backend2("Histomaxvardrth0", lambda p,i : clustering3d.create_histoMax_variableDr(p,i,seed_threshold=0.))
+chains.register_backend2("Histomaxvardrth10", lambda p,i : clustering3d.create_histoMax_variableDr(p,i,seed_threshold=10.))
+chains.register_backend2("Histomaxvardrth20", lambda p,i : clustering3d.create_histoMax_variableDr(p,i,seed_threshold=20.))
+# Register selector
+chains.register_selector("Genmatch", selectors.create_genmatch)
+# Register ntuples
+ntuple_list = ['event', 'gen', 'multiclusters']
+chains.register_ntuple("Genclustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
+
+# Register trigger chains
+backend_algos = ['Histomax', 'Histomaxvardrth0', 'Histomaxvardrth10', 'Histomaxvardrth20']
+
+chains.register_truth_chain('Floatingpoint8', 'TruthProd', '', '', '', 'Genclustersntuple')
+for be in backend_algos:
+    chains.register_truth_chain('Floatingpoint8', 'TruthProd', 'TruthDummy', be, 'Genmatch', 'Genclustersntuple')
+
+process = chains.create_truth_sequences(process)
+
+# Remove towers from sequence
+process.hgcalTriggerPrimitivesTruth.remove(process.hgcalTowerMap)
+process.hgcalTriggerPrimitivesTruth.remove(process.hgcalTower)
+
+process.hgcl1tpg_truth_step = cms.Path(process.hgcalTriggerPrimitivesTruth)
+process.selector_step = cms.Path(process.hgcalTriggerSelector)
+process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.hgcl1tpg_truth_step, process.selector_step, process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+


### PR DESCRIPTION
Adds TPG chains to save clusters based on calo truth information and run backend clustering algorithms on calo truth cells. An example configuration (in text format) is attached. 

[testHGCalL1T_multialgo_with_truth_cfg.txt](https://github.com/PFCal-dev/cmssw/files/3335214/testHGCalL1T_multialgo_with_truth_cfg.txt)


