### PR TITLE
HGCSample: fixes and improvements

### DIFF
--- a/DataFormats/HGCDigi/bin/HGCSampleTest.cpp
+++ b/DataFormats/HGCDigi/bin/HGCSampleTest.cpp
@@ -6,6 +6,8 @@
 // run for instance with:
 //
 //                         time HGCSampleTest  10000000000
+//                         time HGCSampleTest  1000000000 => 14 sec ; 11 sec after restructuring set()
+//                         time HGCSampleTest  10000000000    y   [to require randomisation]
 //
 // for a measureble amount of time taken
 
@@ -15,53 +17,81 @@ int main(int argc, char** argv) {
   std::cout << "Basic performance tests for HGCSample\n" << std::endl;
   std::cout << "num parameters entered: " << argc << std::endl;
 
+
   // first command line argument is the number of trials
   unsigned long int repetitions = 100;
   if (argc>1) repetitions  =  std::stoul (argv[1],nullptr,0);
+  std::cout << "\t + repetitions [int]: " << repetitions << std::endl;
   // second command line argument (whatever it is) will activate
   //                  the random choice of values for all inputs
   bool generateRandomValues = (argc > 2 ? true: false);
+  std::cout << "\t + generateRandomValues [true/false]: " << generateRandomValues << "\n" << std::endl;
 
 
-  uint32_t adc    = 124;
-  uint32_t gain   = 1;
-  uint32_t thrADC = 995;
 
-  bool     thr    = adc > thrADC;
-  uint32_t toa    = 0;
-  bool     mode   = false;
+  // init static values
+  uint32_t adc      = 124;
+  uint32_t gain     = 1;
+  uint32_t thrADC   = 900;
+  bool     thr      = adc > thrADC;
+  uint32_t toa      = 0;
+  bool     mode     = false;
+  bool     toaFired = true;
 
-
-  // do the trials
+  // do the trials: time/performance test and exploit randomisation to check
   unsigned long int u =0;
   for( ; u<repetitions; u++)
     {
-      HGCSample aSample;
-
       // randomise all inputs, if chosen at the command line
       if(generateRandomValues){
-	adc    = rand() %4046;
-	gain   = rand() %4;
-	thrADC = rand() %2;
-	mode   = rand() %2;
-	toa    = rand() %1024;
-	std::cout << adc << "\t" << mode << std::endl;
+	adc       = rand() %1024;
+	toa       = rand() %1024;
+	gain      = rand() %4;
+	mode      = rand() %2;
+	thr       = rand() %2;
+	toaFired  = rand() %2;
       }
 
 
+      HGCSample aSample;
       // writing on an empty container first
       aSample.set(thr, mode, gain, toa, adc);
-      assert( thr  == aSample.threshold() );
-      assert( mode == aSample.mode() );
-      assert( toa  == aSample.toa() );
-      assert( adc  == aSample.data() );      
-      
+      aSample.setToAValid(toaFired);
+      // check the values that went in also come out
+      assert( thr      == aSample.threshold() );
+      assert( mode     == aSample.mode() );
+      assert( toa      == aSample.toa() );
+      assert( gain     == aSample.gain() );
+      assert( adc      == aSample.data() );
+      assert( thr      == aSample.threshold() );
+      assert( toaFired == aSample.getToAValid() );
+
+      // std::cout << aSample.raw() << "\t" << thr << "\t" << mode  << "\t" << toaFired 
+      // << "\t" << gain << "\t" << toa << "\t" << adc << std::endl;
+
+      HGCSample ASample;
+      ASample.setThreshold(thr);
+      ASample.setMode(mode);
+      ASample.setGain(gain);
+      ASample.setToA(toa);
+      ASample.setData(adc);
+      ASample.setToAValid(toaFired);
+      // check that using the individual setters yields the same result as the generic set
+      assert( ASample.threshold()   == aSample.threshold() );
+      assert( ASample.mode()        == aSample.mode() );
+      assert( ASample.gain()        == aSample.gain() );
+      assert( ASample.toa()         == aSample.toa() );
+      assert( ASample.data()        == aSample.data() );
+      assert( ASample.getToAValid() == aSample.getToAValid() );
+
+
       HGCSample bSample;
       bSample.setThreshold(thr);
       bSample.setMode(mode);
       bSample.setGain(gain+100);
       bSample.setToA(toa+100);
       bSample.setData(adc+100);
+      bSample.setToAValid(toaFired);
 
       // cover the case where we write on a container with numbers already set
       bSample.setThreshold(thr);
@@ -69,15 +99,17 @@ int main(int argc, char** argv) {
       bSample.setGain(gain);
       bSample.setToA(toa);
       bSample.setData(adc);
-      assert( thr  == aSample.threshold() &&  thr  == bSample.threshold() );
-      assert( mode == aSample.mode()      &&  mode == bSample.mode() );
-      assert( gain == aSample.gain()      &&  gain == bSample.gain() );
-      assert( toa  == aSample.toa()       &&  toa  == bSample.toa() );
-      assert( adc  == aSample.data()      &&  adc  == bSample.data() );
+      bSample.setToAValid(toaFired);
+      assert( thr      == aSample.threshold()    &&  thr       == bSample.threshold() );
+      assert( mode     == aSample.mode()         &&  mode      == bSample.mode() );
+      assert( gain     == aSample.gain()         &&  gain      == bSample.gain() );
+      assert( toa      == aSample.toa()          &&  toa       == bSample.toa() );
+      assert( adc      == aSample.data()         &&  adc       == bSample.data() );
+      assert( toaFired == aSample.getToAValid()  &&  toaFired  == bSample.getToAValid() );
 
     }  
 
-  std::cout << "\nDone " << repetitions << "\t" << u<< ", ciao" << std::endl;
+  std::cout << "\nDone " << repetitions << "\t" << u << std::endl;
 
   return 0;
 }

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -36,18 +36,13 @@ public:
 
   // GF: why do we not use setWord for this case ??
   void set(bool thr, bool mode, uint16_t gain, uint16_t toa, uint16_t data) {
-
-    // std::cout << "GF HGCSample - in the set method " << std::endl;
-    gain = (gain > (uint16_t)kGainMask ? (uint16_t)kGainMask : gain);
-    toa = (toa > (uint16_t)kToAMask ? (uint16_t)kToAMask : toa);
-    data = (data > (uint16_t)kDataMask ? (uint16_t)kDataMask : data);
-
-    value_ = (((uint32_t)thr  & kThreshMask) << kThreshShift |
-	      ((uint32_t)mode & kModeMask)   << kModeShift   |
-              ((uint32_t)gain & kGainMask)   << kToGainShift |
-              ((uint32_t)toa  & kToAMask)    << kToAShift    |
-	      ((uint32_t)data & kDataMask)   << kDataShift);
+    setThreshold(thr);
+    setMode(mode);
+    setGain(gain);
+    setToA(toa);
+    setData(data);
   }
+
   void print(std::ostream& out = std::cout) {
     out << "THR: " << threshold() << " Mode: " << mode() << " ToA: " << toa() << " Data: " << data() << " Raw=0x"
         << std::hex << raw() << std::dec << std::endl;
@@ -71,16 +66,20 @@ private:
    */
   void setWord(uint32_t word, uint32_t mask, uint32_t pos) {
 
+    // deal with saturation: set to mask 
+    // should we throw ?
     word = ( mask > word  ?  word : mask );
-    // deal with saturation: should we throw ?
-
-    //clear required bits
     // std::cout <<  "word: " << word << "  mask: " << mask <<  " pos: " << pos << std::endl;
+
+    // mask (not strictly needed) and shift
     const uint32_t masked_word = (word & mask) << pos;
     //std::cout <<  "\t masked_word " << masked_word << std::endl;
+
+    //clear to 0  bits which will be set
     value_ &= ~(mask << pos);
     // std::cout <<  "\t value tmp " << value_ << std::endl;
-    //now set the new value
+
+    //now set bits
     value_ |= (masked_word);
     //std::cout <<  "\t value " << value_ << std::endl;
   }

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -13,7 +13,7 @@
 class HGCSample {
 public:
   enum HGCSampleMasks  { kThreshMask  = 0x1, kModeMask  = 0x1, kGainMask    = 0x3,   kToAMask  = 0x3ff, kDataMask  = 0x3ff };
-  enum HGCSampleShifts { kThreshShift = 31,  kModeShift = 30,  kToGainShift = 21,    kToAShift = 11,    kDataShift = 0 };
+  enum HGCSampleShifts { kThreshShift = 31,  kModeShift = 30,  kToGainShift = 20,    kToAShift = 10,    kDataShift = 0 };
 
   /**
      @short CTOR
@@ -70,8 +70,10 @@ private:
      @short wrapper to reset words at a given position
    */
   void setWord(uint32_t word, uint32_t mask, uint32_t pos) {
-    if (word > mask)
-      word = mask;  // deal with saturation - should we throw ?
+
+    word = ( mask > word  ?  word : mask );
+    // deal with saturation: should we throw ?
+
     //clear required bits
     // std::cout <<  "word: " << word << "  mask: " << mask <<  " pos: " << pos << std::endl;
     const uint32_t masked_word = (word & mask) << pos;

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -55,12 +55,12 @@ public:
      @short getters
   */
   uint32_t raw() const { return value_; }
-  bool     threshold() const { return ((value_ >> kThreshShift) & kThreshMask); }
-  bool     mode() const { return ((value_ >> kModeShift) & kModeMask); }
-  uint32_t gain() const { return ((value_ >> kToGainShift) & kGainMask); }
-  uint32_t toa() const { return ((value_ >> kToAShift) & kToAMask); }
-  uint32_t data() const { return ((value_ >> kDataShift) & kDataMask); }
-  bool     getToAValid() const { return ((value_ >> kToAValidShift) & kToAValidMask); }
+  bool     threshold() const { return getWord(kThreshMask, kThreshShift); }
+  bool     mode() const { return getWord(kModeMask, kModeShift); }
+  uint32_t gain() const { return getWord(kGainMask, kToGainShift); }
+  uint32_t toa() const { return getWord(kToAMask, kToAShift); }
+  uint32_t data() const { return getWord(kDataMask, kDataShift); }
+  bool     getToAValid() const { return getWord(kToAValidMask, kToAValidShift); }
   uint32_t operator()() { return value_; }
 
 
@@ -68,24 +68,24 @@ private:
   /**
      @short wrapper to reset words at a given position
    */
-  void setWord(uint32_t word, uint32_t mask, uint32_t pos) {
+  void setWord(uint32_t word, uint32_t mask, uint32_t shift) {
 
     // deal with saturation: set to mask 
     // should we throw ?
     word = ( mask > word  ?  word : mask );
 
     // mask (not strictly needed) and shift
-    const uint32_t masked_word = (word & mask) << pos;
+    const uint32_t masked_word = (word & mask) << shift;
 
-    //clear to 0  bits which will be set
-    value_ &= ~(mask << pos);
+    //clear to 0  bits which will be set by word
+    value_ &= ~(mask << shift);
 
     //now set bits
     value_ |= (masked_word);
   }
 
-  uint32_t getWord(uint32_t mask, uint32_t pos) {
-    return ((value_ >> pos) & mask);
+  uint32_t getWord(uint32_t mask, uint32_t shift) const {
+    return ((value_ >> shift) & mask);
   }
 
   // a 32-bit word

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -12,8 +12,8 @@
 
 class HGCSample {
 public:
-  enum HGCSampleMasks  { kThreshMask  = 0x1, kModeMask  = 0x1, kGainMask    = 0x3,   kToAMask  = 0x3ff, kDataMask  = 0xfff };
-  enum HGCSampleShifts { kThreshShift = 31,  kModeShift = 30,  kToGainShift = 23,    kToAShift = 13,    kDataShift = 0 };
+  enum HGCSampleMasks  { kThreshMask  = 0x1, kModeMask  = 0x1, kGainMask    = 0x3,   kToAMask  = 0x3ff, kDataMask  = 0x3ff };
+  enum HGCSampleShifts { kThreshShift = 31,  kModeShift = 30,  kToGainShift = 21,    kToAShift = 11,    kDataShift = 0 };
 
   /**
      @short CTOR

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -20,7 +20,7 @@ public:
 
   /**
      @short CTOR
-   */
+  */
 
  HGCSample() : value_(0) { }
  HGCSample(uint32_t value) : value_(value) { }
@@ -28,17 +28,17 @@ public:
 
   /**
      @short setters
-   */
+  */
 
-  // GF indentation
-  void setThreshold(bool thr) { setWord(thr, kThreshMask, kThreshShift); }
-  void setMode(bool mode) { setWord(mode, kModeMask, kModeShift); }
-  void setGain(uint16_t gain) { setWord(gain, kGainMask, kToGainShift); }
-  void setToA(uint16_t toa) { setWord(toa, kToAMask, kToAShift); }
-  void setData(uint16_t data) { setWord(data, kDataMask, kDataShift); }
+  void setThreshold(bool thr)     { setWord(thr, kThreshMask, kThreshShift); }
+  void setMode(bool mode)         { setWord(mode, kModeMask, kModeShift); }
+  void setGain(uint16_t gain)     { setWord(gain, kGainMask, kToGainShift); }
+  void setToA(uint16_t toa)       { setWord(toa, kToAMask, kToAShift); }
+  void setData(uint16_t data)     { setWord(data, kDataMask, kDataShift); }
   void setToAValid(bool toaFired) { setWord(toaFired, kToAValidMask, kToAValidShift); }
 
-  void set(bool thr, bool mode, uint16_t gain, uint16_t toa, uint16_t data) {
+  void set(bool thr, bool mode, uint16_t gain,
+	   uint16_t toa, uint16_t data) {
     setThreshold(thr);
     setMode(mode);
     setGain(gain);
@@ -47,27 +47,28 @@ public:
   }
 
   void print(std::ostream& out = std::cout) {
-    out << "THR: " << threshold() << " Mode: " << mode() << " ToA: " << toa() << " Data: " << data() << " Raw=0x"
+    out << "THR: " << threshold() << " Mode: " << mode() 
+	<< " ToA: " << toa() << " Data: " << data() << " Raw=0x"
         << std::hex << raw() << std::dec << std::endl;
   }
 
   /**
      @short getters
   */
-  uint32_t raw() const { return value_; }
-  bool     threshold() const { return getWord(kThreshMask, kThreshShift); }
-  bool     mode() const { return getWord(kModeMask, kModeShift); }
-  uint32_t gain() const { return getWord(kGainMask, kToGainShift); }
-  uint32_t toa() const { return getWord(kToAMask, kToAShift); }
-  uint32_t data() const { return getWord(kDataMask, kDataShift); }
+  uint32_t raw()         const { return value_; }
+  bool     threshold()   const { return getWord(kThreshMask, kThreshShift); }
+  bool     mode()        const { return getWord(kModeMask, kModeShift); }
+  uint32_t gain()        const { return getWord(kGainMask, kToGainShift); }
+  uint32_t toa()         const { return getWord(kToAMask, kToAShift); }
+  uint32_t data()        const { return getWord(kDataMask, kDataShift); }
   bool     getToAValid() const { return getWord(kToAValidMask, kToAValidShift); }
   uint32_t operator()() { return value_; }
 
 
-private:
+ private:
   /**
      @short wrapper to reset words at a given position
-   */
+  */
   void setWord(uint32_t word, uint32_t mask, uint32_t shift) {
 
     // deal with saturation: set to mask 

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -21,7 +21,6 @@ public:
   /**
      @short CTOR
   */
-
  HGCSample() : value_(0) { }
  HGCSample(uint32_t value) : value_(value) { }
  HGCSample(const HGCSample& o) : value_(o.value_) { }
@@ -29,7 +28,6 @@ public:
   /**
      @short setters
   */
-
   void setThreshold(bool thr)     { setWord(thr, kThreshMask, kThreshShift); }
   void setMode(bool mode)         { setWord(mode, kModeMask, kModeShift); }
   void setGain(uint16_t gain)     { setWord(gain, kGainMask, kToGainShift); }


### PR DESCRIPTION
#### PR description:

. 10 bits only used for adc (was 12)
. remove toaFired_ as data member, use one of the bits of value_ instead
. used setWord and getWord to set and read back values

#### PR validation:

we'll regenerate plots, to be done

#### if this PR is a backport please specify the original PR:

not a backport