### PR TITLE
Add framework for multiple energy interpretations of 3D clusters and implement EM one

### DIFF
--- a/DataFormats/L1THGCal/BuildFile.xml
+++ b/DataFormats/L1THGCal/BuildFile.xml
@@ -6,6 +6,8 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Utilities"/>
 <use   name="rootrflx"/>
+<use   name="boost"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1THGCal/interface/HGCalMulticluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalMulticluster.h
@@ -5,6 +5,8 @@
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "DataFormats/L1THGCal/interface/HGCalClusterT.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include <boost/iterator/transform_iterator.hpp>
+#include <functional>
 
 namespace l1t {
 
@@ -13,7 +15,7 @@ namespace l1t {
     HGCalMulticluster() : hOverEValid_(false) {}
     HGCalMulticluster(const LorentzVector p4, int pt = 0, int eta = 0, int phi = 0);
 
-    HGCalMulticluster(const edm::Ptr<l1t::HGCalCluster> &tc, float fraction = 1);
+    HGCalMulticluster(const edm::Ptr<l1t::HGCalCluster>& tc, float fraction = 1);
 
     ~HGCalMulticluster() override;
 
@@ -31,9 +33,63 @@ namespace l1t {
       hOverEValid_ = true;
     }
 
+    enum EnergyInterpretation { EM = 0 };
+
+    void saveEnergyInterpretation(const HGCalMulticluster::EnergyInterpretation eInt, double energy);
+
+    double iEnergy(const HGCalMulticluster::EnergyInterpretation eInt) const {
+      return energy() * interpretationFraction(eInt);
+    }
+
+    double iPt(const HGCalMulticluster::EnergyInterpretation eInt) const { return pt() * interpretationFraction(eInt); }
+
+    math::XYZTLorentzVector iP4(const HGCalMulticluster::EnergyInterpretation eInt) const {
+      return p4() * interpretationFraction(eInt);
+    }
+
+    math::PtEtaPhiMLorentzVector iPolarP4(const HGCalMulticluster::EnergyInterpretation eInt) const {
+      return math::PtEtaPhiMLorentzVector(pt() * interpretationFraction(eInt), eta(), phi(), 0.);
+    }
+
   private:
+    template <typename Iter>
+    struct KeyGetter : std::unary_function<typename Iter::value_type, typename Iter::value_type::first_type> {
+      const typename Iter::value_type::first_type& operator()(const typename Iter::value_type& p) const {
+        return p.first;
+      }
+    };
+
+    template <typename Iter>
+    boost::transform_iterator<KeyGetter<Iter>, Iter> key_iterator(Iter itr) const {
+      return boost::make_transform_iterator<KeyGetter<Iter>, Iter>(itr, KeyGetter<Iter>());
+    }
+
+  public:
+    typedef boost::transform_iterator<KeyGetter<std::map<EnergyInterpretation, double>::const_iterator>,
+                                      std::map<EnergyInterpretation, double>::const_iterator>
+        EnergyInterpretation_const_iterator;
+
+    std::pair<EnergyInterpretation_const_iterator, EnergyInterpretation_const_iterator> energyInterpretations() const {
+      return std::make_pair(key_iterator(energyInterpretationFractions_.cbegin()),
+                            key_iterator(energyInterpretationFractions_.cend()));
+    }
+
+    EnergyInterpretation_const_iterator interpretations_begin() const {
+      return key_iterator(energyInterpretationFractions_.cbegin());
+    }
+
+    EnergyInterpretation_const_iterator interpretations_end() const {
+      return key_iterator(energyInterpretationFractions_.cend());
+    }
+
+    size_type interpretations_size() const { return energyInterpretationFractions_.size(); }
+
+  private:
+    double interpretationFraction(const HGCalMulticluster::EnergyInterpretation eInt) const;
+
     float hOverE_;
     bool hOverEValid_;
+    std::map<EnergyInterpretation, double> energyInterpretationFractions_;
   };
 
   typedef BXVector<HGCalMulticluster> HGCalMulticlusterBxCollection;

--- a/DataFormats/L1THGCal/src/HGCalMulticluster.cc
+++ b/DataFormats/L1THGCal/src/HGCalMulticluster.cc
@@ -9,3 +9,16 @@ HGCalMulticluster::HGCalMulticluster(const edm::Ptr<l1t::HGCalCluster> &clusterS
     : HGCalClusterT<l1t::HGCalCluster>(clusterSeed, fraction), hOverE_(-99), hOverEValid_(false) {}
 
 HGCalMulticluster::~HGCalMulticluster() {}
+
+void HGCalMulticluster::saveEnergyInterpretation(const HGCalMulticluster::EnergyInterpretation eInt, double energy) {
+  energyInterpretationFractions_[eInt] = energy / this->energy();
+}
+
+double HGCalMulticluster::interpretationFraction(const HGCalMulticluster::EnergyInterpretation eInt) const {
+  auto intAndEnergyFraction = energyInterpretationFractions_.find(eInt);
+  if (intAndEnergyFraction == energyInterpretationFractions_.end()) {
+    // NOTE: this is an arbitary choice: we return the default cluster energy if this interpreation is not available!
+    return 1;
+  }
+  return intAndEnergyFraction->second;
+}

--- a/DataFormats/L1THGCal/src/classes.h
+++ b/DataFormats/L1THGCal/src/classes.h
@@ -64,5 +64,6 @@ namespace DataFormats {
     edm::Wrapper<edm::PtrVector<l1t::HGCalCluster>> w_hgcalClusterList;
 
     l1t::ClusterShapes clusterShapes;
+    std::map<l1t::HGCalMulticluster::EnergyInterpretation, double> ei;
   }  // namespace L1THGCal
 }  // namespace DataFormats

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -46,7 +46,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
 
-  <class name="l1t::HGCalMulticluster" ClassVersion="18">
+  <class name="l1t::HGCalMulticluster" ClassVersion="19">
+   <version ClassVersion="19" checksum="3914904215"/>
    <version ClassVersion="18" checksum="1001614855"/>
    <version ClassVersion="17" checksum="460658789"/>
   <version ClassVersion="16" checksum="1276395758"/>
@@ -71,7 +72,7 @@
   <class name="std::vector<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalTriggerCellBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTriggerCellBxCollection>"/>
-  
+
   <class name="l1t::HGCalTriggerSums" ClassVersion="12">
    <version ClassVersion="12" checksum="1802885417"/>
     <version ClassVersion="11" checksum="4058188392"/>
@@ -104,5 +105,6 @@
   <class name="edm::Wrapper<edm::PtrVector<l1t::HGCalTowerMap>>"/>
 
   <class name="l1t::ClusterShapes"/>
+  <class name="std::map<l1t::HGCalMulticluster::EnergyInterpretation, double>"/>
 
 </lcgdict>

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -79,6 +79,7 @@ public:
 
   DetId simToReco(const DetId&, const HGCalTopology&) const;
   DetId simToReco(const DetId&, const HcalTopology&) const;
+  unsigned triggerLayer(const unsigned id) const { return geom_->triggerLayer(id); }
 
 private:
   const HGCalTriggerGeometryBase* geom_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h
@@ -1,0 +1,22 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTriggerClusterInterpreterBase_h__
+#define __L1Trigger_L1THGCal_HGCalTriggerClusterInterpreterBase_h__
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+
+class HGCalTriggerClusterInterpreterBase {
+public:
+  HGCalTriggerClusterInterpreterBase(){};
+  virtual ~HGCalTriggerClusterInterpreterBase(){};
+  virtual void initialize(const edm::ParameterSet& conf) = 0;
+  virtual void eventSetup(const edm::EventSetup& es) = 0;
+  virtual void interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const = 0;
+};
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory<HGCalTriggerClusterInterpreterBase*()> HGCalTriggerClusterInterpreterFactory;
+
+#define DEFINE_HGC_TPG_CLUSTER_INTERPRETER(type, name) \
+  DEFINE_EDM_PLUGIN(HGCalTriggerClusterInterpreterFactory, type, name)
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
@@ -8,6 +8,7 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalMulticlusteringImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h"
 
 class HGCalBackendLayer2Processor3DClustering : public HGCalBackendLayer2ProcessorBase {
 public:
@@ -27,6 +28,13 @@ public:
           conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_clustering_parameters"));
     } else {
       throw cms::Exception("HGCTriggerParameterError") << "Unknown Multiclustering type '" << typeMulticluster << "'";
+    }
+
+    for (auto interpretationPset : conf.getParameter<std::vector<edm::ParameterSet>>("energy_interpretations")) {
+      std::unique_ptr<HGCalTriggerClusterInterpreterBase> interpreter{
+          HGCalTriggerClusterInterpreterFactory::get()->create(interpretationPset.getParameter<std::string>("type"))};
+      interpreter->initialize(interpretationPset);
+      energy_interpreters_.push_back(std::move(interpreter));
     }
   }
 
@@ -68,6 +76,12 @@ public:
         // Should not happen, clustering type checked in constructor
         break;
     }
+
+    // Call all the energy interpretation modules on the cluster collection
+    for (const auto& interpreter : energy_interpreters_) {
+      interpreter->eventSetup(es);
+      interpreter->interpret(collCluster3D);
+    }
   }
 
 private:
@@ -82,6 +96,8 @@ private:
 
   /* algorithm type */
   MulticlusterType multiclusteringAlgoType_;
+
+  std::vector<std::unique_ptr<HGCalTriggerClusterInterpreterBase>> energy_interpreters_;
 };
 
 DEFINE_EDM_PLUGIN(HGCalBackendLayer2Factory,

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterInterpretationEM.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterInterpretationEM.cc
@@ -1,0 +1,65 @@
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerClusterInterpretationEM : public HGCalTriggerClusterInterpreterBase {
+public:
+  HGCalTriggerClusterInterpretationEM();
+  ~HGCalTriggerClusterInterpretationEM() override{};
+  void initialize(const edm::ParameterSet& conf) final;
+  void eventSetup(const edm::EventSetup& es) final;
+  void interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const final;
+
+private:
+  std::vector<double> layer_containment_corrs_;
+  std::vector<double> scale_corrections_coeff_;
+  std::vector<double> dr_bylayer_;
+
+  HGCalTriggerTools triggerTools_;
+};
+
+DEFINE_HGC_TPG_CLUSTER_INTERPRETER(HGCalTriggerClusterInterpretationEM, "HGCalTriggerClusterInterpretationEM");
+
+HGCalTriggerClusterInterpretationEM::HGCalTriggerClusterInterpretationEM() {}
+
+void HGCalTriggerClusterInterpretationEM::initialize(const edm::ParameterSet& conf) {
+  layer_containment_corrs_ = conf.getParameter<std::vector<double>>("layer_containment_corrs");
+  scale_corrections_coeff_ = conf.getParameter<std::vector<double>>("scale_correction_coeff");
+  dr_bylayer_ = conf.getParameter<std::vector<double>>("dr_bylayer");
+
+  if (scale_corrections_coeff_.size() != 2) {
+    throw cms::Exception("HGCTriggerParameterError")
+        << "HGCalTriggerClusterInterpretationEM::scale_correction_coeff parameter has size: "
+        << scale_corrections_coeff_.size() << " while expected is 2";
+  }
+  if (layer_containment_corrs_.size() != dr_bylayer_.size()) {
+    throw cms::Exception("HGCTriggerParameterError")
+        << "HGCalTriggerClusterInterpretationEM::layer_containment_corrs and "
+           "HGCalTriggerClusterInterpretationEM::dr_bylayer have different size!";
+  }
+}
+
+void HGCalTriggerClusterInterpretationEM::eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+void HGCalTriggerClusterInterpretationEM::interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const {
+  for (unsigned int idx = 0; idx != multiclusters.size(); idx++) {
+    l1t::HGCalMulticluster& cluster3d = multiclusters[idx];
+
+    const GlobalPoint& cluster3d_position = cluster3d.centreProj();
+    double energy = 0.;
+
+    for (const auto& cluster2d : cluster3d.constituents()) {
+      const unsigned layer = triggerTools_.triggerLayer(cluster2d.first);
+      if (layer <= layer_containment_corrs_.size() - 1) {
+        double dr = (cluster3d_position - cluster2d.second->centreProj()).mag();
+        if (dr <= dr_bylayer_.at(layer)) {
+          energy += layer_containment_corrs_.at(layer) * cluster2d.second->energy();
+        }
+      }
+    }
+    energy += scale_corrections_coeff_.at(1) * fabs(cluster3d.eta()) + scale_corrections_coeff_.at(0);
+    cluster3d.saveEnergyInterpretation(l1t::HGCalMulticluster::EnergyInterpretation::EM, max(energy, 0.));
+  }
+}

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -9,6 +9,7 @@ from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_c
                                                     egamma_identification_histomax
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 
 
 binSums = cms.vuint32(13,               # 0
@@ -56,7 +57,7 @@ seed_smoothing_hcal = cms.vdouble(
         1., 1., 1., 1., 1.,
         1., 1., 2., 1., 1.,
         1., 1., 1., 1., 1.,
-        1., 1., 1., 1., 1., 
+        1., 1., 1., 1., 1.,
         )
 
 
@@ -142,8 +143,24 @@ histoMax_C3d_params = cms.PSet(
         histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone(),
         )
 
+
+energy_interpretations_em = cms.PSet(type = cms.string('HGCalTriggerClusterInterpretationEM'),
+                                     layer_containment_corrs = cms.vdouble(0., 0., 1.6144949, 0.92495334, 1.0820811, 0.9753549, 0.9742881, 1.0634482, 1.0599478, 0.9376349, 0.92587173, 0.8003076, 1.0417082, 1.7032381, 2.),
+                                     scale_correction_coeff = cms.vdouble(16.68182373, -8.487143517),
+                                     dr_bylayer = cms.vdouble([0.015]*15)
+                                     )
+
+phase2_hgcalV10.toModify(energy_interpretations_em,
+                         layer_containment_corrs=cms.vdouble(0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.),
+                         scale_correction_coeff=cms.vdouble(0., 0.),
+                         )
+
+
+energy_interpretations = cms.VPSet(energy_interpretations_em)
+
 be_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer2Processor3DClustering'),
-                   C3d_parameters = histoMax_C3d_params.clone()
+                   C3d_parameters = histoMax_C3d_params.clone(),
+                   energy_interpretations = energy_interpretations
                    )
 
 hgcalBackEndLayer2Producer = cms.EDProducer(

--- a/L1Trigger/L1THGCal/src/backend/HGCalTriggerClusterInterpreterBase.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTriggerClusterInterpreterBase.cc
@@ -1,0 +1,3 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h"
+
+EDM_REGISTER_PLUGINFACTORY(HGCalTriggerClusterInterpreterFactory, "HGCalTriggerClusterInterpreterFactory");

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -81,7 +81,8 @@ ntuple_multiclusters = cms.PSet(
     NtupleName = cms.string('HGCalTriggerNtupleHGCMulticlusters'),
     Multiclusters = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'),
     EGIdentification = egamma_identification_histomax.clone(),
-    FillLayerInfo = cms.bool(False)
+    FillLayerInfo = cms.bool(False),
+    FillInterpretationInfo = cms.bool(True)
 )
 
 ntuple_panels = cms.PSet(


### PR DESCRIPTION
This PR modifies the Multicluster dataformat adding the possibility of having different energy/momentum values according to some "interpretation".

The different interpretations are provided via a plugin factory and can be steered via configuration.

One concrete implementation is also implemented for EM particles, using a smaller dr for the energy evaluation, correcting for the energy containemnt layer by layer and a global scale (eta dependent) calibrated at PU200.

**NOTE I:** the interpretations are indexed by an enum which is defined in the dataformat.

**NOTE II**: asking for an interpretation which has not been computed for a given cluster silently results in getting the full energy of the cluster.

**NOTE III**: the EM interpretation is computed for all clusters independently on their quality.




