### PR TITLE
Refined calibrations for EM inerpretation in v11 v10 and v9 geometries

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -145,21 +145,21 @@ histoMax_C3d_params = cms.PSet(
 
 
 energy_interpretations_em = cms.PSet(type = cms.string('HGCalTriggerClusterInterpretationEM'),
-                                     layer_containment_corrs = cms.vdouble(0., 0., 1.6144949, 0.92495334, 1.0820811, 0.9753549, 0.9742881, 1.0634482, 1.0599478, 0.9376349, 0.92587173, 0.8003076, 1.0417082, 1.7032381, 2.),
-                                     scale_correction_coeff = cms.vdouble(16.68182373, -8.487143517),
+                                     layer_containment_corrs = cms.vdouble(0., 0.0, 1.38, 0.97, 1.11, 0.92, 1.06, 1.01, 1.06, 0.89, 1.0, 1.06, 0.89, 1.62, 1.83),
+                                     scale_correction_coeff = cms.vdouble(-27.15, 53.94),
                                      dr_bylayer = cms.vdouble([0.015]*15)
                                      )
 
 phase2_hgcalV10.toModify(
         energy_interpretations_em,
-        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 2.0, 0.63, 0.5, 1.91, 0.5, 1.3, 1.27, 0.66, 0.76, 0.78, 2.0, 2.0),
-        scale_correction_coeff=cms.vdouble(-43.074539, 76.823082),
+        layer_containment_corrs=cms.vdouble(0., 0.0, 1.73, 0.97, 1.08, 1.1, 1.01, 0.96, 1.18, 0.98, 1.05, 0.99, 0.89, 1.75, 2.0),
+        scale_correction_coeff=cms.vdouble(-27.53, 53.92),
         )
 
 phase2_hgcalV11.toModify(
         energy_interpretations_em,
-        layer_containment_corrs=cms.vdouble(0., 0.0, 2.0, 1.29, 0.5, 1.73, 0.5, 1.25, 1.46, 0.75, 0.68, 0.5, 1.89, 1.83, 1.71),
-        scale_correction_coeff=cms.vdouble(-41.7769, 80.5795),
+        layer_containment_corrs=cms.vdouble(0., 0.0, 1.28, 1.09, 1.0, 1.07, 1.09, 1.04, 1.0, 1.09, 1.07, 1.03, 0.93, 1.4, 1.89),
+        scale_correction_coeff=cms.vdouble(-24.96, 52.99),
         )
 
 


### PR DESCRIPTION
#### PR description:

A better calibration for the EM interpreted cluster in the HGC V11 geometry (CMS D49).

The main difference is the application of a tighter eta cut on the clusters used to derive the calibrations (both the layer by layer coefficients and the eta dependent scale correction).

#### PR validation:

![canvas(103)](https://user-images.githubusercontent.com/4802196/84399845-9f8d3e00-ac01-11ea-8869-e971f00ebf90.png)
![canvas(102)](https://user-images.githubusercontent.com/4802196/84399908-addb5a00-ac01-11ea-8f02-04310df73db5.png)
![canvas(101)](https://user-images.githubusercontent.com/4802196/84399939-b59afe80-ac01-11ea-88f8-b53a7943806c.png)
![canvas(100)](https://user-images.githubusercontent.com/4802196/84399995-c8adce80-ac01-11ea-9dd1-07a93a0c0167.png)
![canvas(99)](https://user-images.githubusercontent.com/4802196/84400005-cb102880-ac01-11ea-9aca-1313664554c1.png)
