### PR TITLE
save OOT digis as separate branches

### DIFF
--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -31,6 +31,9 @@ private:
   bool is_Simhit_comp_;
   edm::EDGetToken SimHits_inputee_, SimHits_inputfh_, SimHits_inputbh_;
 
+  std::vector<unsigned int> digiBXselect_;
+  static constexpr unsigned kDigiSize_ = 5;
+
   HGCalTriggerTools triggerTools_;
 
   int hgcdigi_n_;
@@ -75,6 +78,17 @@ DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCDigis, "HGCalT
 
 HGCalTriggerNtupleHGCDigis::HGCalTriggerNtupleHGCDigis(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
   is_Simhit_comp_ = conf.getParameter<bool>("isSimhitComp");
+  digiBXselect_ = conf.getParameter<std::vector<unsigned int>>("digiBXselect");
+
+  if (*std::max_element(digiBXselect_.begin(), digiBXselect_.end()) >= kDigiSize_) {
+    throw cms::Exception("BadInitialization")
+        << "digiBXselect vector requests a BX outside of maximum size of digis (" << kDigiSize_ << " BX)";
+  }
+  //sort and check for duplicates
+  std::sort(digiBXselect_.begin(), digiBXselect_.end());
+  if (std::unique(digiBXselect_.begin(), digiBXselect_.end()) != digiBXselect_.end()) {
+    throw cms::Exception("BadInitialization") << "digiBXselect vector contains duplicate BX values";
+  }
 }
 
 void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
@@ -88,6 +102,12 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
     SimHits_inputfh_ = collector.consumes<edm::PCaloHitContainer>(conf.getParameter<edm::InputTag>("fhSimHits"));
     SimHits_inputbh_ = collector.consumes<edm::PCaloHitContainer>(conf.getParameter<edm::InputTag>("bhSimHits"));
   }
+
+  hgcdigi_data_.resize(digiBXselect_.size());
+  hgcdigi_isadc_.resize(digiBXselect_.size());
+  bhdigi_data_.resize(digiBXselect_.size());
+  bhdigi_isadc_.resize(digiBXselect_.size());
+
   tree.Branch("hgcdigi_n", &hgcdigi_n_, "hgcdigi_n/I");
   tree.Branch("hgcdigi_id", &hgcdigi_id_);
   tree.Branch("hgcdigi_subdet", &hgcdigi_subdet_);
@@ -97,8 +117,16 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
   tree.Branch("hgcdigi_eta", &hgcdigi_eta_);
   tree.Branch("hgcdigi_phi", &hgcdigi_phi_);
   tree.Branch("hgcdigi_z", &hgcdigi_z_);
-  tree.Branch("hgcdigi_data", &hgcdigi_data_);
-  tree.Branch("hgcdigi_isadc", &hgcdigi_isadc_);
+  std::string bname;
+  auto withBX([&bname](char const* vname, unsigned int bx) -> char const* {
+    bname = std::string(vname) + "_BX" + to_string(bx);
+    return bname.c_str();
+  });
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    unsigned int bxi = digiBXselect_[i];
+    tree.Branch(withBX("hgcdigi_data", bxi), &hgcdigi_data_[i]);
+    tree.Branch(withBX("hgcdigi_isadc", bxi), &hgcdigi_isadc_[i]);
+  }
   // V9 detid scheme
   tree.Branch("hgcdigi_waferu", &hgcdigi_waferu_);
   tree.Branch("hgcdigi_waferv", &hgcdigi_waferv_);
@@ -120,8 +148,11 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
   tree.Branch("bhdigi_eta", &bhdigi_eta_);
   tree.Branch("bhdigi_phi", &bhdigi_phi_);
   tree.Branch("bhdigi_z", &bhdigi_z_);
-  tree.Branch("bhdigi_data", &bhdigi_data_);
-  tree.Branch("bhdigi_isadc", &bhdigi_isadc_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    unsigned int bxi = digiBXselect_[i];
+    tree.Branch(withBX("bhdigi_data", bxi), &bhdigi_data_[i]);
+    tree.Branch(withBX("bhdigi_isadc", bxi), &bhdigi_isadc_[i]);
+  }
   if (is_Simhit_comp_)
     tree.Branch("bhdigi_simenergy", &bhdigi_simenergy_);
 }
@@ -158,8 +189,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
   hgcdigi_eta_.reserve(hgcdigi_n_);
   hgcdigi_phi_.reserve(hgcdigi_n_);
   hgcdigi_z_.reserve(hgcdigi_n_);
-  hgcdigi_data_.reserve(hgcdigi_n_);
-  hgcdigi_isadc_.reserve(hgcdigi_n_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    hgcdigi_data_[i].reserve(hgcdigi_n_);
+    hgcdigi_isadc_[i].reserve(hgcdigi_n_);
+  }
   if (triggerGeometry_->isV9Geometry()) {
     hgcdigi_waferu_.reserve(hgcdigi_n_);
     hgcdigi_waferv_.reserve(hgcdigi_n_);
@@ -182,6 +215,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
   bhdigi_eta_.reserve(bhdigi_n_);
   bhdigi_phi_.reserve(bhdigi_n_);
   bhdigi_z_.reserve(bhdigi_n_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    bhdigi_data_[i].reserve(bhdigi_n_);
+    bhdigi_isadc_[i].reserve(bhdigi_n_);
+  }
   if (is_Simhit_comp_)
     bhdigi_simenergy_.reserve(bhdigi_n_);
 
@@ -195,14 +232,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> hgcdigi_data(digi.size());
-    vector<int> hgcdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      hgcdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      hgcdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    hgcdigi_data_.emplace_back(hgcdigi_data);
-    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -235,14 +268,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> hgcdigi_data(digi.size());
-    vector<int> hgcdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      hgcdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      hgcdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    hgcdigi_data_.emplace_back(hgcdigi_data);
-    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -276,14 +305,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     bhdigi_eta_.emplace_back(cellpos.eta());
     bhdigi_phi_.emplace_back(cellpos.phi());
     bhdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> bhdigi_data(digi.size());
-    vector<int> bhdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      bhdigi_data[i] = digi[i].data();
-      bhdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      bhdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      bhdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    bhdigi_data_.emplace_back(bhdigi_data);
-    bhdigi_isadc_.emplace_back(bhdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCScintillatorDetId idv9(digi.id());
       bhdigi_ieta_.emplace_back(idv9.ietaAbs());
@@ -361,8 +386,10 @@ void HGCalTriggerNtupleHGCDigis::clear() {
   hgcdigi_eta_.clear();
   hgcdigi_phi_.clear();
   hgcdigi_z_.clear();
-  hgcdigi_data_.clear();
-  hgcdigi_isadc_.clear();
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    hgcdigi_data_[i].clear();
+    hgcdigi_isadc_[i].clear();
+  }
   if (is_Simhit_comp_)
     hgcdigi_simenergy_.clear();
 
@@ -376,8 +403,10 @@ void HGCalTriggerNtupleHGCDigis::clear() {
   bhdigi_eta_.clear();
   bhdigi_phi_.clear();
   bhdigi_z_.clear();
-  bhdigi_data_.clear();
-  bhdigi_isadc_.clear();
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    bhdigi_data_[i].clear();
+    bhdigi_isadc_[i].clear();
+  }
   if (is_Simhit_comp_)
     bhdigi_simenergy_.clear();
 }

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -50,7 +50,8 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(False)
+    isSimhitComp = cms.bool(False),
+    digiBXselect = cms.vuint32([2])
 )
 
 ntuple_triggercells = cms.PSet(


### PR DESCRIPTION
#### PR description:

Changes the way digi branches for data and isadc are saved.  Instead of each being a branch which is a vector of vectors, each BX is saved as a separate branch "hgcdigi_data_BXN" or "hgcdigi_isadc_BXN" (of bhdigi) where N is the BX number.  The list of BX to save in the ntuple is a configurable parameter, with the default being that only BX2 is saved.  Storing as separate branches improves the I/O efficiency, and reduces file sizes when OOT BX are not needed. 