### PR TITLE
Updates to phi smoothing function for cluster seeding

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
@@ -19,11 +19,14 @@ typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>,
     HGCalConcentratorProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalClusterBxCollection>
     HGCalBackendLayer1ProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalClusterBxCollection>, l1t::HGCalMulticlusterBxCollection>
+typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalClusterBxCollection>,
+                            std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection> >
     HGCalBackendLayer2ProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalTowerMapBxCollection>
+typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerSumsBxCollection>, l1t::HGCalTowerMapBxCollection>
     HGCalTowerMapProcessorBase;
-typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTowerMapBxCollection>, l1t::HGCalTowerBxCollection>
+typedef HGCalProcessorBaseT<
+    std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection> >,
+    l1t::HGCalTowerBxCollection>
     HGCalTowerProcessorBase;
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
@@ -18,6 +18,8 @@ public:
 
   void setGeometry(const HGCalTriggerGeometryBase* const geom) { geometry_ = geom; }
 
+  virtual void eventSetup(const edm::EventSetup& es){};
+
   virtual void run(const InputCollection& inputColl, OutputCollection& outColl, const edm::EventSetup& es) = 0;
 
 protected:

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -13,6 +13,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 
 #include <vector>
 #include <unordered_map>
@@ -32,7 +34,9 @@ public:
 
   const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 
-  unsigned short getTriggerTowerFromTriggerCell(const unsigned tcId, const float& eta, const float& phi) const;
+  unsigned short getTriggerTowerFromEtaPhi(const float& eta, const float& phi) const;
+  unsigned short getTriggerTower(const l1t::HGCalTriggerCell&) const;
+  unsigned short getTriggerTower(const l1t::HGCalTriggerSums&) const;
 
 private:
   std::vector<l1t::HGCalTowerCoord> tower_coords_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
@@ -32,17 +32,21 @@ public:
   void clusterizeHisto(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtr,
                        const std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                        const HGCalTriggerGeometryBase& triggerGeometry,
-                       l1t::HGCalMulticlusterBxCollection& multiclusters) const;
+                       l1t::HGCalMulticlusterBxCollection& multiclusters,
+                       l1t::HGCalClusterBxCollection& rejected_clusters) const;
 
 private:
   enum ClusterAssociationStrategy { NearestNeighbour, EnergySplit };
 
   std::vector<l1t::HGCalMulticluster> clusterSeedMulticluster(
       const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-      const std::vector<std::pair<GlobalPoint, double>>& seeds) const;
+      const std::vector<std::pair<GlobalPoint, double>>& seeds,
+      std::vector<l1t::HGCalCluster>& rejected_clusters) const;
 
   void finalizeClusters(std::vector<l1t::HGCalMulticluster>&,
+                        std::vector<l1t::HGCalCluster>&,
                         l1t::HGCalMulticlusterBxCollection&,
+                        l1t::HGCalClusterBxCollection&,
                         const HGCalTriggerGeometryBase&) const;
 
   double dr_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -151,6 +151,8 @@ private:
   unsigned nBins2_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
+  static constexpr double area_per_triggercell_ =
+      4.91E-05;  // Hex_Wafer_Area (x/z units)/N_TC (per wafer) = (0.866*((hexWafer_minimal_diameter)*(1./319.))^2 / 48)
   std::vector<double> neighbour_weights_;
   std::vector<double> smoothing_ecal_;
   std::vector<double> smoothing_hcal_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
@@ -5,6 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
@@ -16,8 +17,37 @@ public:
 
   void resetTowerMaps();
 
-  void buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& triggerCellsPtrs,
-                       l1t::HGCalTowerMapBxCollection& towermaps);
+  template <class T>
+  void buildTowerMap2D(const std::vector<edm::Ptr<T>>& ptrs, l1t::HGCalTowerMapBxCollection& towerMaps) {
+    std::unordered_map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
+
+    for (auto ptr : ptrs) {
+      if (triggerTools_.isNose(ptr->detId()))
+        continue;
+      unsigned layer = triggerTools_.layerWithOffset(ptr->detId());
+      if (towerMapsTmp.find(layer) == towerMapsTmp.end()) {
+        throw cms::Exception("Out of range")
+            << "HGCalTowerMap2dImpl: Found trigger sum in layer " << layer << " for which there is no tower map\n";
+      }
+      // FIXME: should actually sum the energy not the Et...
+      double calibPt = ptr->pt();
+      if (useLayerWeights_)
+        calibPt = layerWeights_[layer] * ptr->mipPt();
+
+      double etEm = layer <= triggerTools_.lastLayerEE() ? calibPt : 0;
+      double etHad = layer > triggerTools_.lastLayerEE() ? calibPt : 0;
+
+      towerMapsTmp[layer].addEt(towerGeometryHelper_.getTriggerTower(*ptr), etEm, etHad);
+    }
+
+    /* store towerMaps in the persistent collection */
+    towerMaps.resize(0, towerMapsTmp.size());
+    int i = 0;
+    for (auto towerMap : towerMapsTmp) {
+      towerMaps.set(0, i, towerMap.second);
+      i++;
+    }
+  }
 
   void eventSetup(const edm::EventSetup& es) {
     triggerTools_.eventSetup(es);

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -16,6 +16,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
 #include <memory>
+#include <utility>
 
 class HGCalBackendLayer2Producer : public edm::stream::EDProducer<> {
 public:
@@ -46,6 +47,7 @@ HGCalBackendLayer2Producer::HGCalBackendLayer2Producer(const edm::ParameterSet& 
       HGCalBackendLayer2Factory::get()->create(beProcessorName, beParamConfig)};
 
   produces<l1t::HGCalMulticlusterBxCollection>(backendProcess_->name());
+  produces<l1t::HGCalClusterBxCollection>(backendProcess_->name());
 }
 
 void HGCalBackendLayer2Producer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
@@ -55,14 +57,15 @@ void HGCalBackendLayer2Producer::beginRun(const edm::Run& /*run*/, const edm::Ev
 
 void HGCalBackendLayer2Producer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output collections
-  auto be_multicluster_output = std::make_unique<l1t::HGCalMulticlusterBxCollection>();
+  std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection> be_output;
 
   // Input collections
   edm::Handle<l1t::HGCalClusterBxCollection> trigCluster2DBxColl;
 
   e.getByToken(input_clusters_, trigCluster2DBxColl);
 
-  backendProcess_->run(trigCluster2DBxColl, *be_multicluster_output, es);
+  backendProcess_->run(trigCluster2DBxColl, be_output, es);
 
-  e.put(std::move(be_multicluster_output), backendProcess_->name());
+  e.put(std::make_unique<l1t::HGCalMulticlusterBxCollection>(std::move(be_output.first)), backendProcess_->name());
+  e.put(std::make_unique<l1t::HGCalClusterBxCollection>(std::move(be_output.second)), backendProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
@@ -25,7 +25,7 @@ public:
 
 private:
   // inputs
-  edm::EDGetToken input_cell_;
+  edm::EDGetToken input_sums_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
   edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
   std::unique_ptr<HGCalTowerMapProcessorBase> towersMapProcess_;
@@ -34,7 +34,7 @@ private:
 DEFINE_FWK_MODULE(HGCalTowerMapProducer);
 
 HGCalTowerMapProducer::HGCalTowerMapProducer(const edm::ParameterSet& conf)
-    : input_cell_(consumes<l1t::HGCalTriggerCellBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerCells"))),
+    : input_sums_(consumes<l1t::HGCalTriggerSumsBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerSums"))),
       triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()) {
   //setup TowerMap parameters
   const edm::ParameterSet& towerMapParamConfig = conf.getParameterSet("ProcessorParameters");
@@ -55,11 +55,11 @@ void HGCalTowerMapProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   auto towersMap_output = std::make_unique<l1t::HGCalTowerMapBxCollection>();
 
   // Input collections
-  edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
+  edm::Handle<l1t::HGCalTriggerSumsBxCollection> trigSumBxColl;
 
-  e.getByToken(input_cell_, trigCellBxColl);
+  e.getByToken(input_sums_, trigSumBxColl);
 
-  towersMapProcess_->run(trigCellBxColl, *towersMap_output, es);
+  towersMapProcess_->run(trigSumBxColl, *towersMap_output, es);
 
   e.put(std::move(towersMap_output), towersMapProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
 
@@ -14,21 +14,21 @@ public:
     towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>(conf.getParameterSet("towermap_parameters"));
   }
 
-  void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+  void run(const edm::Handle<l1t::HGCalTriggerSumsBxCollection>& collHandle,
            l1t::HGCalTowerMapBxCollection& collTowerMap,
            const edm::EventSetup& es) override {
     es.get<CaloGeometryRecord>().get("", triggerGeometry_);
     towermap2D_->eventSetup(es);
 
-    /* create a persistent vector of pointers to the trigger-cells */
-    std::vector<edm::Ptr<l1t::HGCalTriggerCell>> triggerCellsPtrs;
+    /* create a persistent vector of pointers to the trigger-sums */
+    std::vector<edm::Ptr<l1t::HGCalTriggerSums>> triggerSumsPtrs;
     for (unsigned i = 0; i < collHandle->size(); ++i) {
-      edm::Ptr<l1t::HGCalTriggerCell> ptr(collHandle, i);
-      triggerCellsPtrs.push_back(ptr);
+      edm::Ptr<l1t::HGCalTriggerSums> ptr(collHandle, i);
+      triggerSumsPtrs.push_back(ptr);
     }
 
     /* call to towerMap2D clustering */
-    towermap2D_->buildTowerMap2D(triggerCellsPtrs, collTowerMap);
+    towermap2D_->buildTowerMap2D(triggerSumsPtrs, collTowerMap);
   }
 
 private:

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -6,24 +6,52 @@
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
 
 class HGCalTowerProcessor : public HGCalTowerProcessorBase {
 public:
   HGCalTowerProcessor(const edm::ParameterSet& conf) : HGCalTowerProcessorBase(conf) {
+    towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>(conf.getParameterSet("towermap_parameters"));
     towermap3D_ = std::make_unique<HGCalTowerMap3DImpl>();
   }
 
-  void run(const edm::Handle<l1t::HGCalTowerMapBxCollection>& collHandle,
+  void eventSetup(const edm::EventSetup& es) override { towermap2D_->eventSetup(es); }
+
+  void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
+               collHandle,
            l1t::HGCalTowerBxCollection& collTowers,
            const edm::EventSetup& es) override {
     es.get<CaloGeometryRecord>().get("", triggerGeometry_);
 
+    auto& towerMapCollHandle = collHandle.first;
+    auto& unclTCsCollHandle = collHandle.second;
+
     /* create a persistent vector of pointers to the towerMaps */
     std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
-    for (unsigned i = 0; i < collHandle->size(); ++i) {
-      edm::Ptr<l1t::HGCalTowerMap> ptr(collHandle, i);
-      towerMapsPtrs.push_back(ptr);
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+      towerMapsPtrs.emplace_back(towerMapCollHandle, i);
+    }
+
+    /* create additional TowerMaps from the unclustered TCs */
+
+    // translate our HGCalClusters into HGCalTriggerCells
+    std::vector<edm::Ptr<l1t::HGCalTriggerCell>> trigCellVec;
+    for (unsigned i = 0; i < unclTCsCollHandle->size(); ++i) {
+      edm::Ptr<l1t::HGCalCluster> ptr(unclTCsCollHandle, i);
+      for (auto itTC : ptr->constituents()) {
+        trigCellVec.push_back(itTC.second);
+      }
+    }
+
+    // fill the TowerMaps with the HGCalTriggersCells
+    l1t::HGCalTowerMapBxCollection towerMapsFromUnclTCs;
+    towermap2D_->buildTowerMap2D(trigCellVec, towerMapsFromUnclTCs);
+
+    /* merge the two sets of TowerMaps */
+    unsigned int towerMapsPtrsSize = towerMapsPtrs.size();
+    for (unsigned int i = 0; i < towerMapsFromUnclTCs.size(); ++i) {
+      towerMapsPtrs.emplace_back(&(towerMapsFromUnclTCs[i]), i + towerMapsPtrsSize);
     }
 
     /* call to towerMap3D clustering */
@@ -34,6 +62,7 @@ private:
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   /* algorithms instances */
+  std::unique_ptr<HGCalTowerMap2DImpl> towermap2D_;
   std::unique_ptr<HGCalTowerMap3DImpl> towermap3D_;
 };
 

--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -1,6 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 import math
 
+def custom_towers_unclustered_tc(process):
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering')
+    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering')
+    return process
+
+
+def custom_towers_all_tc(process):
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering')
+    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering')
+    return process
+
 
 def custom_towers_etaphi(process,
         minEta=1.479,

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -106,7 +106,7 @@ histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
 # (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
 # for more details)
 phase2_hgcalV9.toModify(histoMax_C3d_seeding_params,
-                        threshold_histo_multicluster=7.5,  # MipT
+                        threshold_histo_multicluster=8.5,  # MipT
                         )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -76,7 +76,7 @@ coarseTCCompression_proc = cms.PSet(exponentBits = cms.uint32(4),
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                           Method = cms.vstring(['bestChoiceSelect']*3),
-                          NData = cms.vuint32(bestchoice_ndata_centralized),
+                          NData = cms.vuint32(bestchoice_ndata_decentralized),
                           coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
@@ -98,7 +98,7 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
 
 custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                           Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
-                          NData = cms.vuint32(bestchoice_ndata_centralized),
+                          NData = cms.vuint32(bestchoice_ndata_decentralized),
                           threshold_silicon = cms.double(2.), # MipT
                           threshold_scintillator = cms.double(2.), # MipT
                           coarsenTriggerCells = cms.vuint32(0,0,0),

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -22,10 +22,10 @@ tower_map = cms.PSet( ProcessorName  = cms.string('HGCalTowerMapProcessor'),
 
 hgcalTowerMapProducer = cms.EDProducer(
     "HGCalTowerMapProducer",
-    InputTriggerCells = cms.InputTag('hgcalVFEProducer:HGCalVFEProcessorSums'),
+    InputTriggerSums = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
     ProcessorParameters = tower_map.clone()
     )
 
 hgcalTowerMapProducerHFNose = hgcalTowerMapProducer.clone(
-    InputTriggerCells = cms.InputTag('hfnoseVFEProducer:HFNoseVFEProcessorSums')
+    InputTriggerSums = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')
 )

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -8,13 +8,13 @@ tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
 hgcalTowerProducer = cms.EDProducer(
     "HGCalTowerProducer",
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
-    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'), 
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
     ProcessorParameters = tower.clone(),
     )
 
 
 hgcalTowerProducerHFNose = hgcalTowerProducer.clone(
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor'),
-    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering'), 
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering'),
 )
 

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -1,16 +1,20 @@
 import FWCore.ParameterSet.Config as cms
+import L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi as hgcalTowerMapProducer_cfi
 
-tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor')
+tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
+      towermap_parameters = hgcalTowerMapProducer_cfi.towerMap2D_parValues.clone()
                   )
 
 hgcalTowerProducer = cms.EDProducer(
     "HGCalTowerProducer",
     InputTowerMaps = cms.InputTag('hgcalTowerMapProducer:HGCalTowerMapProcessor'), 
-    ProcessorParameters = tower.clone()
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'), 
+    ProcessorParameters = tower.clone(),
     )
 
 
 hgcalTowerProducerHFNose = hgcalTowerProducer.clone(
-    InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor')
+    InputTowerMaps = cms.InputTag('hgcalTowerMapProducerHFNose:HGCalTowerMapProcessor'),
+    InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering'), 
 )
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -37,9 +37,10 @@ float HGCalHistoClusteringImpl::dR(const l1t::HGCalCluster& clu, const GlobalPoi
 
 std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticluster(
     const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-    const std::vector<std::pair<GlobalPoint, double>>& seeds) const {
+    const std::vector<std::pair<GlobalPoint, double>>& seeds,
+    std::vector<l1t::HGCalCluster>& rejected_clusters) const {
   std::map<int, l1t::HGCalMulticluster> mapSeedMulticluster;
-  std::vector<l1t::HGCalMulticluster> multiclustersTmp;
+  std::vector<l1t::HGCalMulticluster> multiclustersOut;
 
   for (const auto& clu : clustersPtrs) {
     int z_side = triggerTools_.zside(clu->detId());
@@ -77,8 +78,10 @@ std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticl
       }
     }
 
-    if (targetSeedsEnergy.empty())
+    if (targetSeedsEnergy.empty()) {
+      rejected_clusters.emplace_back(*clu);
       continue;
+    }
     //Loop over target seeds and divide up the clusters energy
     double totalTargetSeedEnergy = 0;
     for (const auto& energy : targetSeedsEnergy) {
@@ -98,24 +101,33 @@ std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticl
   }
 
   for (const auto& mclu : mapSeedMulticluster)
-    multiclustersTmp.emplace_back(mclu.second);
+    multiclustersOut.emplace_back(mclu.second);
 
-  return multiclustersTmp;
+  return multiclustersOut;
 }
 
 void HGCalHistoClusteringImpl::clusterizeHisto(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
                                                const std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                                                const HGCalTriggerGeometryBase& triggerGeometry,
-                                               l1t::HGCalMulticlusterBxCollection& multiclusters) const {
+                                               l1t::HGCalMulticlusterBxCollection& multiclusters,
+                                               l1t::HGCalClusterBxCollection& rejected_clusters) const {
   /* clusterize clusters around seeds */
-  std::vector<l1t::HGCalMulticluster> multiclustersTmp = clusterSeedMulticluster(clustersPtrs, seedPositionsEnergy);
+  std::vector<l1t::HGCalCluster> rejected_clusters_vec;
+  std::vector<l1t::HGCalMulticluster> multiclusters_vec =
+      clusterSeedMulticluster(clustersPtrs, seedPositionsEnergy, rejected_clusters_vec);
   /* making the collection of multiclusters */
-  finalizeClusters(multiclustersTmp, multiclusters, triggerGeometry);
+  finalizeClusters(multiclusters_vec, rejected_clusters_vec, multiclusters, rejected_clusters, triggerGeometry);
 }
 
 void HGCalHistoClusteringImpl::finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
+                                                std::vector<l1t::HGCalCluster>& rejected_clusters_in,
                                                 l1t::HGCalMulticlusterBxCollection& multiclusters_out,
+                                                l1t::HGCalClusterBxCollection& rejected_clusters_out,
                                                 const HGCalTriggerGeometryBase& triggerGeometry) const {
+  for (auto& tc : rejected_clusters_in) {
+    rejected_clusters_out.push_back(0, tc);
+  }
+
   for (auto& multicluster : multiclusters_in) {
     // compute the eta, phi from its barycenter
     // + pT as scalar sum of pT of constituents
@@ -133,6 +145,10 @@ void HGCalHistoClusteringImpl::finalizeClusters(std::vector<l1t::HGCalMulticlust
       multicluster.saveHOverE();
 
       multiclusters_out.push_back(0, multicluster);
+    } else {
+      for (auto& tc : multicluster.constituents()) {
+        rejected_clusters_out.push_back(0, *(tc.second));
+      }
     }
   }
 }

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -166,12 +166,12 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
   for (int z_side : {-1, 1}) {
     for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
       int nBinsSide = (binSums[bin1] - 1) / 2;
-      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_);
-      float R2 = R1 + (kROverZMax_ - kROverZMin_);
+      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_) / nBins1_;
+      float R2 = R1 + ((kROverZMax_ - kROverZMin_) / nBins1_);
       double area =
-          0.5 * (pow(R2, 2) - pow(R1, 2)) *
+          ((M_PI * (pow(R2, 2) - pow(R1, 2))) / nBins2_) *
           (1 +
-           0.5 *
+           2.0 *
                (1 -
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
@@ -196,7 +196,7 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
         }
 
         auto& bin = histoSumPhiClusters.at(z_side, bin1, bin2);
-        bin.values[Bin::Content::Sum] = content / area;
+        bin.values[Bin::Content::Sum] = (content / area) * area_per_triggercell_;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
       }

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
@@ -26,36 +26,3 @@ std::unordered_map<int, l1t::HGCalTowerMap> HGCalTowerMap2DImpl::newTowerMaps() 
 
   return towerMaps;
 }
-
-void HGCalTowerMap2DImpl::buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& triggerCellsPtrs,
-                                          l1t::HGCalTowerMapBxCollection& towerMaps) {
-  std::unordered_map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
-
-  for (auto tc : triggerCellsPtrs) {
-    if (triggerTools_.isNose(tc->detId()))
-      continue;
-    unsigned layer = triggerTools_.layerWithOffset(tc->detId());
-    if (towerMapsTmp.find(layer) == towerMapsTmp.end()) {
-      throw cms::Exception("Out of range")
-          << "HGCalTowerMap2dImpl: Found trigger cell in layer " << layer << " for which there is no tower map\n";
-    }
-    // FIXME: should actually sum the energy not the Et...
-    double calibPt = tc->pt();
-    if (useLayerWeights_)
-      calibPt = layerWeights_[layer] * tc->mipPt();
-
-    double etEm = layer <= triggerTools_.lastLayerEE() ? calibPt : 0;
-    double etHad = layer > triggerTools_.lastLayerEE() ? calibPt : 0;
-
-    towerMapsTmp[layer].addEt(
-        towerGeometryHelper_.getTriggerTowerFromTriggerCell(tc->detId(), tc->eta(), tc->phi()), etEm, etHad);
-  }
-
-  /* store towerMaps in the persistent collection */
-  towerMaps.resize(0, towerMapsTmp.size());
-  int i = 0;
-  for (auto towerMap : towerMapsTmp) {
-    towerMaps.set(0, i, towerMap.second);
-    i++;
-  }
-}

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -31,6 +31,9 @@ private:
   bool is_Simhit_comp_;
   edm::EDGetToken SimHits_inputee_, SimHits_inputfh_, SimHits_inputbh_;
 
+  std::vector<unsigned int> digiBXselect_;
+  static constexpr unsigned kDigiSize_ = 5;
+
   HGCalTriggerTools triggerTools_;
 
   int hgcdigi_n_;
@@ -75,6 +78,17 @@ DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCDigis, "HGCalT
 
 HGCalTriggerNtupleHGCDigis::HGCalTriggerNtupleHGCDigis(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
   is_Simhit_comp_ = conf.getParameter<bool>("isSimhitComp");
+  digiBXselect_ = conf.getParameter<std::vector<unsigned int>>("digiBXselect");
+
+  if (*std::max_element(digiBXselect_.begin(), digiBXselect_.end()) >= kDigiSize_) {
+    throw cms::Exception("BadInitialization")
+        << "digiBXselect vector requests a BX outside of maximum size of digis (" << kDigiSize_ << " BX)";
+  }
+  //sort and check for duplicates
+  std::sort(digiBXselect_.begin(), digiBXselect_.end());
+  if (std::unique(digiBXselect_.begin(), digiBXselect_.end()) != digiBXselect_.end()) {
+    throw cms::Exception("BadInitialization") << "digiBXselect vector contains duplicate BX values";
+  }
 }
 
 void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
@@ -88,6 +102,12 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
     SimHits_inputfh_ = collector.consumes<edm::PCaloHitContainer>(conf.getParameter<edm::InputTag>("fhSimHits"));
     SimHits_inputbh_ = collector.consumes<edm::PCaloHitContainer>(conf.getParameter<edm::InputTag>("bhSimHits"));
   }
+
+  hgcdigi_data_.resize(digiBXselect_.size());
+  hgcdigi_isadc_.resize(digiBXselect_.size());
+  bhdigi_data_.resize(digiBXselect_.size());
+  bhdigi_isadc_.resize(digiBXselect_.size());
+
   tree.Branch("hgcdigi_n", &hgcdigi_n_, "hgcdigi_n/I");
   tree.Branch("hgcdigi_id", &hgcdigi_id_);
   tree.Branch("hgcdigi_subdet", &hgcdigi_subdet_);
@@ -97,8 +117,16 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
   tree.Branch("hgcdigi_eta", &hgcdigi_eta_);
   tree.Branch("hgcdigi_phi", &hgcdigi_phi_);
   tree.Branch("hgcdigi_z", &hgcdigi_z_);
-  tree.Branch("hgcdigi_data", &hgcdigi_data_);
-  tree.Branch("hgcdigi_isadc", &hgcdigi_isadc_);
+  std::string bname;
+  auto withBX([&bname](char const* vname, unsigned int bx) -> char const* {
+    bname = std::string(vname) + "_BX" + to_string(bx);
+    return bname.c_str();
+  });
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    unsigned int bxi = digiBXselect_[i];
+    tree.Branch(withBX("hgcdigi_data", bxi), &hgcdigi_data_[i]);
+    tree.Branch(withBX("hgcdigi_isadc", bxi), &hgcdigi_isadc_[i]);
+  }
   // V9 detid scheme
   tree.Branch("hgcdigi_waferu", &hgcdigi_waferu_);
   tree.Branch("hgcdigi_waferv", &hgcdigi_waferv_);
@@ -120,8 +148,11 @@ void HGCalTriggerNtupleHGCDigis::initialize(TTree& tree,
   tree.Branch("bhdigi_eta", &bhdigi_eta_);
   tree.Branch("bhdigi_phi", &bhdigi_phi_);
   tree.Branch("bhdigi_z", &bhdigi_z_);
-  tree.Branch("bhdigi_data", &bhdigi_data_);
-  tree.Branch("bhdigi_isadc", &bhdigi_isadc_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    unsigned int bxi = digiBXselect_[i];
+    tree.Branch(withBX("bhdigi_data", bxi), &bhdigi_data_[i]);
+    tree.Branch(withBX("bhdigi_isadc", bxi), &bhdigi_isadc_[i]);
+  }
   if (is_Simhit_comp_)
     tree.Branch("bhdigi_simenergy", &bhdigi_simenergy_);
 }
@@ -158,8 +189,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
   hgcdigi_eta_.reserve(hgcdigi_n_);
   hgcdigi_phi_.reserve(hgcdigi_n_);
   hgcdigi_z_.reserve(hgcdigi_n_);
-  hgcdigi_data_.reserve(hgcdigi_n_);
-  hgcdigi_isadc_.reserve(hgcdigi_n_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    hgcdigi_data_[i].reserve(hgcdigi_n_);
+    hgcdigi_isadc_[i].reserve(hgcdigi_n_);
+  }
   if (triggerGeometry_->isV9Geometry()) {
     hgcdigi_waferu_.reserve(hgcdigi_n_);
     hgcdigi_waferv_.reserve(hgcdigi_n_);
@@ -182,6 +215,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
   bhdigi_eta_.reserve(bhdigi_n_);
   bhdigi_phi_.reserve(bhdigi_n_);
   bhdigi_z_.reserve(bhdigi_n_);
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    bhdigi_data_[i].reserve(bhdigi_n_);
+    bhdigi_isadc_[i].reserve(bhdigi_n_);
+  }
   if (is_Simhit_comp_)
     bhdigi_simenergy_.reserve(bhdigi_n_);
 
@@ -195,14 +232,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> hgcdigi_data(digi.size());
-    vector<int> hgcdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      hgcdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      hgcdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    hgcdigi_data_.emplace_back(hgcdigi_data);
-    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -235,14 +268,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     hgcdigi_eta_.emplace_back(cellpos.eta());
     hgcdigi_phi_.emplace_back(cellpos.phi());
     hgcdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> hgcdigi_data(digi.size());
-    vector<int> hgcdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      hgcdigi_data[i] = digi[i].data();
-      hgcdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      hgcdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      hgcdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    hgcdigi_data_.emplace_back(hgcdigi_data);
-    hgcdigi_isadc_.emplace_back(hgcdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCSiliconDetId idv9(digi.id());
       hgcdigi_waferu_.emplace_back(idv9.waferU());
@@ -276,14 +305,10 @@ void HGCalTriggerNtupleHGCDigis::fill(const edm::Event& e, const edm::EventSetup
     bhdigi_eta_.emplace_back(cellpos.eta());
     bhdigi_phi_.emplace_back(cellpos.phi());
     bhdigi_z_.emplace_back(cellpos.z());
-    vector<uint32_t> bhdigi_data(digi.size());
-    vector<int> bhdigi_isadc(digi.size());
-    for (int i = 0; i < digi.size(); i++) {
-      bhdigi_data[i] = digi[i].data();
-      bhdigi_isadc[i] = !digi[i].mode();
+    for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+      bhdigi_data_[i].emplace_back(digi[digiBXselect_[i]].data());
+      bhdigi_isadc_[i].emplace_back(!digi[digiBXselect_[i]].mode());
     }
-    bhdigi_data_.emplace_back(bhdigi_data);
-    bhdigi_isadc_.emplace_back(bhdigi_isadc);
     if (triggerGeometry_->isV9Geometry()) {
       const HGCScintillatorDetId idv9(digi.id());
       bhdigi_ieta_.emplace_back(idv9.ietaAbs());
@@ -361,8 +386,10 @@ void HGCalTriggerNtupleHGCDigis::clear() {
   hgcdigi_eta_.clear();
   hgcdigi_phi_.clear();
   hgcdigi_z_.clear();
-  hgcdigi_data_.clear();
-  hgcdigi_isadc_.clear();
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    hgcdigi_data_[i].clear();
+    hgcdigi_isadc_[i].clear();
+  }
   if (is_Simhit_comp_)
     hgcdigi_simenergy_.clear();
 
@@ -376,8 +403,10 @@ void HGCalTriggerNtupleHGCDigis::clear() {
   bhdigi_eta_.clear();
   bhdigi_phi_.clear();
   bhdigi_z_.clear();
-  bhdigi_data_.clear();
-  bhdigi_isadc_.clear();
+  for (unsigned int i = 0; i < digiBXselect_.size(); i++) {
+    bhdigi_data_[i].clear();
+    bhdigi_isadc_[i].clear();
+  }
   if (is_Simhit_comp_)
     bhdigi_simenergy_.clear();
 }

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -50,7 +50,8 @@ ntuple_digis = cms.PSet(
     eeSimHits = cms.InputTag('g4SimHits:HGCHitsEE'),
     fhSimHits = cms.InputTag('g4SimHits:HGCHitsHEfront'),
     bhSimHits = cms.InputTag('g4SimHits:HcalHits'),
-    isSimhitComp = cms.bool(False)
+    isSimhitComp = cms.bool(False),
+    digiBXselect = cms.vuint32([2])
 )
 
 ntuple_triggercells = cms.PSet(

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerValidation_cff.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerValidation_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
+from L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff import *
+
+hgcalTriggerValidation = cms.Sequence(hgcalTriggerPrimitives*hgcalTriggerNtuples)
+
+


### PR DESCRIPTION
#### PR description:

The PR introduces updates to correct the normalization used in the Phi smoothing function (fillSmoothRPhiHistoClusters) used for 3D cluster seeding: 
-- update to the calculation of area of R rings used for calculation of area weights
-- introduce area_per_trigger cell variable to use energy_per_TCarea value in the seed finding histograms 



