### PR TITLE
Trigger towers in HGCal

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
@@ -19,11 +19,14 @@ typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>,
     HGCalConcentratorProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalClusterBxCollection>
     HGCalBackendLayer1ProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalClusterBxCollection>, l1t::HGCalMulticlusterBxCollection>
+typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalClusterBxCollection>,
+                            std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection> >
     HGCalBackendLayer2ProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalTowerMapBxCollection>
+typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerSumsBxCollection>, l1t::HGCalTowerMapBxCollection>
     HGCalTowerMapProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTowerMapBxCollection>, l1t::HGCalTowerBxCollection>
+typedef HGCalProcessorBaseT<
+    std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection> >,
+    l1t::HGCalTowerBxCollection>
     HGCalTowerProcessorBase;
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
@@ -18,6 +18,8 @@ public:
 
   void setGeometry(const HGCalTriggerGeometryBase* const geom) { geometry_ = geom; }
 
+  virtual void eventSetup(const edm::EventSetup& es){};
+
   virtual void run(const InputCollection& inputColl, OutputCollection& outColl, const edm::EventSetup& es) = 0;
 
 protected:

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -13,6 +13,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 
 #include <vector>
 #include <unordered_map>
@@ -32,7 +34,9 @@ public:
 
   const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 
-  unsigned short getTriggerTowerFromTriggerCell(const unsigned tcId, const float& eta, const float& phi) const;
+  unsigned short getTriggerTowerFromEtaPhi(const float& eta, const float& phi) const;
+  unsigned short getTriggerTower(const l1t::HGCalTriggerCell&) const;
+  unsigned short getTriggerTower(const l1t::HGCalTriggerSums&) const;
 
 private:
   std::vector<l1t::HGCalTowerCoord> tower_coords_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
@@ -32,17 +32,21 @@ public:
   void clusterizeHisto(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtr,
                        const std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                        const HGCalTriggerGeometryBase& triggerGeometry,
-                       l1t::HGCalMulticlusterBxCollection& multiclusters) const;
+                       l1t::HGCalMulticlusterBxCollection& multiclusters,
+                       l1t::HGCalClusterBxCollection& rejected_clusters) const;
 
 private:
   enum ClusterAssociationStrategy { NearestNeighbour, EnergySplit };
 
   std::vector<l1t::HGCalMulticluster> clusterSeedMulticluster(
       const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-      const std::vector<std::pair<GlobalPoint, double>>& seeds) const;
+      const std::vector<std::pair<GlobalPoint, double>>& seeds,
+      std::vector<l1t::HGCalCluster>& rejected_clusters) const;
 
   void finalizeClusters(std::vector<l1t::HGCalMulticluster>&,
+                        std::vector<l1t::HGCalCluster>&,
                         l1t::HGCalMulticlusterBxCollection&,
+                        l1t::HGCalClusterBxCollection&,
                         const HGCalTriggerGeometryBase&) const;
 
   double dr_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
@@ -5,6 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
@@ -16,8 +17,37 @@ public:
 
   void resetTowerMaps();
 
-  void buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& triggerCellsPtrs,
-                       l1t::HGCalTowerMapBxCollection& towermaps);
+  template <class T>
+  void buildTowerMap2D(const std::vector<edm::Ptr<T>>& ptrs, l1t::HGCalTowerMapBxCollection& towerMaps) {
+    std::unordered_map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
+
+    for (auto ptr : ptrs) {
+      if (triggerTools_.isNose(ptr->detId()))
+        continue;
+      unsigned layer = triggerTools_.layerWithOffset(ptr->detId());
+      if (towerMapsTmp.find(layer) == towerMapsTmp.end()) {
+        throw cms::Exception("Out of range")
+            << "HGCalTowerMap2dImpl: Found trigger sum in layer " << layer << " for which there is no tower map\n";
+      }
+      // FIXME: should actually sum the energy not the Et...
+      double calibPt = ptr->pt();
+      if (useLayerWeights_)
+        calibPt = layerWeights_[layer] * ptr->mipPt();
+
+      double etEm = layer <= triggerTools_.lastLayerEE() ? calibPt : 0;
+      double etHad = layer > triggerTools_.lastLayerEE() ? calibPt : 0;
+
+      towerMapsTmp[layer].addEt(towerGeometryHelper_.getTriggerTower(*ptr), etEm, etHad);
+    }
+
+    /* store towerMaps in the persistent collection */
+    towerMaps.resize(0, towerMapsTmp.size());
+    int i = 0;
+    for (auto towerMap : towerMapsTmp) {
+      towerMaps.set(0, i, towerMap.second);
+      i++;
+    }
+  }
 
   void eventSetup(const edm::EventSetup& es) {
     triggerTools_.eventSetup(es);

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -15,6 +15,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
 #include <memory>
+#include <utility>
 
 class HGCalBackendLayer2Producer : public edm::stream::EDProducer<> {
 public:
@@ -43,6 +44,7 @@ HGCalBackendLayer2Producer::HGCalBackendLayer2Producer(const edm::ParameterSet& 
       HGCalBackendLayer2Factory::get()->create(beProcessorName, beParamConfig)};
 
   produces<l1t::HGCalMulticlusterBxCollection>(backendProcess_->name());
+  produces<l1t::HGCalClusterBxCollection>(backendProcess_->name());
 }
 
 void HGCalBackendLayer2Producer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
@@ -52,14 +54,15 @@ void HGCalBackendLayer2Producer::beginRun(const edm::Run& /*run*/, const edm::Ev
 
 void HGCalBackendLayer2Producer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output collections
-  auto be_multicluster_output = std::make_unique<l1t::HGCalMulticlusterBxCollection>();
+  std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection> be_output;
 
   // Input collections
   edm::Handle<l1t::HGCalClusterBxCollection> trigCluster2DBxColl;
 
   e.getByToken(input_clusters_, trigCluster2DBxColl);
 
-  backendProcess_->run(trigCluster2DBxColl, *be_multicluster_output, es);
+  backendProcess_->run(trigCluster2DBxColl, be_output, es);
 
-  e.put(std::move(be_multicluster_output), backendProcess_->name());
+  e.put(std::make_unique<l1t::HGCalMulticlusterBxCollection>(std::move(be_output.first)), backendProcess_->name());
+  e.put(std::make_unique<l1t::HGCalClusterBxCollection>(std::move(be_output.second)), backendProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
@@ -25,7 +25,7 @@ public:
 
 private:
   // inputs
-  edm::EDGetToken input_cell_;
+  edm::EDGetToken input_sums_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   std::unique_ptr<HGCalTowerMapProcessorBase> towersMapProcess_;
@@ -34,7 +34,7 @@ private:
 DEFINE_FWK_MODULE(HGCalTowerMapProducer);
 
 HGCalTowerMapProducer::HGCalTowerMapProducer(const edm::ParameterSet& conf)
-    : input_cell_(consumes<l1t::HGCalTriggerCellBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerCells"))) {
+    : input_sums_(consumes<l1t::HGCalTriggerSumsBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerSums"))) {
   //setup TowerMap parameters
   const edm::ParameterSet& towerMapParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& towerMapProcessorName = towerMapParamConfig.getParameter<std::string>("ProcessorName");
@@ -54,11 +54,11 @@ void HGCalTowerMapProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   auto towersMap_output = std::make_unique<l1t::HGCalTowerMapBxCollection>();
 
   // Input collections
-  edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
+  edm::Handle<l1t::HGCalTriggerSumsBxCollection> trigSumBxColl;
 
-  e.getByToken(input_cell_, trigCellBxColl);
+  e.getByToken(input_sums_, trigSumBxColl);
 
-  towersMapProcess_->run(trigCellBxColl, *towersMap_output, es);
+  towersMapProcess_->run(trigSumBxColl, *towersMap_output, es);
 
   e.put(std::move(towersMap_output), towersMapProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
@@ -26,6 +26,7 @@ public:
 private:
   // inputs
   edm::EDGetToken input_towers_map_;
+  edm::EDGetToken input_trigger_cells_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   std::unique_ptr<HGCalTowerProcessorBase> towersProcess_;
@@ -34,7 +35,9 @@ private:
 DEFINE_FWK_MODULE(HGCalTowerProducer);
 
 HGCalTowerProducer::HGCalTowerProducer(const edm::ParameterSet& conf)
-    : input_towers_map_(consumes<l1t::HGCalTowerMapBxCollection>(conf.getParameter<edm::InputTag>("InputTowerMaps"))) {
+    : input_towers_map_(consumes<l1t::HGCalTowerMapBxCollection>(conf.getParameter<edm::InputTag>("InputTowerMaps"))),
+      input_trigger_cells_(
+          consumes<l1t::HGCalClusterBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerCells"))) {
   //setup TowerMap parameters
   const edm::ParameterSet& towerParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& towerProcessorName = towerParamConfig.getParameter<std::string>("ProcessorName");
@@ -44,6 +47,7 @@ HGCalTowerProducer::HGCalTowerProducer(const edm::ParameterSet& conf)
 }
 
 void HGCalTowerProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+  towersProcess_->eventSetup(es);
   es.get<CaloGeometryRecord>().get("", triggerGeometry_);
   towersProcess_->setGeometry(triggerGeometry_.product());
 }
@@ -53,11 +57,14 @@ void HGCalTowerProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   auto towers_output = std::make_unique<l1t::HGCalTowerBxCollection>();
 
   // Input collections
-  edm::Handle<l1t::HGCalTowerMapBxCollection> towersMapBxColl;
+  std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection> > inputsColl;
+  auto& towersMapBxColl = inputsColl.first;
+  auto& clustersBxColl = inputsColl.second;
 
   e.getByToken(input_towers_map_, towersMapBxColl);
+  e.getByToken(input_trigger_cells_, clustersBxColl);
 
-  towersProcess_->run(towersMapBxColl, *towers_output, es);
+  towersProcess_->run(inputsColl, *towers_output, es);
 
   e.put(std::move(towers_output), towersProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
 
@@ -14,21 +14,21 @@ public:
     towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>(conf.getParameterSet("towermap_parameters"));
   }
 
-  void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+  void run(const edm::Handle<l1t::HGCalTriggerSumsBxCollection>& collHandle,
            l1t::HGCalTowerMapBxCollection& collTowerMap,
            const edm::EventSetup& es) override {
     es.get<CaloGeometryRecord>().get("", triggerGeometry_);
     towermap2D_->eventSetup(es);
 
-    /* create a persistent vector of pointers to the trigger-cells */
-    std::vector<edm::Ptr<l1t::HGCalTriggerCell>> triggerCellsPtrs;
+    /* create a persistent vector of pointers to the trigger-sums */
+    std::vector<edm::Ptr<l1t::HGCalTriggerSums>> triggerSumsPtrs;
     for (unsigned i = 0; i < collHandle->size(); ++i) {
-      edm::Ptr<l1t::HGCalTriggerCell> ptr(collHandle, i);
-      triggerCellsPtrs.push_back(ptr);
+      edm::Ptr<l1t::HGCalTriggerSums> ptr(collHandle, i);
+      triggerSumsPtrs.push_back(ptr);
     }
 
     /* call to towerMap2D clustering */
-    towermap2D_->buildTowerMap2D(triggerCellsPtrs, collTowerMap);
+    towermap2D_->buildTowerMap2D(triggerSumsPtrs, collTowerMap);
   }
 
 private:

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -6,24 +6,53 @@
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
 
 class HGCalTowerProcessor : public HGCalTowerProcessorBase {
 public:
   HGCalTowerProcessor(const edm::ParameterSet& conf) : HGCalTowerProcessorBase(conf) {
+    towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>(conf.getParameterSet("towermap_parameters"));
     towermap3D_ = std::make_unique<HGCalTowerMap3DImpl>();
   }
 
-  void run(const edm::Handle<l1t::HGCalTowerMapBxCollection>& collHandle,
+  void eventSetup(const edm::EventSetup& es) override { towermap2D_->eventSetup(es); }
+
+  void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
+               collHandle,
            l1t::HGCalTowerBxCollection& collTowers,
            const edm::EventSetup& es) override {
     es.get<CaloGeometryRecord>().get("", triggerGeometry_);
 
+    auto& towerMapCollHandle = collHandle.first;
+    auto& unclTCsCollHandle = collHandle.second;
+
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    for (unsigned i = 0; i < collHandle->size(); ++i) {
-      edm::Ptr<l1t::HGCalTowerMap> ptr(collHandle, i);
-      towerMapsPtrs.push_back(ptr);
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+      towerMapsPtrs.emplace_back(towerMapCollHandle, i);
+    }
+
+    /* create additional TowerMaps from the unclustered TCs */
+
+    // translate our HGCalClusters into HGCalTriggerCells
+    std::vector<edm::Ptr<l1t::HGCalTriggerCell>> trigCellVec;
+    for (unsigned i = 0; i < unclTCsCollHandle->size(); ++i) {
+      edm::Ptr<l1t::HGCalCluster> ptr(unclTCsCollHandle, i);
+      for (auto itTC : ptr->constituents()) {
+        trigCellVec.push_back(itTC.second);
+      }
+    }
+
+    // fill the TowerMaps with the HGCalTriggersCells
+    l1t::HGCalTowerMapBxCollection towerMapsFromUnclTCs;
+    towermap2D_->buildTowerMap2D(trigCellVec, towerMapsFromUnclTCs);
+
+    /* merge the two sets of TowerMaps */
+    unsigned int towerMapsPtrsSize = towerMapsPtrs.size();
+    for (unsigned int i = 0; i < towerMapsFromUnclTCs.size(); ++i) {
+      towerMapsPtrs.emplace_back(&(towerMapsFromUnclTCs[i]), i + towerMapsPtrsSize);
     }
 
     /* call to towerMap3D clustering */
@@ -34,6 +63,7 @@ private:
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   /* algorithms instances */
+  std::unique_ptr<HGCalTowerMap2DImpl> towermap2D_;
   std::unique_ptr<HGCalTowerMap3DImpl> towermap3D_;
 };
 

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -22,10 +22,10 @@ tower_map = cms.PSet( ProcessorName  = cms.string('HGCalTowerMapProcessor'),
 
 hgcalTowerMapProducer = cms.EDProducer(
     "HGCalTowerMapProducer",
-    InputTriggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
+    InputTriggerSums = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
     ProcessorParameters = tower_map.clone()
     )
 
 hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone(
-    InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')
+    InputTriggerSums = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')
 )

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -1,16 +1,20 @@
 import FWCore.ParameterSet.Config as cms
+import L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi as hgcalTowerMapProducer_cfi
 
-tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor')
+tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
+      towermap_parameters = hgcalTowerMapProducer_cfi.towerMap2D_parValues.clone()
                   )
 
 hgcalTowerProducer = cms.EDProducer(
     "HGCalTowerProducer",
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
-    ProcessorParameters = tower.clone()
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'), 
+    ProcessorParameters = tower.clone(),
     )
 
 
 hgcalTowerProducerHFNose = hgcalTowerProducer.clone(
-    InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+    InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor'),
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering'), 
 )
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -37,9 +37,10 @@ float HGCalHistoClusteringImpl::dR(const l1t::HGCalCluster& clu, const GlobalPoi
 
 std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticluster(
     const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-    const std::vector<std::pair<GlobalPoint, double>>& seeds) const {
+    const std::vector<std::pair<GlobalPoint, double>>& seeds,
+    std::vector<l1t::HGCalCluster>& rejected_clusters) const {
   std::map<int, l1t::HGCalMulticluster> mapSeedMulticluster;
-  std::vector<l1t::HGCalMulticluster> multiclustersTmp;
+  std::vector<l1t::HGCalMulticluster> multiclustersOut;
 
   for (const auto& clu : clustersPtrs) {
     int z_side = triggerTools_.zside(clu->detId());
@@ -77,8 +78,10 @@ std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticl
       }
     }
 
-    if (targetSeedsEnergy.empty())
+    if (targetSeedsEnergy.empty()) {
+      rejected_clusters.emplace_back(*clu);
       continue;
+    }
     //Loop over target seeds and divide up the clusters energy
     double totalTargetSeedEnergy = 0;
     for (const auto& energy : targetSeedsEnergy) {
@@ -98,24 +101,33 @@ std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticl
   }
 
   for (const auto& mclu : mapSeedMulticluster)
-    multiclustersTmp.emplace_back(mclu.second);
+    multiclustersOut.emplace_back(mclu.second);
 
-  return multiclustersTmp;
+  return multiclustersOut;
 }
 
 void HGCalHistoClusteringImpl::clusterizeHisto(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
                                                const std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                                                const HGCalTriggerGeometryBase& triggerGeometry,
-                                               l1t::HGCalMulticlusterBxCollection& multiclusters) const {
+                                               l1t::HGCalMulticlusterBxCollection& multiclusters,
+                                               l1t::HGCalClusterBxCollection& rejected_clusters) const {
   /* clusterize clusters around seeds */
-  std::vector<l1t::HGCalMulticluster> multiclustersTmp = clusterSeedMulticluster(clustersPtrs, seedPositionsEnergy);
+  std::vector<l1t::HGCalCluster> rejected_clusters_vec;
+  std::vector<l1t::HGCalMulticluster> multiclusters_vec =
+      clusterSeedMulticluster(clustersPtrs, seedPositionsEnergy, rejected_clusters_vec);
   /* making the collection of multiclusters */
-  finalizeClusters(multiclustersTmp, multiclusters, triggerGeometry);
+  finalizeClusters(multiclusters_vec, rejected_clusters_vec, multiclusters, rejected_clusters, triggerGeometry);
 }
 
 void HGCalHistoClusteringImpl::finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
+                                                std::vector<l1t::HGCalCluster>& rejected_clusters_in,
                                                 l1t::HGCalMulticlusterBxCollection& multiclusters_out,
+                                                l1t::HGCalClusterBxCollection& rejected_clusters_out,
                                                 const HGCalTriggerGeometryBase& triggerGeometry) const {
+  for (auto& tc : rejected_clusters_in) {
+    rejected_clusters_out.push_back(0, tc);
+  }
+
   for (auto& multicluster : multiclusters_in) {
     // compute the eta, phi from its barycenter
     // + pT as scalar sum of pT of constituents
@@ -133,6 +145,10 @@ void HGCalHistoClusteringImpl::finalizeClusters(std::vector<l1t::HGCalMulticlust
       multicluster.saveHOverE();
 
       multiclusters_out.push_back(0, multicluster);
+    } else {
+      for (auto& tc : multicluster.constituents()) {
+        rejected_clusters_out.push_back(0, *(tc.second));
+      }
     }
   }
 }

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
@@ -26,36 +26,3 @@ std::unordered_map<int, l1t::HGCalTowerMap> HGCalTowerMap2DImpl::newTowerMaps() 
 
   return towerMaps;
 }
-
-void HGCalTowerMap2DImpl::buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& triggerCellsPtrs,
-                                          l1t::HGCalTowerMapBxCollection& towerMaps) {
-  std::unordered_map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
-
-  for (auto tc : triggerCellsPtrs) {
-    if (triggerTools_.isNose(tc->detId()))
-      continue;
-    unsigned layer = triggerTools_.layerWithOffset(tc->detId());
-    if (towerMapsTmp.find(layer) == towerMapsTmp.end()) {
-      throw cms::Exception("Out of range")
-          << "HGCalTowerMap2dImpl: Found trigger cell in layer " << layer << " for which there is no tower map\n";
-    }
-    // FIXME: should actually sum the energy not the Et...
-    double calibPt = tc->pt();
-    if (useLayerWeights_)
-      calibPt = layerWeights_[layer] * tc->mipPt();
-
-    double etEm = layer <= triggerTools_.lastLayerEE() ? calibPt : 0;
-    double etHad = layer > triggerTools_.lastLayerEE() ? calibPt : 0;
-
-    towerMapsTmp[layer].addEt(
-        towerGeometryHelper_.getTriggerTowerFromTriggerCell(tc->detId(), tc->eta(), tc->phi()), etEm, etHad);
-  }
-
-  /* store towerMaps in the persistent collection */
-  towerMaps.resize(0, towerMapsTmp.size());
-  int i = 0;
-  for (auto towerMap : towerMapsTmp) {
-    towerMaps.set(0, i, towerMap.second);
-    i++;
-  }
-}


### PR DESCRIPTION
#### PR description:

- trigger towers are built from trigger sums, instead of trigger cells.
- unclustered trigger cells are now also included into the trigger towers.

#### PR validation:

- ran `code-checks`, `code-format`, `runtests`.
- `L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV10_cfg.py` gives an apparently sensible output, though I have not compared it yet between before and after this PR.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport