### PR TITLE
New EG ID for v10 geometry

### DIFF
--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_3151_higheta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_3151_higheta_v0.xml
@@ -1,0 +1,2140 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.984762E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     5.171066E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.693493E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.737991E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.603520E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.111111E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.939540E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.098364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.509434E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.531215E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.857143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.935421E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.701767E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.543986E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.168142E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.548726E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.954121E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.716981E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.023622E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     4.102192E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.043479E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.285714E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.434783E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     9.759266E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.764706E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.448276E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.656127E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.972414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.677636E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.040000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.333333E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.909091E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.667312E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.667022E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.172414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.153847E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.640371E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.509317E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.948164E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.299133E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.763776E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.275770E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.108700E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.321839E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.747402E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.521526E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.567850E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.433664E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.187731E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.566739E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.538462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.562021E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.449033E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.839858E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.529216E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.213561E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.202712E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.909091E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.153847E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.920603E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.047013E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     5.730202E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.240000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.489955E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.880000E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.765101E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     2.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.975664E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.428572E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.800000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.446808E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.845310E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.586214E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.752238E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.909926E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.990784E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.190520E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.097829E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.271224E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.946738E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.716179E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.139956E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.571429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.169811E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.582532E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.778158E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.982854E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     5.072282E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.900769E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.787252E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.114161E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.407642E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.549854E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.582192E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.334459E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.250573E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.791752E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.087443E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.964360E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.467454E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.832956E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     5.548722E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.363947E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.277991E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.999432E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.545338E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.101416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.347383E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.203671E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.696961E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.791453E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.937306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.830430E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.020309E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.604514E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.342048E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.855437E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.354098E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.432617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.635936E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.432851E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.690077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.716276E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.494252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.458147E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.367538E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="4" Cut="     1.712768E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.760029E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.176359E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.544428E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.643236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.210017E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.420662E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.550989E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.528539E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.749103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.779864E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.498338E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.597109E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.668249E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.980301E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.420907E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.503244E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.611427E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     3.556160E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.494553E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.253655E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.109477E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.718126E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.315155E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.488830E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.375890E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.500000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.708068E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.650447E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     2.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.561882E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.546404E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.600184E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.291928E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.373941E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.527235E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.658017E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.062449E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.438339E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.716179E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.152530E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.517972E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.919688E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.233521E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.280647E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.620791E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     5.119383E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.849697E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.658772E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.586212E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.398493E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.094804E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.984979E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.136894E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.083303E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.578680E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.994811E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.409887E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.783217E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.675418E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     5.254707E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.549382E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.446257E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.360701E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.008175E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.811857E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.129311E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.483320E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.360579E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.198015E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.715804E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.487924E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.035648E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.723932E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.855432E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.248120E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.432617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.037306E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.432851E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.213063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.757364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.778912E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.768842E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.416590E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.376010E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.015720E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.731420E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     4.171073E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     5.956535E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.761951E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.964166E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.239714E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.647342E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.336156E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.402038E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.518246E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     9.597513E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.492684E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.407380E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.775693E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.204512E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.420635E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.141876E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.329713E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.327746E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.175687E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.455038E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.860902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.544741E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.069109E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.551701E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.071741E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     5.580410E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.699950E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.909926E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.466940E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.344083E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.364128E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.763271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.580375E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.916401E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.577533E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.091131E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.455317E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.180025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.620315E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.620254E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.810611E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.085446E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.932683E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.624858E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.060921E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.060789E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.774772E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.374052E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.022420E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.929642E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.587180E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.575938E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     2.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.586212E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.495643E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.651702E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.224223E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     2.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.854368E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.133603E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.495441E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.622204E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.942646E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.616656E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.745504E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.283912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.016978E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.284236E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.432410E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.413139E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.424834E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.986465E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.670367E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.020309E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.787876E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.373496E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.364027E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.199077E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.555523E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.871026E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.656127E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.678029E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.242785E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.906598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.635597E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.550689E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.738632E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.104655E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.717475E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.464390E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.367940E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.367538E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.646440E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.096185E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.600995E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.595139E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.353961E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.399192E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.872929E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.509408E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.531086E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.720993E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.488550E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.737440E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     3.747094E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.700000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.513501E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.237700E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.142387E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.141650E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.440465E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.778697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.731678E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.032261E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.618191E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.110965E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.130195E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.870162E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.024446E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.375433E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.518079E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.605427E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.570958E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.251784E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.182469E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.775295E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.564246E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.145598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.986094E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.738513E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.714607E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.595479E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     4.336894E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.335997E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.370973E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.505666E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.386744E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.430726E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.677471E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.929642E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.581862E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.575938E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     2.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.603520E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.239141E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.420975E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.451408E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     5.416515E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.192868E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.833270E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.254225E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.748227E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.659536E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.676847E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.243763E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.866105E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.974651E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.808942E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.250502E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.471962E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.581970E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.484197E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.716291E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.829329E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.027214E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.656127E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.456365E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.242785E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.825399E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.392504E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.667312E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.725102E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.803997E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.597129E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.640371E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.609539E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.834271E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.637008E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.487191E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.384620E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.031312E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.853120E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.315476E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.549950E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.584236E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.839063E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.136189E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.283922E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.975344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.600745E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.544076E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.235283E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.404171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.082803E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.078725E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.250884E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.248160E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.794527E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.142387E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.141650E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.097757E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.375746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.507695E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.233521E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.108843E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.798383E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.355970E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.498930E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.595038E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.598695E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.481156E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.434546E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.434274E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.628466E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.639327E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     2.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.115810E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.320311E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.691998E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.097509E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.996524E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.285628E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.442921E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     5.148134E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.376789E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.094610E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.620280E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.620254E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.269429E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.247285E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.194706E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.095784E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.465427E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     5.119383E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.427379E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.792805E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     5.050712E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.495482E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.283806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.819999E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.065237E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.773252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.105254E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.368223E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.550783E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.328397E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.647867E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.501597E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.136646E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.622841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.531313E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     5.171349E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.271120E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.391070E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.909240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.676200E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.368480E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.744751E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.710082E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.432666E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.087684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.599008E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.432617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.160021E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.561310E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.152933E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.217922E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.220744E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.198923E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.341921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.716276E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.165623E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.054204E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.286746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.082710E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.338684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.985532E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.432851E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.899150E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.639045E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.019224E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.217845E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.600184E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     5.180742E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.596056E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.904412E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.018211E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.547200E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.999180E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.238587E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.668776E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.500000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.318305E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.866042E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.305655E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.155821E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.400862E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.390846E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.450195E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.724980E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.589675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.082586E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.081196E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.993993E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.765780E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.133703E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.286279E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.293715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.204819E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.534451E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.618639E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.536249E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.935763E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.464003E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.362550E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.204752E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.106260E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.100438E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.353945E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.738513E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.738468E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.119146E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.406169E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.280547E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.093431E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.060928E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.306451E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.095315E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.194706E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.886694E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.324510E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.888369E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.372036E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.543369E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.810145E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.994445E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.134795E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.342875E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.166063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.366555E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.290880E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.536768E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.678081E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.020774E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.997741E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.611365E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.285990E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.254617E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.239551E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.205758E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.893006E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.311778E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.432836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.396176E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.911258E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.750537E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.535644E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.718730E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.238664E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.602278E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.656127E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.160021E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.054964E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.425555E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.243765E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.392254E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     5.356709E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.052651E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.149047E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.287728E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     4.294054E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.340109E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.889330E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.403440E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.178942E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.577042E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.647844E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.849206E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.721754E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.489980E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.167737E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.588245E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     4.623676E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.221671E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.397026E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.349386E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.378398E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.398476E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.586151E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     2.558985E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     3.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.472119E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.277344E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.546725E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.399672E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.937798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.867279E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     2.953563E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.751507E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.042219E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.271014E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.595365E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.547688E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.000658E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.939672E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.450248E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.228966E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.491049E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.615227E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.659417E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.321895E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.095864E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.807485E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.066547E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.279312E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.060921E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     5.766323E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.726604E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.254394E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.213350E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.738513E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.738468E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.999816E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.973131E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.194706E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.689257E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.218918E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     5.156873E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.658923E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.377570E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.810227E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     4.598309E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.037181E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.827983E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.153542E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.919523E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.296836E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.597350E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.280895E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.422591E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.559861E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.944331E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.305946E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.368947E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.931965E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.024107E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.634776E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.958381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.985777E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     4.355628E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.849276E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.092430E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.087202E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     5.290019E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.735057E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.781171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.432617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.056807E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.082371E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.176697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.242785E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.084835E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.029075E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.325448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.545294E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.124257E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     2.500000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.930895E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.663434E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.432851E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.633549E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.812103E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.949434E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.660710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     4.307663E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     6.108843E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.336156E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.399714E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.432820E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.542797E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.799788E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.391632E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.860963E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.923753E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.919846E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.454425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.117124E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.255088E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     2.728391E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.725438E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.237125E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.124661E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.396049E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.183102E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.212556E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     5.775295E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="4" Cut="     1.606134E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.881541E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.770292E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.738958E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.177732E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     5.240170E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.801530E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.122717E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.724460E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.233108E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.136174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.605925E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.182976E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.485026E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     8.787154E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     5.780049E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.336350E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.070307E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.132300E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     5.783158E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.180674E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.061548E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     8.800121E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.171823E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.018824E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.817731E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     2.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="8" Cut="     4.377570E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.474576E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.810145E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.994445E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.727813E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.054151E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     2.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.019199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.380327E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.357869E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.586135E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.012921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.746345E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.362724E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.192049E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.042254E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.425890E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.005612E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.797502E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.428894E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.530573E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.108357E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     5.285725E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.936513E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.709104E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.469178E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.332679E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.668695E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.656127E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.432181E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.117084E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.432851E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.074449E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.983154E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.242785E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.692459E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.849635E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.997057E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.640468E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.609539E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.157342E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.767983E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.781539E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     5.609521E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.302215E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.355054E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.365938E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.374078E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     5.121147E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.241072E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.797896E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     5.672380E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.171509E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.287142E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.975438E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.716649E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     3.472334E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.150120E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.472365E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.516266E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.323367E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.221091E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.843136E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     4.582487E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.420737E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.581032E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.119484E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.668164E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.718126E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.746921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.907116E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     2.531546E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.517049E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.093850E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.290453E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.336410E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.388858E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.796941E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.194706E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.192425E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.766323E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.050253E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.096255E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.162437E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.738513E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.738456E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.709802E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.208172E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.091625E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     5.172991E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.472774E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     4.721640E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     2.736117E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.019793E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.941906E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.948374E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.375860E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.342598E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.761712E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.468332E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.090750E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.188278E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.360610E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.729053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.587158E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.901452E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.409187E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.776304E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     3.849276E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.111923E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.020448E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.970034E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.024608E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.293857E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="5" Cut="     3.432617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     3.217922E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.811826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.394025E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.176164E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.552592E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.627685E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.095577E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.325448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.545294E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.914171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.296083E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.165998E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.288347E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.472365E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.472334E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.305321E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.293856E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.977575E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.181174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="8" Cut="     4.755075E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     6.119146E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     4.822333E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.469744E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.024692E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.387199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     5.972584E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.427074E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.023756E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.923753E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.598411E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.182174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.361565E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     5.777870E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.119970E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.697051E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     4.394080E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.386649E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.728805E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.783094E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.091324E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     4.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.485778E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.031249E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.108425E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     5.595391E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     4.428701E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     5.426208E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.809891E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.375348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.296746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.426246E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.160509E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.936868E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.716114E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     4.955636E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.378691E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.174862E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     5.595321E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.835118E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.707401E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.194706E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.194616E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     5.766323E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.342466E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.048480E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.133437E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.044108E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/data/egamma_id_histomax_3151_loweta_v0.xml
+++ b/L1Trigger/L1THGCal/data/egamma_id_histomax_3151_loweta_v0.xml
@@ -1,0 +1,2360 @@
+
+        <?xml version="1.0"?>
+        <MethodSetup Method="BDT::bdt">
+        <GeneralInfo>
+        <Info name="TMVA Release" value=""/>
+        <Info name="ROOT Release" value=""/>
+        <Info name="Creator" value="mlglue"/>
+        <Info name="Date" value=""/>
+        <Info name="Host" value=""/>
+        <Info name="Dir" value=""/>
+        <Info name="Training events" value="-1"/>
+        <Info name="TrainingTime" value="-1"/>
+        <Info name="AnalysisType" value="Classification"/>
+        </GeneralInfo>
+        <Options>
+        <Option name="NTrees" modified="Yes">10</Option>
+        <Option name="MaxDepth" modified="Yes">6</Option>
+        <Option name="BoostType" modified="Yes">Grad</Option>
+        <Option name="Shrinkage" modified="Yes">0.3</Option>
+        <Option name="UseNvars" modified="Yes">9</Option>
+        </Options>
+
+        <Variables NVar="9">
+        <Variable VarIndex="0" Expression="cl3d_coreshowerlength" Label="cl3d_coreshowerlength" Title="cl3d_coreshowerlength" Unit="" Internal="cl3d_coreshowerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="1" Expression="cl3d_showerlength" Label="cl3d_showerlength" Title="cl3d_showerlength" Unit="" Internal="cl3d_showerlength" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="2" Expression="cl3d_firstlayer" Label="cl3d_firstlayer" Title="cl3d_firstlayer" Unit="" Internal="cl3d_firstlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="3" Expression="cl3d_maxlayer" Label="cl3d_maxlayer" Title="cl3d_maxlayer" Unit="" Internal="cl3d_maxlayer" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="4" Expression="cl3d_szz" Label="cl3d_szz" Title="cl3d_szz" Unit="" Internal="cl3d_szz" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="5" Expression="cl3d_srrmean" Label="cl3d_srrmean" Title="cl3d_srrmean" Unit="" Internal="cl3d_srrmean" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="6" Expression="cl3d_srrtot" Label="cl3d_srrtot" Title="cl3d_srrtot" Unit="" Internal="cl3d_srrtot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="7" Expression="cl3d_seetot" Label="cl3d_seetot" Title="cl3d_seetot" Unit="" Internal="cl3d_seetot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+<Variable VarIndex="8" Expression="cl3d_spptot" Label="cl3d_spptot" Title="cl3d_spptot" Unit="" Internal="cl3d_spptot" Type="F" Min="0.0000000000000000000000000000000000000000000000000000000000000000E+00" Max="0.0000000000000000000000000000000000000000000000000000000000000000E+00"/>
+
+        </Variables>
+
+        <Classes NClass="2">
+        <Class Name="background" Index="0"/>
+<Class Name="signal" Index="1"/>
+
+        </Classes>
+
+        <Targets NTrgt="0">
+        
+        </Targets>
+
+        <Transformations NTransformations="0"/>
+        <MVAPdfs/>
+        <Weights NTrees="10" AnalysisType="1">
+        <BinaryTree type="DecisionTree" boostWeight="0.0" itree="0">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.455674E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     2.213857E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     8.488132E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.047221E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     7.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.333334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.538462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.923323E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.151871E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="4" Cut="     1.648732E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     5.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.909091E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.883860E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.526627E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.014050E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.601332E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.049771E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.389937E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.982319E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.468846E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.244095E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.150685E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.190510E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.970180E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.652174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.774413E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.280000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.600000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.615385E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.255814E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.972412E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.045688E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.191716E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.490116E-08" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.666667E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.751296E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.977551E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.666667E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.775176E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.199985E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.264946E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.800000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.967720E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.247875E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.864865E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.346939E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.800608E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.585568E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.504428E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.285052E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.849949E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.118199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.235294E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.468550E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.125949E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.970526E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.801653E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.229508E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.605262E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.672355E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.473684E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.823754E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.333334E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.478261E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.500000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     1.552800E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.742812E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.160494E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.608696E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.952503E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.372861E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.354066E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.976744E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.304348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.601660E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.819860E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.547826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.714286E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.131385E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.142857E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.800000E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.180378E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.628696E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.481240E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.400375E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.953143E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.246305E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.312253E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.868852E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.249078E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.715289E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.978348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="1">
+    <Node pos="c" depth="1" NCoef="0"     IVar="6" Cut="     4.384548E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="5" Cut="     2.274332E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     8.488132E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     1.871094E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     5.492703E-01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.472141E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.164274E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.560957E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.808300E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.436796E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.059993E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.563570E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.241502E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.432088E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.935466E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.158941E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.582456E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.891446E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.818565E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.768744E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.663316E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.190510E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.970180E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -0.000000E+00" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.393017E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.420896E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.826110E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.696385E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.982085E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.643635E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.601116E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.093231E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     8.780770E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.191716E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     3.226973E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.544050E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.691582E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.866112E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.450565E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.189912E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.199985E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.264946E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.505874E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.616896E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.702578E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.305217E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.917358E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.789300E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.494506E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.482702E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.097573E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.019858E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.481886E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.092512E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.995699E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.972586E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.889009E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.273085E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.344291E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.125949E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.663001E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.080946E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.823754E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.728181E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.848998E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.289235E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.850853E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.005888E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.523390E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.537166E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.100212E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.535234E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.597168E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.393780E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.159777E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.498480E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.140664E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.861298E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.802851E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.582063E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.819860E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.315483E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.042340E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.131385E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.266436E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.813475E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.947854E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.881008E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.612760E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.389772E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.517722E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.608304E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.422396E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.564801E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.607310E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.446169E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.096632E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.602275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="2">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.263445E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.672850E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.272733E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.366430E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     6.744442E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.075473E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.182622E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.961860E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.959471E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.509571E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     1.963489E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.606530E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.970209E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.383147E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.216775E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.813419E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.096617E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.194508E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.244297E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.154640E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.441516E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.812340E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.813889E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.734700E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.410587E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.672798E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.389049E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.269896E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.902120E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.103303E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.026798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     1.490116E-08" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.332053E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.229370E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     4.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.976742E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.524144E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.770045E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     9.798622E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.272600E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.009889E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.067198E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.735083E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     7.793491E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.906098E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.624144E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.001898E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.121942E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.822056E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.004725E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.618024E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.249436E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.475824E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.039346E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.274770E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.104672E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.279908E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.250848E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.675191E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.599910E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.326761E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.237938E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.264946E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     2.801077E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.469429E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.455214E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.059016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.033758E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.807265E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.078090E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.847697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.739597E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.136542E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.020219E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.400913E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.409135E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     1.218909E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.142691E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.377049E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.655428E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     9.719414E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.128355E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.056284E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.957841E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.697936E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.983444E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.688710E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.532559E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.175836E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.743867E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.228646E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.655651E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.277181E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.974638E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.572356E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     1.267848E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.371868E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.184236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.215095E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.812364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.021065E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="3">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.270444E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.513466E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.048876E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.434328E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     8.457539E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.924339E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.184694E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.592258E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.316070E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     1.860898E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.076589E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.542204E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.959686E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.120093E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.963060E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.024020E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.947891E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.963918E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.938626E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.702885E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.321676E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.589976E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.458486E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.512255E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     4.364055E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.035069E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.941062E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.723782E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.036326E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.244114E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.168225E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.379073E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.761956E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.974071E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.288349E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.515624E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.932447E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.300723E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.162199E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.408481E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.710581E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.685753E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.416437E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.530137E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.988207E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.229736E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     4.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.587121E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.821329E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.454545E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.648599E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.180822E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.062991E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.114767E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.671098E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.994675E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.084654E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.706239E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.178180E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.988020E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.252670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.390872E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.329522E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.323180E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.690243E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.322913E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.273872E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.407869E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.011241E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.762703E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.402473E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.245793E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.147273E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.601683E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.022277E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.677133E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.016485E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.409135E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     1.943666E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="1" Cut="     4.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.621013E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.685002E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     6.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.219992E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.781707E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     9.624701E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.422364E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.834678E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.632364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     9.435210E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.000083E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.904147E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.190182E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.954556E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.196360E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.553812E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     1.144035E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.395832E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.620602E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.215095E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.924670E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.572468E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.305999E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.965679E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.674979E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="4">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.309899E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.452569E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.045039E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.563091E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     8.457539E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.597100E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.920990E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.346657E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.911415E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.668024E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.308998E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.613299E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.728614E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.416189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.254134E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.590100E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.676972E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.983875E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.332826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.949657E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.957450E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.014935E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.123166E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.479862E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.350000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.872420E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.717933E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.598160E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.480448E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     3.947867E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.490116E-08" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.527220E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.363912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.001559E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.262174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.188026E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.244114E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.928834E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.362798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.607647E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.776690E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.202074E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     7.793491E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.056504E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.464881E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.789300E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.247797E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     4.043145E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     9.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -8.744702E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.763711E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.506345E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.878646E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.085728E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.219545E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.418004E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.798462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.741187E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.607817E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.726761E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.612966E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     9.322913E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     2.801077E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.469429E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.945678E-05" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.465423E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.123661E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.030252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.022277E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.009323E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.047813E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.463161E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.723369E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.654733E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.165745E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.409135E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     1.943666E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.251058E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.925613E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.620348E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.084085E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.024032E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.042444E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.207069E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.871696E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.098114E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.988855E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.964506E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.190182E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.193766E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.595076E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.694932E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.925768E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.429074E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.215095E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.606699E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.301944E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.072266E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.454801E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.178396E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="5">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.131585E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.800000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.344135E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     3.961860E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     6.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     7.310949E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.037316E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.706564E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.702102E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.238619E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.446599E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.038172E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.249675E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.741947E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.645073E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.382174E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.947891E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.147755E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.535377E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.689278E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.542411E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.128280E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.842174E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.087476E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.360633E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.922919E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.512663E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.940275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.238338E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     2.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.730174E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.980309E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.782103E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.716992E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.248701E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.322204E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.065647E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.338151E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     3.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     1.490116E-08" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.253672E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.249885E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.403746E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.457381E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.061854E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.660448E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.293969E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.858387E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     4.248108E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.750117E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.454959E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.860768E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.665051E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.053021E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.606667E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.530779E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.716921E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.855199E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.051247E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     1.009323E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     3.129123E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.046786E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.104960E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.620976E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.754600E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.959415E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.177296E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.312075E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.653960E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.846624E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.979826E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.950760E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     1.484205E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.770916E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.256968E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.410318E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.693098E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     6.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.274034E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.392789E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     4.721901E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.255149E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.292031E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.149416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.422396E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.109644E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.236988E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.371577E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.059054E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.746348E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.232971E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     1.371440E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.420806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.119115E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.249028E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.972291E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.321540E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="6">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.309899E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.297477E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="6" Cut="     3.933876E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.563091E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     8.457539E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.688328E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.293967E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.047148E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.240090E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.078285E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.156597E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.716027E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.611962E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.548656E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     5.416189E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     4.091882E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.963911E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -7.663405E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.467938E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.300451E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.559144E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.579444E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.957450E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     3.504909E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.022610E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.220312E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.216362E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     2.301900E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.917314E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.706062E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     7.182684E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.018008E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.516193E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     1.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.301931E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.316351E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.654645E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.682458E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.242223E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     3.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     1.490116E-08" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.035499E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.129571E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="1" Cut="     3.650000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.075280E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.930503E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="6" Cut="     4.979082E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     2.979119E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     1.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.709708E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.114893E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.566272E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.703433E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.431675E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.275805E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.340149E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     2.258068E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.518462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.513986E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     1.009323E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     2.801790E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.469429E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.930195E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.204112E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     3.450000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.764458E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.432743E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     3.199988E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     4.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.201468E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.442277E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.899832E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.235236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.508326E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="8" Cut="     1.829931E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="5" Cut="     3.303985E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.612863E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.769635E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.882678E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.169343E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.053049E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.137091E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.104128E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.197806E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="3" Cut="     4.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.373360E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.706756E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.477111E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     6.186841E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.231973E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.209115E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.254510E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.434213E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.118961E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.409488E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.403346E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.216795E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     8.072266E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.232798E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.470776E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="7">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.344642E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     3.936477E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.161408E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.047009E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.275433E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.349930E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.989142E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.223718E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.903739E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     1.616828E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.954622E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.425682E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.259542E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.092194E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.299690E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.225916E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.729526E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.684792E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.641912E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.918184E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     1.678877E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.055722E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.846933E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.604766E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.265932E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.468064E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.856007E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     5.422417E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.974871E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.990416E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.833620E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.050667E-03" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.572424E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.883782E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.711974E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.373008E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.041374E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.201921E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.443118E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.239241E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.832285E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.146188E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.212456E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.186448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.743225E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.883792E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.211139E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.432647E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.865076E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.145146E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.266411E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.942160E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.647255E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     3.470910E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.732542E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.167481E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     2.511651E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.148442E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.278416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.281253E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.230689E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     4.029348E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.853232E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.289003E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.215236E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.182819E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.549502E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.187462E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.401600E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     1.556754E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.121080E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.070452E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.387277E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     8.911173E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.743418E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.786387E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.181275E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="7" Cut="     3.034896E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     3.031245E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.223943E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.030815E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.412729E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.402178E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.072266E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.181015E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.128188E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.080392E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     4.133794E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.802252E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.752272E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="8">
+    <Node pos="c" depth="1" NCoef="0"     IVar="4" Cut="     1.086399E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="3" Cut="     8.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     1.056129E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="0" Cut="     5.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     6.449922E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.870569E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.149027E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     2.290268E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.114770E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.107727E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     4.141284E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.175450E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.393980E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.969380E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.292977E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     1.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     6.602059E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.368953E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.442792E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.126028E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="0" Cut="     3.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     6.611624E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.305933E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.877676E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     4.430260E-04" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.033470E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.541496E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     4.104548E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.135619E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.385978E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.645819E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.470416E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.745579E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.164835E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.079775E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="8" Cut="     3.368805E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="3" Cut="     2.000000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.849378E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.368715E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.504878E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.745047E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.993765E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="5" Cut="     4.297419E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.233212E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     2.500815E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.578835E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.105763E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.771221E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.840637E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.628613E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.792725E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.646093E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.009378E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.114403E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     4.999083E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     9.951302E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.682414E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="3" Cut="     1.200000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="6" Cut="     4.965183E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="1" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.793667E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     7.375531E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.955075E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.025043E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.601474E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     5.783501E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.941172E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     2.092567E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     4.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.779008E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.443457E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     9.045685E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     3.051938E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.561944E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.477222E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     3.891824E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.410833E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.381911E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     3.458900E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.784702E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.156344E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     5.409488E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     4.219477E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.375493E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.006839E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.114142E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="7" Cut="     1.707507E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     1.690167E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     2.337907E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.049361E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.948363E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.762872E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.147451E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.552126E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.950000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.473574E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.845895E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.259389E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.214611E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.460071E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     1.145312E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="0" Cut="     8.500000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.994449E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.324363E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.122944E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.801353E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="6" Cut="     4.243794E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="5" Cut="     3.022277E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.078492E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.038234E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     2.986450E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.862584E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.974810E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+<BinaryTree type="DecisionTree" boostWeight="0.0" itree="9">
+    <Node pos="c" depth="1" NCoef="0"     IVar="3" Cut="     1.400000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+        <Node pos="l" depth="2" NCoef="0"     IVar="6" Cut="     4.061686E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.150000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="7" Cut="     1.135619E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.782381E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.523823E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.078124E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     6.698177E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     8.407974E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.454394E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="5" Cut="     2.911766E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.285667E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.949564E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.831008E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     3.745579E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.286171E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.262534E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="4" Cut="     1.128284E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     3.448390E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.786520E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.115135E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.358671E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -6.143013E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.414770E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="1" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     3.759769E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.384729E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.048697E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     3.931963E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.234296E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.187895E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="6" Cut="     5.548800E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="8" Cut="     3.252765E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="7" Cut="     2.541235E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     2.569396E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.391615E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.403205E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="5" Cut="     3.165769E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.520746E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.747480E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="7" Cut="     2.729326E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.439672E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -4.069379E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.213016E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.124892E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.281717E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.574386E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     3.503608E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="6" Cut="     6.186448E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     3.874071E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.024415E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.233019E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     1.432647E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.904902E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.976364E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     4.902108E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.090982E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     4.970148E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.930019E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.839820E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+        <Node pos="r" depth="2" NCoef="0"     IVar="7" Cut="     2.736493E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0"     IVar="0" Cut="     1.050000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="3" Cut="     3.550000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="3" Cut="     2.600000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     1.126827E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.214427E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.244059E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="6" Cut="     6.345709E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.069641E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.028312E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="3" Cut="     3.750000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="1" Cut="     3.850000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.691615E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.729777E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="8" Cut="     4.501104E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.325573E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.132511E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="6" Cut="     3.854745E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="5" Cut="     2.853232E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="7" Cut="     9.289003E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.697335E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.094296E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="4" Cut="     1.258054E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     1.478394E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     4.061950E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="2" Cut="     2.000000E+00" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="8" Cut="     1.556560E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     6.212844E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.798726E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="7" Cut="     2.675628E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.544568E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -9.427382E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+            <Node pos="r" depth="3" NCoef="0"     IVar="0" Cut="     1.250000E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                <Node pos="l" depth="4" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.066628E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                </Node>
+                <Node pos="r" depth="4" NCoef="0"     IVar="8" Cut="     2.986450E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                    <Node pos="l" depth="5" NCoef="0"     IVar="8" Cut="     2.978228E-02" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="4" Cut="     2.093469E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -5.962938E-02" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -2.778150E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     7.404984E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                    <Node pos="r" depth="5" NCoef="0"     IVar="4" Cut="     8.072266E+01" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                        <Node pos="l" depth="6" NCoef="0"     IVar="6" Cut="     4.206457E-03" cType="1"     res="     0.000000E+00" rms="0.0"     purity="0.00000000E+00" nType="0">
+                            <Node pos="l" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -1.757464E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                            <Node pos="r" depth="7" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="    -3.010269E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                            </Node>
+                        </Node>
+                        <Node pos="r" depth="6" NCoef="0"     IVar="-1" Cut="     0.000000E+00" cType="1"     res="     2.059851E-01" rms="0.0e-00"     purity="0.00000000E+00" nType="-99">
+                        </Node>
+                    </Node>
+                </Node>
+            </Node>
+        </Node>
+    </Node>
+</BinaryTree>
+
+          </Weights>
+        </MethodSetup>
+        

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 
 inputs_small = ['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean']
 inputs_large = ['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
@@ -75,7 +76,8 @@ working_points_drnn_dbscan = [
 input_features_histomax = {
         "v8_352":inputs_small,
         "v9_370":inputs_large,
-        "v9_394":inputs_large
+        "v9_394":inputs_large,
+        "v10_3151":inputs_large
         }
 
 bdt_weights_histomax = {
@@ -96,6 +98,12 @@ bdt_weights_histomax = {
                 'L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml',
                 # High eta
                 'L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml'
+                ],
+        "v10_3151":[ #trained using TPG software version 3.15.1
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_3151_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_3151_higheta_v0.xml'
                 ]
         }
 
@@ -128,7 +136,7 @@ working_points_histomax = {
                 {
                 '900':0.7078400, #epsilon_b = 3.5%
                 '950':-0.0239623, #epsilon_b = 6.9%
-                '975':-0.7045071, #epsilon_b = 11.6% 
+                '975':-0.7045071, #epsilon_b = 11.6%
                 '995':-0.9811426, #epsilon_b = 26.1%
                 }
              ],
@@ -144,8 +152,24 @@ working_points_histomax = {
                 {
                 '900':0.8825340, #epsilon_b = 1.0%
                 '950':0.2856039, #epsilon_b = 1.7%
-                '975':-0.5274948, #epsilon_b = 2.8% 
+                '975':-0.5274948, #epsilon_b = 2.8%
                 '995':-0.9864445, #epsilon_b = 7.6%
+                }
+             ],
+        "v10_3151": [
+                # Low eta
+                {
+                 '900': 0.9903189,
+                 '950': 0.9646683,
+                 '975': 0.8292287,
+                 '995': -0.7099538,
+                },
+                # High eta
+                {
+                 '900': 0.9932326,
+                 '950': 0.9611762,
+                 '975': 0.7616282,
+                 '995': -0.9163715,
                 }
              ]
         }
@@ -190,5 +214,13 @@ phase2_hgcalV9.toModify(egamma_identification_histomax,
         Weights=cms.vstring(bdt_weights_histomax['v9_394']),
         WorkingPoints=cms.vdouble(
                 [wps[eff] for wps,eff in zip(working_points_histomax['v9_394'],tight_wp)]
+                )
+        )
+
+phase2_hgcalV10.toModify(egamma_identification_histomax,
+        Inputs=cms.vstring(input_features_histomax['v10_3151']),
+        Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
+        WorkingPoints=cms.vdouble(
+                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
                 )
         )


### PR DESCRIPTION
#### PR description:

This PR integrates the model and the WPs presented by Joe Davies in:
https://indico.cern.ch/event/861132/contributions/3630842/attachments/1940094/3216452/e_gamma_ID_for_HGCAL_L1T_v10_geometry.pdf

#### PR validation:

A check on the efficiencies can be found in:
https://nbviewer.jupyter.org/github/cerminar/plot-drawing-tools/blob/v131/plotter-eff-genmatching-tp.ipynb
https://nbviewer.jupyter.org/github/cerminar/plot-drawing-tools/blob/v131/plotter-rate.ipynb

Several aspects will need further investigation, but, in my opinion, this is a step forward w.r.t the old ID.

Next: test performance on V11 samples.  
