### PR TITLE
Switch to sums of all TCs in towers

### DIFF
--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -1,6 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 import math
 
+def custom_towers_unclustered_tc(process):
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering')
+    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering')
+    return process
+
+
+def custom_towers_all_tc(process):
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering')
+    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering')
+    return process
+
 
 def custom_towers_etaphi(process,
         minEta=1.479,

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -8,13 +8,13 @@ tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
 hgcalTowerProducer = cms.EDProducer(
     "HGCalTowerProducer",
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
-    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'), 
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
     ProcessorParameters = tower.clone(),
     )
 
 
 hgcalTowerProducerHFNose = hgcalTowerProducer.clone(
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor'),
-    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering'), 
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering'),
 )
 


### PR DESCRIPTION
As requested by L1T GCT, switch to sums of all TCs in towers.
- Module sums stay the same
- Instead of summing unclustered TCs in the final towers, all TCs from the concentrator are summed

An other way would be to directly sum all TCs in module sums in the concentrator. Which means further loss of position precision when associating energies to tower bins. The choice will depend on what can be done in the ECON and what can be done in the BE Stage-1 / Stage-2.