### PR TITLE
Update to allow customisable mixed concentrator selections 

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -83,6 +83,13 @@ public:
 
   static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
 
+  enum SubDetectorType {
+    hgcal_silicon_CEE,
+    hgcal_silicon_CEH,
+    hgcal_scintillator,
+  };
+  SubDetectorType getSubDetectorType(const DetId& id) const;
+
 private:
   const HGCalTriggerGeometryBase* geom_;
   unsigned eeLayers_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -13,7 +13,7 @@
 
 class HGCalConcentratorProcessorSelection : public HGCalConcentratorProcessorBase {
 private:
-  enum SelectionType { thresholdSelect, bestChoiceSelect, superTriggerCellSelect, mixedBestChoiceSuperTriggerCell };
+  enum SelectionType { thresholdSelect, bestChoiceSelect, superTriggerCellSelect, noSelection };
 
 public:
   HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf);
@@ -23,10 +23,12 @@ public:
            const edm::EventSetup& es) override;
 
 private:
-  SelectionType selectionType_;
   bool fixedDataSizePerHGCROC_;
-  bool coarsenTriggerCells_;
+  std::vector<unsigned> coarsenTriggerCells_;
   static constexpr int kHighDensityThickness_ = 0;
+  static constexpr int kNSubDetectors_ = 3;
+
+  std::vector<SelectionType> selectionType_;
 
   std::unique_ptr<HGCalConcentratorThresholdImpl> thresholdImpl_;
   std::unique_ptr<HGCalConcentratorBestChoiceImpl> bestChoiceImpl_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -29,13 +29,14 @@ private:
     oneBitFraction,
     equalShare,
   };
+
   EnergyDivisionType energyDivisionType_;
   static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kOddNumberMask_ = 1;
 
   HGCalTriggerTools triggerTools_;
   bool fixedDataSizePerHGCROC_;
-  bool coarsenTriggerCells_;
+  std::vector<unsigned> coarsenTriggerCells_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
   HGCalCoarseTriggerCellMapping superTCmapping_;
 

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -8,27 +8,37 @@ DEFINE_EDM_PLUGIN(HGCalConcentratorFactory, HGCalConcentratorProcessorSelection,
 HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf)
     : HGCalConcentratorProcessorBase(conf),
       fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
-      coarsenTriggerCells_(conf.getParameter<bool>("coarsenTriggerCells")) {
-  std::string selectionType(conf.getParameter<std::string>("Method"));
-  if (selectionType == "thresholdSelect") {
-    selectionType_ = thresholdSelect;
-    thresholdImpl_ = std::make_unique<HGCalConcentratorThresholdImpl>(conf);
-  } else if (selectionType == "bestChoiceSelect") {
-    selectionType_ = bestChoiceSelect;
-    bestChoiceImpl_ = std::make_unique<HGCalConcentratorBestChoiceImpl>(conf);
-  } else if (selectionType == "superTriggerCellSelect") {
-    selectionType_ = superTriggerCellSelect;
-    superTriggerCellImpl_ = std::make_unique<HGCalConcentratorSuperTriggerCellImpl>(conf);
-  } else if (selectionType == "mixedBestChoiceSuperTriggerCell") {
-    selectionType_ = mixedBestChoiceSuperTriggerCell;
-    bestChoiceImpl_ = std::make_unique<HGCalConcentratorBestChoiceImpl>(conf);
-    superTriggerCellImpl_ = std::make_unique<HGCalConcentratorSuperTriggerCellImpl>(conf);
-  } else {
+      coarsenTriggerCells_(conf.getParameter<std::vector<unsigned>>("coarsenTriggerCells")),
+      selectionType_(kNSubDetectors_) {
+  std::vector<std::string> selectionType(conf.getParameter<std::vector<std::string>>("Method"));
+  if (selectionType.size() != kNSubDetectors_ || coarsenTriggerCells_.size() != kNSubDetectors_) {
     throw cms::Exception("HGCTriggerParameterError")
-        << "Unknown type of concentrator selection '" << selectionType << "'";
+        << "Inconsistent number of sub-detectors (should be " << kNSubDetectors_ << ")";
   }
 
-  if (coarsenTriggerCells_ || fixedDataSizePerHGCROC_) {
+  for (int subdet = 0; subdet < kNSubDetectors_; subdet++) {
+    if (selectionType[subdet] == "thresholdSelect") {
+      selectionType_[subdet] = thresholdSelect;
+      if (!thresholdImpl_)
+        thresholdImpl_ = std::make_unique<HGCalConcentratorThresholdImpl>(conf);
+    } else if (selectionType[subdet] == "bestChoiceSelect") {
+      selectionType_[subdet] = bestChoiceSelect;
+      if (!bestChoiceImpl_)
+        bestChoiceImpl_ = std::make_unique<HGCalConcentratorBestChoiceImpl>(conf);
+    } else if (selectionType[subdet] == "superTriggerCellSelect") {
+      selectionType_[subdet] = superTriggerCellSelect;
+      if (!superTriggerCellImpl_)
+        superTriggerCellImpl_ = std::make_unique<HGCalConcentratorSuperTriggerCellImpl>(conf);
+    } else if (selectionType[subdet] == "noSelection") {
+      selectionType_[subdet] = noSelection;
+    } else {
+      throw cms::Exception("HGCTriggerParameterError")
+          << "Unknown type of concentrator selection '" << selectionType[subdet] << "'";
+    }
+  }
+
+  if (std::find(coarsenTriggerCells_.begin(), coarsenTriggerCells_.end(), true) != coarsenTriggerCells_.end() ||
+      fixedDataSizePerHGCROC_) {
     coarsenerImpl_ = std::make_unique<HGCalConcentratorCoarsenerImpl>(conf);
   }
 }
@@ -66,10 +76,12 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
       thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
     }
 
-    if (coarsenTriggerCells_ || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {
+    HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(module_trigcell.second.at(0).detId());
+
+    if (coarsenTriggerCells_[subdet] || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {
       coarsenerImpl_->coarsen(module_trigcell.second, trigCellVecCoarsened);
 
-      switch (selectionType_) {
+      switch (selectionType_[subdet]) {
         case thresholdSelect:
           thresholdImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
           break;
@@ -89,15 +101,8 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
         case superTriggerCellSelect:
           superTriggerCellImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
           break;
-        case mixedBestChoiceSuperTriggerCell:
-          if (triggerTools_.isEm(module_trigcell.first)) {
-            bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                    geometry_->getModuleSize(module_trigcell.first),
-                                    trigCellVecCoarsened,
-                                    trigCellVecOutput);
-          } else {
-            superTriggerCellImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
-          }
+        case noSelection:
+          trigCellVecOutput = trigCellVecCoarsened;
           break;
         default:
           // Should not happen, selection type checked in constructor
@@ -105,7 +110,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
       }
 
     } else {
-      switch (selectionType_) {
+      switch (selectionType_[subdet]) {
         case thresholdSelect:
           thresholdImpl_->select(module_trigcell.second, trigCellVecOutput);
           break;
@@ -118,15 +123,8 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
         case superTriggerCellSelect:
           superTriggerCellImpl_->select(module_trigcell.second, trigCellVecOutput);
           break;
-        case mixedBestChoiceSuperTriggerCell:
-          if (triggerTools_.isEm(module_trigcell.first)) {
-            bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                    geometry_->getModuleSize(module_trigcell.first),
-                                    module_trigcell.second,
-                                    trigCellVecOutput);
-          } else {
-            superTriggerCellImpl_->select(module_trigcell.second, trigCellVecOutput);
-          }
+        case noSelection:
+          trigCellVecOutput = module_trigcell.second;
           break;
         default:
           // Should not happen, selection type checked in constructor

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, coarsetc_equalshare_proc, bestchoice_ndata_decentralized, mixedbcstc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, coarsetc_equalshare_proc, bestchoice_ndata_decentralized, custom_conc_proc
 
 def custom_triggercellselect_supertriggercell(process,
                                               stcSize=supertc_conc_proc.stcSize,
@@ -73,16 +73,17 @@ def custom_coarsetc_equalshare(process,
     return process
     
 def custom_triggercellselect_mixedBestChoiceSuperTriggerCell(process,
-                                              stcSize=mixedbcstc_conc_proc.stcSize,
-                                              type_energy_division=mixedbcstc_conc_proc.type_energy_division,
-                                              fixedDataSizePerHGCROC=mixedbcstc_conc_proc.fixedDataSizePerHGCROC,
-                                              triggercells=mixedbcstc_conc_proc.NData
+                                              stcSize=custom_conc_proc.stcSize,
+                                              type_energy_division=custom_conc_proc.type_energy_division,
+                                              fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                                              triggercells=custom_conc_proc.NData
                                               ):
-    parameters = mixedbcstc_conc_proc.clone(stcSize = stcSize,
-                                         type_energy_division = type_energy_division,
-                                         fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-                                         NData=triggercells
-                                         )
+    parameters = custom_conc_proc.clone(stcSize = stcSize,
+                                        type_energy_division = type_energy_division,
+                                        fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                                        NData=triggercells,
+                                        Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
+    )
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -27,10 +27,10 @@ STC_SIZE =  ( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*3 )
 
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                               Method = cms.string('thresholdSelect'),
+                               Method = cms.vstring(['thresholdSelect']*3),
                                threshold_silicon = cms.double(2.), # MipT
                                threshold_scintillator = cms.double(2.), # MipT
-                               coarsenTriggerCells = cms.bool(False),
+                               coarsenTriggerCells = cms.vuint32(0,0,0),
                                fixedDataSizePerHGCROC = cms.bool(False),
                                ctcSize = cms.vuint32(CTC_SIZE),
                                )
@@ -75,9 +75,9 @@ coarseTCCompression_proc = cms.PSet(exponentBits = cms.uint32(4),
 
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                          Method = cms.string('bestChoiceSelect'),
+                          Method = cms.vstring(['bestChoiceSelect']*3),
                           NData = cms.vuint32(bestchoice_ndata_centralized),
-                          coarsenTriggerCells = cms.bool(False),
+                          coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
                           superTCCalibration = vfe_proc.clone(),
@@ -85,39 +85,40 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           )
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                              stcSize = cms.vuint32(STC_SIZE),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(False),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
                              superTCCalibration = vfe_proc.clone(),
                              )
 
-
-mixedbcstc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                          Method = cms.string('mixedBestChoiceSuperTriggerCell'),
+custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                          Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
                           NData = cms.vuint32(bestchoice_ndata_centralized),
-                          coarsenTriggerCells = cms.bool(False),
+                          threshold_silicon = cms.double(2.), # MipT
+                          threshold_scintillator = cms.double(2.), # MipT
+                          coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
                           type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                           stcSize = cms.vuint32(STC_SIZE),
                           ctcSize = cms.vuint32(CTC_SIZE),
-                          supertccompression = superTCCompression_proc.clone(),
+                          superTCCompression = superTCCompression_proc.clone(),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
                           superTCCalibration = vfe_proc.clone(),
                           )
 
 
 coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('oneBitFraction'),
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              oneBitFractionThreshold = cms.double(0.125),
                              oneBitFractionLowValue = cms.double(0.0625),
                              oneBitFractionHighValue = cms.double(0.25),
@@ -128,12 +129,12 @@ coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcen
 
 
 coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
-                             Method = cms.string('superTriggerCellSelect'),
+                             Method = cms.vstring(['superTriggerCellSelect']*3),
                              type_energy_division = cms.string('equalShare'),
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
-                             coarsenTriggerCells = cms.bool(False),
+                             coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
                              superTCCalibration = vfe_proc.clone(),

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -152,6 +152,18 @@ bool HGCalTriggerTools::isSilicon(const DetId& id) const {
   return silicon;
 }
 
+HGCalTriggerTools::SubDetectorType HGCalTriggerTools::getSubDetectorType(const DetId& id) const {
+  SubDetectorType subdet;
+  if (!isScintillator(id)) {
+    if (isEm(id))
+      subdet = HGCalTriggerTools::hgcal_silicon_CEE;
+    else
+      subdet = HGCalTriggerTools::hgcal_silicon_CEH;
+  } else
+    subdet = HGCalTriggerTools::hgcal_scintillator;
+  return subdet;
+}
+
 int HGCalTriggerTools::zside(const DetId& id) const {
   int zside = 0;
   if (id.det() == DetId::Forward) {

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,7 +1,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, mixedbcstc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, custom_conc_proc
 
 
 def create_supertriggercell(process, inputs,
@@ -73,20 +73,50 @@ def create_onebitfraction(process, inputs,
 
 
 def create_mixedfeoptions(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize,
-                            type_energy_division=supertc_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=best_conc_proc.NData
+                            stcSize=custom_conc_proc.stcSize,
+                            type_energy_division=custom_conc_proc.type_energy_division,
+                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                            triggercells=custom_conc_proc.NData
                             ):
     producer = process.hgcalConcentratorProducer.clone(
             InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
             InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
             )
-    producer.ProcessorParameters = mixedbcstc_conc_proc.clone(
+    producer.ProcessorParameters = custom_conc_proc.clone(
             stcSize = stcSize,
             type_energy_division = type_energy_division,
             fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells
+            NData = triggercells,
+            Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
+            )
+    return producer
+
+
+def create_custom(process, inputs,
+                            stcSize=custom_conc_proc.stcSize,
+                            type_energy_division=custom_conc_proc.type_energy_division,
+                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+                            triggercells=custom_conc_proc.NData,
+                            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
+                            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
+                            Method = custom_conc_proc.Method,
+                            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
+                            ctcSize=custom_conc_proc.ctcSize,
+                            ):
+    producer = process.hgcalConcentratorProducer.clone(
+            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
+            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+            )
+    producer.ProcessorParameters = custom_conc_proc.clone(
+            stcSize = stcSize,
+            type_energy_division = type_energy_division,
+            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+            NData = triggercells,
+            threshold_silicon = threshold_silicon,  # MipT
+            threshold_scintillator = threshold_scintillator,  # MipT
+            Method = Method,
+            coarsenTriggerCells=coarsenTriggerCells,
+            ctcSize = ctcSize,
             )
     return producer
 


### PR DESCRIPTION
Small update to allow a more customisable front end selection in the silicon CEE, CEH and scintillator. Extends the existing 'Mixed' BC+STC option (which still exists in the config file for compatibility). 
