### PR TITLE
Differentiate output collection names

### DIFF
--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -47,7 +47,7 @@ HGCalBackendLayer2Producer::HGCalBackendLayer2Producer(const edm::ParameterSet& 
       HGCalBackendLayer2Factory::get()->create(beProcessorName, beParamConfig)};
 
   produces<l1t::HGCalMulticlusterBxCollection>(backendProcess_->name());
-  produces<l1t::HGCalClusterBxCollection>(backendProcess_->name());
+  produces<l1t::HGCalClusterBxCollection>(backendProcess_->name()+"Unclustered");
 }
 
 void HGCalBackendLayer2Producer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
@@ -67,5 +67,5 @@ void HGCalBackendLayer2Producer::produce(edm::Event& e, const edm::EventSetup& e
   backendProcess_->run(trigCluster2DBxColl, be_output, es);
 
   e.put(std::make_unique<l1t::HGCalMulticlusterBxCollection>(std::move(be_output.first)), backendProcess_->name());
-  e.put(std::make_unique<l1t::HGCalClusterBxCollection>(std::move(be_output.second)), backendProcess_->name());
+  e.put(std::make_unique<l1t::HGCalClusterBxCollection>(std::move(be_output.second)), backendProcess_->name()+"Unclustered");
 }

--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 import math
 
 def custom_towers_unclustered_tc(process):
-    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering')
-    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClustering')
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClusteringUnclustered')
+    process.hgcalTowerProducerHFNose.InputTriggerCells = cms.InputTag('hgcalBackEndLayer2ProducerHFNose:HGCalBackendLayer2Processor3DClusteringUnclustered')
     return process
 
 


### PR DESCRIPTION
L1T PF is searching for a collection of `reco::Candidate` from our `HGCalBackendLayer2Producer`. Since both unclustered clusters and multiclusters derive from this reco class, their collection need to be differentiated by their name.