### PR TITLE
HFNoseL1: separate HFNose and HGCal sequences

### DIFF
--- a/L1Trigger/L1THGCal/plugins/HFNoseVFEProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HFNoseVFEProducer.cc
@@ -16,28 +16,26 @@
 
 #include <memory>
 
-class HGCalVFEProducer : public edm::stream::EDProducer<> {
+class HFNoseVFEProducer : public edm::stream::EDProducer<> {
 public:
-  HGCalVFEProducer(const edm::ParameterSet&);
-  ~HGCalVFEProducer() override {}
+  HFNoseVFEProducer(const edm::ParameterSet&);
+  ~HFNoseVFEProducer() override {}
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // inputs
-  edm::EDGetToken inputee_, inputfh_, inputbh_;
+  edm::EDGetToken inputnose_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   std::unique_ptr<HGCalVFEProcessorBase> vfeProcess_;
 };
 
-DEFINE_FWK_MODULE(HGCalVFEProducer);
+DEFINE_FWK_MODULE(HFNoseVFEProducer);
 
-HGCalVFEProducer::HGCalVFEProducer(const edm::ParameterSet& conf)
-    : inputee_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("eeDigis"))),
-      inputfh_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("fhDigis"))),
-      inputbh_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("bhDigis"))) {
+HFNoseVFEProducer::HFNoseVFEProducer(const edm::ParameterSet& conf)
+    : inputnose_(consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("noseDigis"))) {
   // setup VFE parameters
   const edm::ParameterSet& vfeParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& vfeProcessorName = vfeParamConfig.getParameter<std::string>("ProcessorName");
@@ -48,39 +46,22 @@ HGCalVFEProducer::HGCalVFEProducer(const edm::ParameterSet& conf)
   produces<l1t::HGCalTriggerSumsBxCollection>(vfeProcess_->name());
 }
 
-void HGCalVFEProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+void HFNoseVFEProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
   es.get<CaloGeometryRecord>().get(triggerGeometry_);
   vfeProcess_->setGeometry(triggerGeometry_.product());
 }
 
-void HGCalVFEProducer::produce(edm::Event& e, const edm::EventSetup& es) {
+void HFNoseVFEProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output collections
   auto vfe_trigcell_output = std::make_unique<l1t::HGCalTriggerCellBxCollection>();
   auto vfe_trigsums_output = std::make_unique<l1t::HGCalTriggerSumsBxCollection>();
 
-  // Input collections
-  edm::Handle<HGCalDigiCollection> ee_digis_h;
-  edm::Handle<HGCalDigiCollection> fh_digis_h;
-  edm::Handle<HGCalDigiCollection> bh_digis_h;
+  edm::Handle<HGCalDigiCollection> nose_digis_h;
+  e.getByToken(inputnose_, nose_digis_h);
 
-  e.getByToken(inputee_, ee_digis_h);
-  e.getByToken(inputfh_, fh_digis_h);
-  e.getByToken(inputbh_, bh_digis_h);
-
-  // Processing DigiCollections and putting the results into the HGCalTriggerCellBxCollectio
-  if (ee_digis_h.isValid()) {
-    const HGCalDigiCollection& ee_digis = *ee_digis_h;
-    vfeProcess_->run(ee_digis, *vfe_trigcell_output, es);
-  }
-
-  if (fh_digis_h.isValid()) {
-    const HGCalDigiCollection& fh_digis = *fh_digis_h;
-    vfeProcess_->run(fh_digis, *vfe_trigcell_output, es);
-  }
-
-  if (bh_digis_h.isValid()) {
-    const HGCalDigiCollection& bh_digis = *bh_digis_h;
-    vfeProcess_->run(bh_digis, *vfe_trigcell_output, es);
+  if (nose_digis_h.isValid()) {
+    const HGCalDigiCollection& nose_digis = *nose_digis_h;
+    vfeProcess_->run(nose_digis, *vfe_trigcell_output, es);
   }
 
   // Put in the event

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -67,3 +67,6 @@ hgcalBackEndLayer1Producer = cms.EDProducer(
     InputTriggerCells = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
     ProcessorParameters = be_proc.clone()
     )
+
+hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone()
+hgcalBackEndLayer1ProducerHFNose.InputTriggerCells = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import *
 
 hgcalBackEndLayer1 = cms.Task(hgcalBackEndLayer1Producer)
 
+hgcalBackEndLayer1HFNose = cms.Task(hgcalBackEndLayer1ProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -17,15 +17,6 @@ binSums = cms.vuint32(13,               # 0
                       3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 41
                       )
 
-binSumsNose = cms.vuint32(13,               # 0
-                          13,               # 1
-                          11, 11, 11,       # 2 - 4
-                          9, 9, 9,          # 5 - 7
-                          7, 7, 7, 7, 7, 7,  # 8 - 13
-                          5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 14 - 28
-                          3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 29 - 42
-)
-
 EE_DR_GROUP = 7
 FH_DR_GROUP = 6
 BH_DR_GROUP = 12
@@ -97,14 +88,6 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                seed_smoothing_ecal=seed_smoothing_ecal,
                                seed_smoothing_hcal=seed_smoothing_hcal,
                               )
-
-## Note: this customization change both HGC and HFnose, to be revised
-phase2_hfnose.toModify(histoMax_C3d_seeding_params,
-                       nBins_X1_histo_multicluster=cms.uint32(43),
-                       binSumsHisto=binSumsNose,
-                       kROverZMin=cms.double(0.025),
-                       kROverZMax=cms.double(0.58),
-                       )
 
 histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
                                dR_multicluster_byLayer_coefficientA=cms.vdouble(),
@@ -184,3 +167,17 @@ hgcalBackEndLayer2Producer = cms.EDProducer(
     InputCluster = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
     ProcessorParameters = be_proc.clone()
     )
+
+
+hgcalBackEndLayer2ProducerHFNose = hgcalBackEndLayer2Producer.clone()
+hgcalBackEndLayer2ProducerHFNose.InputCluster = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering')
+
+binSumsNose = cms.vuint32(13,11,9,9)
+
+hgcalBackEndLayer2ProducerHFNose.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = dict(
+    ## note in #Phi same bin size for HGCAL and HFNose
+    nBins_X1_histo_multicluster = 4, # R bin size: 5 FullModules * 8 TP
+    binSumsHisto = binSumsNose,
+    kROverZMin = 0.025,
+    kROverZMax = 0.1
+)

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import *
 
 hgcalBackEndLayer2 = cms.Task(hgcalBackEndLayer2Producer)
 
+hgcalBackEndLayer2HFNose = cms.Task(hgcalBackEndLayer2ProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -161,3 +161,9 @@ hgcalConcentratorProducer = cms.EDProducer(
     InputTriggerSums = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
     ProcessorParameters = threshold_conc_proc.clone()
     )
+
+
+hgcalConcentratorProducerHFNose = hgcalConcentratorProducer.clone()
+hgcalConcentratorProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+hgcalConcentratorProducerHFNose.InputTriggerSums = cms.InputTag('hfnoseVFEProducer:HGCalVFEProcessorSums')
+

--- a/L1Trigger/L1THGCal/python/hgcalConcentrator_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentrator_cff.py
@@ -5,4 +5,5 @@ from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import *
 
 
 hgcalConcentrator = cms.Task(hgcalConcentratorProducer)
+hgcalConcentratorHFNose = cms.Task(hgcalConcentratorProducerHFNose)
 

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -25,3 +25,6 @@ hgcalTowerMapProducer = cms.EDProducer(
     InputTriggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
     ProcessorParameters = tower_map.clone()
     )
+
+hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone()
+hgcalTowerMapProducerHFNose.InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')

--- a/L1Trigger/L1THGCal/python/hgcalTowerMap_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMap_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import *
 
 hgcalTowerMap = cms.Task(hgcalTowerMapProducer)
 
+hgcalTowerMapHFNose = cms.Task(hgcalTowerMapProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -8,3 +8,8 @@ hgcalTowerProducer = cms.EDProducer(
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
     ProcessorParameters = tower.clone()
     )
+
+
+hgcalTowerProducerHFNose = hgcalTowerProducer.clone()
+hgcalTowerProducerHFNose.InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+

--- a/L1Trigger/L1THGCal/python/hgcalTower_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTower_cff.py
@@ -6,3 +6,5 @@ from L1Trigger.L1THGCal.hgcalTowerProducer_cfi import *
 
 hgcalTower = cms.Task(hgcalTowerProducer)
 
+hgcalTowerHFNose = cms.Task(hgcalTowerProducerHFNose)
+

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -8,9 +8,15 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2_cff import *
 from L1Trigger.L1THGCal.hgcalTowerMap_cff import *
 from L1Trigger.L1THGCal.hgcalTower_cff import *
 
-
 hgcalTriggerPrimitivesTask = cms.Task(hgcalVFE, hgcalConcentrator, hgcalBackEndLayer1, hgcalBackEndLayer2, hgcalTowerMap, hgcalTower)
 hgcalTriggerPrimitives = cms.Sequence(hgcalTriggerPrimitivesTask)
+
+_hfnose_hgcalTriggerPrimitivesTask = hgcalTriggerPrimitivesTask.copy()
+_hfnose_hgcalTriggerPrimitivesTask.add(hfnoseVFE, hgcalConcentratorHFNose, hgcalBackEndLayer1HFNose, hgcalBackEndLayer2HFNose, hgcalTowerMapHFNose, hgcalTowerHFNose)
+
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+phase2_hfnose.toReplaceWith(
+        hgcalTriggerPrimitivesTask, _hfnose_hgcalTriggerPrimitivesTask )
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9

--- a/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFEProducer_cfi.py
@@ -93,7 +93,14 @@ hgcalVFEProducer = cms.EDProducer(
         eeDigis = cms.InputTag('simHGCalUnsuppressedDigis:EE'),
         fhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEfront'),
         bhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEback'),
+        ProcessorParameters = vfe_proc.clone()
+       )
+
+hfnoseVFEProducer = cms.EDProducer(
+        "HFNoseVFEProducer",
         noseDigis = cms.InputTag('simHFNoseUnsuppressedDigis:HFNose'),
         ProcessorParameters = vfe_proc.clone()
        )
+
+
 

--- a/L1Trigger/L1THGCal/python/hgcalVFE_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalVFE_cff.py
@@ -4,4 +4,5 @@ from L1Trigger.L1THGCal.hgcalTriggerGeometryESProducer_cfi import *
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import *
 
 hgcalVFE = cms.Task(hgcalVFEProducer)
+hfnoseVFE = cms.Task(hfnoseVFEProducer)
 

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_Nose_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_Nose_cfg.py
@@ -68,8 +68,8 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
     outputCommands = cms.untracked.vstring(
         'keep *_genParticles_*_*',
-        'keep *_hgcalBackEndLayer1Producer_*_*',
-        'keep *_hgcalBackEndLayer2Producer_*_*',
+        'keep *_*hgcalBackEndLayer1Producer*_*_*',
+        'keep *_*hgcalBackEndLayer2Producer*_*_*',
         'keep *_hgcalTowerProducer_*_*',
     ),
     fileName = cms.untracked.string('file:/tmp/dalfonso/test.root')


### PR DESCRIPTION
Follow up on few items from previous PR 
https://github.com/PFCal-dev/cmssw/pull/400

With this PR: 
1. a new collection is created to contains the HFNose TP hgcalBackEndLayer1ProducerHFNose
2. the seeding parameters for the BackEndLayer2 are also disentangled fixing the previous issues (now the HGCAL performances should be the same in the scenario w/ and w/o nose)
3. split the VFEProducer
4. extend the seeding in R for the HFNose