### PR TITLE
Add cluster shape variables

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -149,6 +149,12 @@ namespace l1t {
     float sigmaRRTot() const { return sigmaRRTot_; }
     float sigmaRRMax() const { return sigmaRRMax_; }
     float sigmaRRMean() const { return sigmaRRMean_; }
+    float zBarycenter() const { return zBarycenter_; }
+    float layer10percent() const { return layer10percent_; }
+    float layer50percent() const { return layer50percent_; }
+    float layer90percent() const { return layer90percent_; }
+    float triggerCells67percent() const { return triggerCells67percent_; }
+    float triggerCells90percent() const { return triggerCells90percent_; }
 
     void showerLength(int showerLength) { showerLength_ = showerLength; }
     void coreShowerLength(int coreShowerLength) { coreShowerLength_ = coreShowerLength; }
@@ -163,6 +169,12 @@ namespace l1t {
     void sigmaRRTot(float sigmaRRTot) { sigmaRRTot_ = sigmaRRTot; }
     void sigmaRRMean(float sigmaRRMean) { sigmaRRMean_ = sigmaRRMean; }
     void sigmaZZ(float sigmaZZ) { sigmaZZ_ = sigmaZZ; }
+    void zBarycenter(float zBarycenter) { zBarycenter_ = zBarycenter; }
+    void layer10percent(float layer10percent) { layer10percent_ = layer10percent; }
+    void layer50percent(float layer50percent) { layer50percent_ = layer50percent; }
+    void layer90percent(float layer90percent) { layer90percent_ = layer90percent; }
+    void triggerCells67percent(float triggerCells67percent) { triggerCells67percent_ = triggerCells67percent; }
+    void triggerCells90percent(float triggerCells90percent) { triggerCells90percent_ = triggerCells90percent; }
 
     /* operators */
     bool operator<(const HGCalClusterT<C>& cl) const { return mipPt() < cl.mipPt(); }
@@ -186,19 +198,25 @@ namespace l1t {
 
     //shower shape
 
-    int showerLength_;
-    int coreShowerLength_;
-    int firstLayer_;
-    int maxLayer_;
-    float eMax_;
-    float sigmaEtaEtaMax_;
-    float sigmaPhiPhiMax_;
-    float sigmaRRMax_;
-    float sigmaEtaEtaTot_;
-    float sigmaPhiPhiTot_;
-    float sigmaRRTot_;
-    float sigmaRRMean_;
-    float sigmaZZ_;
+    int showerLength_ = 0;
+    int coreShowerLength_ = 0;
+    int firstLayer_ = 0;
+    int maxLayer_ = 0;
+    float eMax_ = 0.;
+    float sigmaEtaEtaMax_ = 0.;
+    float sigmaPhiPhiMax_ = 0.;
+    float sigmaRRMax_ = 0.;
+    float sigmaEtaEtaTot_ = 0.;
+    float sigmaPhiPhiTot_ = 0.;
+    float sigmaRRTot_ = 0.;
+    float sigmaRRMean_ = 0.;
+    float sigmaZZ_ = 0.;
+    float zBarycenter_ = 0.;
+    float layer10percent_ = 0.;
+    float layer50percent_ = 0.;
+    float layer90percent_ = 0.;
+    float triggerCells67percent_ = 0.;
+    float triggerCells90percent_ = 0.;
 
     ClusterShapes shapes_;
 

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -30,7 +30,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerSums>" />
-  <class name="l1t::HGCalCluster" ClassVersion="16">
+  <class name="l1t::HGCalCluster" ClassVersion="17">
+   <version ClassVersion="17" checksum="2841504063"/>
    <version ClassVersion="16" checksum="1572558185"/>
   <version ClassVersion="15" checksum="2522149132"/>
   <version ClassVersion="14" checksum="3289642235"/>
@@ -45,7 +46,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
 
-  <class name="l1t::HGCalMulticluster" ClassVersion="17">
+  <class name="l1t::HGCalMulticluster" ClassVersion="18">
+   <version ClassVersion="18" checksum="1001614855"/>
    <version ClassVersion="17" checksum="460658789"/>
   <version ClassVersion="16" checksum="1276395758"/>
   <version ClassVersion="15" checksum="777879934"/>

--- a/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
@@ -28,9 +28,15 @@ public:
   }  //in number of layers
   // Maximum number of consecutive layers in the cluster
   int coreShowerLength(const l1t::HGCalMulticluster& c3d, const HGCalTriggerGeometryBase& triggerGeometry) const;
+  float percentileLayer(const l1t::HGCalMulticluster& c3d,
+                        const HGCalTriggerGeometryBase& triggerGeometry,
+                        float quantile = 0.5) const;
+
+  float percentileTriggerCells(const l1t::HGCalMulticluster& c3d, float quantile = 0.5) const;
 
   float eMax(const l1t::HGCalMulticluster& c3d) const;
 
+  float meanZ(const l1t::HGCalMulticluster& c3d) const;
   float sigmaZZ(const l1t::HGCalMulticluster& c3d) const;
 
   float sigmaEtaEtaTot(const l1t::HGCalMulticluster& c3d) const;

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <unordered_map>
+#include <numeric>
 
 HGCalShowerShape::HGCalShowerShape(const edm::ParameterSet& conf)
     : threshold_(conf.existsAs<double>("shape_threshold") ? conf.getParameter<double>("shape_threshold") : 0.) {}
@@ -100,6 +101,71 @@ int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d,
       maxlength = length;
   }
   return maxlength;
+}
+
+float HGCalShowerShape::percentileLayer(const l1t::HGCalMulticluster& c3d,
+                                        const HGCalTriggerGeometryBase& triggerGeometry,
+                                        float quantile) const {
+  const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>& clustersPtrs = c3d.constituents();
+  unsigned nlayers = triggerTools_.layers(ForwardSubdetector::ForwardEmpty);
+  std::vector<double> layers(nlayers, 0);
+  for (const auto& id_clu : clustersPtrs) {
+    const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
+
+    for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
+      unsigned layer = triggerGeometry.triggerLayer(id_tc.second->detId());
+      if (layer == 0 || layer > nlayers)
+        continue;
+      layers[layer - 1] += id_tc.second->pt();  //layer 0 doesn't exist, so shift by -1
+    }
+  }
+  std::partial_sum(layers.begin(), layers.end(), layers.begin());
+  double pt_threshold = layers.back() * quantile;
+  int percentile = 0;
+  for (double pt : layers) {
+    if (pt > pt_threshold) {
+      break;
+    }
+    percentile++;
+  }
+  // Linear interpolation of percentile value
+  double pt0 = (percentile > 0 ? layers[percentile - 1] : 0.);
+  double pt1 = layers[percentile];
+  return percentile + (pt1 - pt0 > 0. ? (pt_threshold - pt0) / (pt1 - pt0) : 0.);
+}
+
+float HGCalShowerShape::percentileTriggerCells(const l1t::HGCalMulticluster& c3d, float quantile) const {
+  const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>& clustersPtrs = c3d.constituents();
+  std::set<double> ordered_tcs;
+  double pt_sum = 0.;
+  for (const auto& id_clu : clustersPtrs) {
+    const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
+
+    for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
+      ordered_tcs.emplace(id_tc.second->pt());
+      pt_sum += id_tc.second->pt();
+    }
+  }
+  double pt_threshold = pt_sum * quantile;
+  double partial_sum = 0.;
+  double partial_sum_prev = 0.;
+  int ntc = 0;
+  for (auto itr = ordered_tcs.rbegin(); itr != ordered_tcs.rend(); ++itr) {
+    partial_sum_prev = partial_sum;
+    partial_sum += *itr;
+    ntc++;
+    if (partial_sum > pt_threshold) {
+      break;
+    }
+  }
+  // Linear interpolation of ntc
+  return ntc - 1 +
+         (partial_sum - partial_sum_prev > 0. ? (pt_threshold - partial_sum_prev) / (partial_sum - partial_sum_prev)
+                                              : 0.);
 }
 
 float HGCalShowerShape::sigmaEtaEtaTot(const l1t::HGCalMulticluster& c3d) const {
@@ -343,6 +409,24 @@ float HGCalShowerShape::eMax(const l1t::HGCalMulticluster& c3d) const {
   return EMax;
 }
 
+float HGCalShowerShape::meanZ(const l1t::HGCalMulticluster& c3d) const {
+  const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>& clustersPtrs = c3d.constituents();
+
+  std::vector<std::pair<float, float>> tc_energy_z;
+
+  for (const auto& id_clu : clustersPtrs) {
+    const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
+
+    for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
+      tc_energy_z.emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->position().z()));
+    }
+  }
+
+  return meanX(tc_energy_z);
+}
+
 float HGCalShowerShape::sigmaZZ(const l1t::HGCalMulticluster& c3d) const {
   const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>& clustersPtrs = c3d.constituents();
 
@@ -431,4 +515,10 @@ void HGCalShowerShape::fillShapes(l1t::HGCalMulticluster& c3d, const HGCalTrigge
   c3d.sigmaRRMax(sigmaRRMax(c3d));
   c3d.sigmaRRMean(sigmaRRMean(c3d));
   c3d.eMax(eMax(c3d));
+  c3d.zBarycenter(meanZ(c3d));
+  c3d.layer10percent(percentileLayer(c3d, triggerGeometry, 0.10));
+  c3d.layer50percent(percentileLayer(c3d, triggerGeometry, 0.50));
+  c3d.layer90percent(percentileLayer(c3d, triggerGeometry, 0.90));
+  c3d.triggerCells67percent(percentileTriggerCells(c3d, 0.67));
+  c3d.triggerCells90percent(percentileTriggerCells(c3d, 0.90));
 }

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -42,6 +42,13 @@ private:
   std::vector<float> cl3d_srrmax_;
   std::vector<float> cl3d_srrmean_;
   std::vector<float> cl3d_emaxe_;
+  std::vector<float> cl3d_hoe_;
+  std::vector<float> cl3d_meanz_;
+  std::vector<float> cl3d_layer10_;
+  std::vector<float> cl3d_layer50_;
+  std::vector<float> cl3d_layer90_;
+  std::vector<float> cl3d_ntc67_;
+  std::vector<float> cl3d_ntc90_;
   std::vector<float> cl3d_bdteg_;
   std::vector<int> cl3d_quality_;
 };
@@ -91,6 +98,13 @@ void HGCalTriggerNtupleHGCMulticlusters::initialize(TTree& tree,
   tree.Branch(withPrefix("srrmax"), &cl3d_srrmax_);
   tree.Branch(withPrefix("srrmean"), &cl3d_srrmean_);
   tree.Branch(withPrefix("emaxe"), &cl3d_emaxe_);
+  tree.Branch(withPrefix("hoe"), &cl3d_hoe_);
+  tree.Branch(withPrefix("meanz"), &cl3d_meanz_);
+  tree.Branch(withPrefix("layer10"), &cl3d_layer10_);
+  tree.Branch(withPrefix("layer50"), &cl3d_layer50_);
+  tree.Branch(withPrefix("layer90"), &cl3d_layer90_);
+  tree.Branch(withPrefix("ntc67"), &cl3d_ntc67_);
+  tree.Branch(withPrefix("ntc90"), &cl3d_ntc90_);
   tree.Branch(withPrefix("bdteg"), &cl3d_bdteg_);
   tree.Branch(withPrefix("quality"), &cl3d_quality_);
 }
@@ -128,6 +142,13 @@ void HGCalTriggerNtupleHGCMulticlusters::fill(const edm::Event& e, const edm::Ev
     cl3d_srrmax_.emplace_back(cl3d_itr->sigmaRRMax());
     cl3d_srrmean_.emplace_back(cl3d_itr->sigmaRRMean());
     cl3d_emaxe_.emplace_back(cl3d_itr->eMax() / cl3d_itr->energy());
+    cl3d_hoe_.emplace_back(cl3d_itr->hOverE());
+    cl3d_meanz_.emplace_back(std::abs(cl3d_itr->zBarycenter()));
+    cl3d_layer10_.emplace_back(cl3d_itr->layer10percent());
+    cl3d_layer50_.emplace_back(cl3d_itr->layer50percent());
+    cl3d_layer90_.emplace_back(cl3d_itr->layer90percent());
+    cl3d_ntc67_.emplace_back(cl3d_itr->triggerCells67percent());
+    cl3d_ntc90_.emplace_back(cl3d_itr->triggerCells90percent());
     cl3d_bdteg_.emplace_back(id_->value(*cl3d_itr));
     cl3d_quality_.emplace_back(cl3d_itr->hwQual());
 
@@ -174,6 +195,13 @@ void HGCalTriggerNtupleHGCMulticlusters::clear() {
   cl3d_srrmax_.clear();
   cl3d_srrmean_.clear();
   cl3d_emaxe_.clear();
+  cl3d_hoe_.clear();
+  cl3d_meanz_.clear();
+  cl3d_layer10_.clear();
+  cl3d_layer50_.clear();
+  cl3d_layer90_.clear();
+  cl3d_ntc67_.clear();
+  cl3d_ntc90_.clear();
   cl3d_bdteg_.clear();
   cl3d_quality_.clear();
 }


### PR DESCRIPTION
Related to #296.
Add the following cluster shape variables:
- z barycenter
- Longitudinal percentiles (10%, 50%, 90%) in trigger layer units
- Numbers of trigger cells containing more than X% of the energy (X=67 and 90)

Add also H/E in the ntuples.