### PR TITLE
eta dependent binning for seeding

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -161,10 +161,10 @@ private:
   Navigator navigator_;
 
   static constexpr unsigned neighbour_weights_size_ = 9;
-  double kROverZMin_ = 0.076;
-  double kROverZMax_ = 0.58;
-  std::vector<double> vkROverZMin_;
-  std::vector<double> vkROverZMax_;
+  double ROverZMin_ = 0.076;
+  double ROverZMax_ = 0.58;
+  std::vector<double> vROverZMin_;
+  std::vector<double> vROverZMax_;
 
   static constexpr double kXYMax_ = 0.6;
 };

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -149,6 +149,8 @@ private:
 
   unsigned nBins1_ = 42;
   unsigned nBins2_ = 216;
+  std::vector<unsigned> vnBins1_;
+  std::vector<unsigned> vnBins2_;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
   std::vector<double> neighbour_weights_;
@@ -159,8 +161,10 @@ private:
   Navigator navigator_;
 
   static constexpr unsigned neighbour_weights_size_ = 9;
-  const double kROverZMin_ = 0.076;
-  const double kROverZMax_ = 0.58;
+  double kROverZMin_ = 0.076;
+  double kROverZMax_ = 0.58;
+  std::vector<double> vkROverZMin_;
+  std::vector<double> vkROverZMax_;
 
   static constexpr double kXYMax_ = 0.6;
 };

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -151,7 +151,9 @@ private:
   unsigned nBins2_ = 216;
   std::vector<unsigned> vnBins1_;
   std::vector<unsigned> vnBins2_;
-  std::vector<unsigned> binsSumsHisto_;
+  std::vector<std::vector<unsigned>>binsSumsHisto_;
+  std::vector<unsigned> binsSumsHistoN_;
+  int nbins1_counter = 0;
   double histoThreshold_ = 20.;
   std::vector<double> neighbour_weights_;
   std::vector<double> smoothing_ecal_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -153,7 +153,6 @@ private:
   std::vector<unsigned> vnBins2_;
   std::vector<std::vector<unsigned>>binsSumsHisto_;
   std::vector<unsigned> binsSumsHistoN_;
-  int nbins1_counter = 0;
   double histoThreshold_ = 20.;
   std::vector<double> neighbour_weights_;
   std::vector<double> smoothing_ecal_;

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -22,6 +22,10 @@ FH_DR_GROUP = 6
 BH_DR_GROUP = 12
 MAX_LAYERS = 52
 
+nBins_X1_histo_multiclusterRPhi = cms.vuint32(42, 42)
+nBins_X2_histo_multiclusterRPhi = cms.vuint32(216, 108)
+kROverZMinRPhi=cms.vdouble(0.076, 0.224)
+kROverZMaxRPhi=cms.vdouble(0.224, 0.58)
 
 dr_layerbylayer = ([0] + # no layer 0
         [0.015]*EE_DR_GROUP + [0.020]*EE_DR_GROUP + [0.030]*EE_DR_GROUP + [0.040]*EE_DR_GROUP + # EM
@@ -76,11 +80,11 @@ dbscan_C3d_params = cms.PSet(type_multicluster=cms.string('DBSCANC3d'),
 
 
 histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
-                               nBins_X1_histo_multicluster=cms.uint32(42), # bin size of about 0.012
-                               nBins_X2_histo_multicluster=cms.uint32(216), # bin size of about 0.029
+                               nBins_X1_histo_multicluster=nBins_X1_histo_multiclusterRPhi, 
+                               nBins_X2_histo_multicluster=nBins_X2_histo_multiclusterRPhi,
                                binSumsHisto=binSums,
-                               kROverZMin=cms.double(0.076),
-                               kROverZMax=cms.double(0.58),
+                               kROverZMin=kROverZMinRPhi,
+                               kROverZMax=kROverZMaxRPhi,
                                threshold_histo_multicluster=cms.double(10.),
                                neighbour_weights=neighbour_weights_1stOrder,
                                seed_position=cms.string("TCWeighted"),#BinCentre, TCWeighted

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -181,8 +181,8 @@ binSumsNose = cms.vuint32(13,11,9,9)
 
 hgcalBackEndLayer2ProducerHFNose.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = dict(
     ## note in #Phi same bin size for HGCAL and HFNose
-    nBins_X1_histo_multicluster = 4, # R bin size: 5 FullModules * 8 TP
+    nBins_X1_histo_multicluster = cms.vuint32(4), # R bin size: 5 FullModules * 8 TP
     binSumsHisto = binSumsNose,
-    kROverZMin = 0.025,
-    kROverZMax = 0.1
+    ROverZMin = cms.vdouble(0.025),
+    ROverZMax = cms.vdouble(0.1)
 )

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -8,21 +8,22 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 
-
-binSums = cms.vuint32(13,               # 0
-                      11, 11, 11,       # 1 - 3
-                      9, 9, 9,          # 4 - 6
-                      7, 7, 7, 7, 7, 7,  # 7 - 12
-                      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
-                      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 41
-                      )
+binSumslistoflists = [[13, 
+                       11, 11, 11,
+                       9, 9, 9,
+                       7, 7, 7, 7, 7, 7,
+                       5, 5, 5, 5, 5, 5, 5], 
+                      [5, 5, 5, 5, 5, 5, 5, 5,
+                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]]
+flatten_binSumslist = [val for sublist in binSumslistoflists for val in sublist]
+binSums = cms.vuint32(flatten_binSumslist)
 
 EE_DR_GROUP = 7
 FH_DR_GROUP = 6
 BH_DR_GROUP = 12
 MAX_LAYERS = 52
 
-nBins_X1_histo_multiclusterRPhi = cms.vuint32(42, 42)
+nBins_X1_histo_multiclusterRPhi = cms.vuint32(20, 22)
 nBins_X2_histo_multiclusterRPhi = cms.vuint32(216, 108)
 ROverZMinRPhi=cms.vdouble(0.076, 0.224)
 ROverZMaxRPhi=cms.vdouble(0.224, 0.58)

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -24,8 +24,8 @@ MAX_LAYERS = 52
 
 nBins_X1_histo_multiclusterRPhi = cms.vuint32(42, 42)
 nBins_X2_histo_multiclusterRPhi = cms.vuint32(216, 108)
-kROverZMinRPhi=cms.vdouble(0.076, 0.224)
-kROverZMaxRPhi=cms.vdouble(0.224, 0.58)
+ROverZMinRPhi=cms.vdouble(0.076, 0.224)
+ROverZMaxRPhi=cms.vdouble(0.224, 0.58)
 
 dr_layerbylayer = ([0] + # no layer 0
         [0.015]*EE_DR_GROUP + [0.020]*EE_DR_GROUP + [0.030]*EE_DR_GROUP + [0.040]*EE_DR_GROUP + # EM
@@ -83,8 +83,8 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                nBins_X1_histo_multicluster=nBins_X1_histo_multiclusterRPhi, 
                                nBins_X2_histo_multicluster=nBins_X2_histo_multiclusterRPhi,
                                binSumsHisto=binSums,
-                               kROverZMin=kROverZMinRPhi,
-                               kROverZMax=kROverZMaxRPhi,
+                               ROverZMin=ROverZMinRPhi,
+                               ROverZMax=ROverZMaxRPhi,
                                threshold_histo_multicluster=cms.double(10.),
                                neighbour_weights=neighbour_weights_1stOrder,
                                seed_position=cms.string("TCWeighted"),#BinCentre, TCWeighted

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -127,8 +127,8 @@ histoSecondaryMax_C3d_params = histoMax_C3d_seeding_params.clone(
 
 histoMaxXYVariableDR_C3d_params = histoMax_C3d_seeding_params.clone(
         seeding_space=cms.string("XY"),
-        nBins_X1_histo_multicluster=cms.uint32(192),
-        nBins_X2_histo_multicluster=cms.uint32(192)
+        nBins_X1_histo_multicluster=cms.vuint32(192),
+        nBins_X2_histo_multicluster=cms.vuint32(192)
         )
 
 histoInterpolatedMax_C3d_params = histoMax_C3d_seeding_params.clone(

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -1,4 +1,4 @@
-#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h"
+1;95;0c#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
@@ -48,17 +48,17 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
       << "\nMulticluster MIPT threshold for histo threshold algorithm: " << histoThreshold_
       << "\nMulticluster type of multiclustering algortihm: " << seedingAlgoType_;
 
-    if (seedingAlgoType_.find("Histo") != std::string::npos && seedingSpace_ == RPhi &&
-	nBins1_ != binsSumsHisto_.size()) {
-      throw cms::Exception("Inconsistent bin size")
-        << "Inconsistent nBins_X1_histo_multicluster ( " << vnBins1_[0] << " ) and binSumsHisto ( " << binsSumsHisto_.size()
-        << " ) size in HGCalMulticlustering\n";
-    }
-
+  if (seedingAlgoType_.find("Histo") != std::string::npos && seedingSpace_ == RPhi &&
+      vnBins1_[0] != binsSumsHisto_.size()) {
+    throw cms::Exception("Inconsistent bin size")
+      << "Inconsistent nBins_X1_histo_multicluster ( " << vnBins1_[0] << " ) and binSumsHisto ( " << binsSumsHisto_.size()
+      << " ) size in HGCalMulticlustering\n";
+  }
+  
   if (neighbour_weights_.size() != neighbour_weights_size_) {
     throw cms::Exception("Inconsistent vector size")
-        << "Inconsistent size of neighbour weights vector in HGCalMulticlustering ( " << neighbour_weights_.size()
-        << " ). Should be " << neighbour_weights_size_ << "\n";
+      << "Inconsistent size of neighbour weights vector in HGCalMulticlustering ( " << neighbour_weights_.size()
+      << " ). Should be " << neighbour_weights_size_ << "\n";
   }
 }
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -527,7 +527,7 @@ void HGCalHistoSeedingImpl::findHistoSeeds(const std::vector<edm::Ptr<l1t::HGCal
       smoothHistoCluster = fillSmoothRPhiHistoClusters(smoothPhiHistoCluster);
     } else if (seedingSpace_ == XY) {
 
-      navigator_ = Navigator(nBins1_, Navigator::AxisType::Bounded, nBins2_, Navigator::AxisType::Circular); 
+      navigator_ = Navigator(nBins1_, Navigator::AxisType::Bounded, nBins2_, Navigator::AxisType::Bounded); 
       
       smoothHistoCluster = fillSmoothHistoClusters(histoCluster, smoothing_ecal_, Bin::Content::Ecal);
       smoothHistoCluster = fillSmoothHistoClusters(smoothHistoCluster, smoothing_hcal_, Bin::Content::Hcal);


### PR DESCRIPTION
This PR proposes changes in the phi binning used for the RPhi based seeding histogram used for 3D clustering. The binning is now eta dependent. 



