### PR TITLE
Update cell remapping to allow for other AE architecture choices

### DIFF
--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
@@ -24,21 +24,39 @@ public:
 
 private:
   static constexpr int nTriggerCells_ = 48;
+
+  static constexpr int maxAEInputSize_ = 192;
+
   static constexpr int nEncodedLayerNodes_ = 16;
-
-  static constexpr int cellRemapRowOffset_ = 8;
-
-  static constexpr unsigned int encoderShape_0_ = 1;
-  static constexpr unsigned int encoderShape_1_ = 4;
-  static constexpr unsigned int encoderShape_2_ = 4;
-  static constexpr unsigned int encoderShape_3_ = 3;
-
-  static constexpr unsigned int decoderShape_0_ = 1;
-  static constexpr unsigned int decoderShape_1_ = 16;
 
   static constexpr unsigned int maxNumberOfLinks_ = 13;
 
+  static constexpr int cellUVSize_ = 8;
+
+  static constexpr int encoderTensorDims_ = 4;
+
+  static constexpr int decoderTensorDims_ = 2;
+
+  static constexpr int cellUVremap_[cellUVSize_][cellUVSize_] = {{47, 46, 45, 44, -1, -1, -1, -1},
+                                                                 {16, 43, 42, 41, 40, -1, -1, -1},
+                                                                 {20, 17, 39, 38, 37, 36, -1, -1},
+                                                                 {24, 21, 18, 35, 34, 33, 32, -1},
+                                                                 {28, 25, 22, 19, 3, 7, 11, 15},
+                                                                 {-1, 29, 26, 23, 2, 6, 10, 14},
+                                                                 {-1, -1, 30, 27, 1, 5, 9, 13},
+                                                                 {-1, -1, -1, 31, 0, 4, 8, 12}};
+  static constexpr int ae_outputCellU_[nTriggerCells_] = {7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4,
+                                                          1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6, 4, 5, 6, 7,
+                                                          3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0};
+  static constexpr int ae_outputCellV_[nTriggerCells_] = {4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7,
+                                                          0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
+                                                          6, 5, 4, 3, 5, 4, 3, 2, 4, 3, 2, 1, 3, 2, 1, 0};
+
+  unsigned int nInputs_;
   std::vector<int> cellRemap_;
+  std::vector<int> cellRemapNoDuplicates_;
+  std::vector<uint> encoderShape_;
+  std::vector<uint> decoderShape_;
   int bitsPerInput_;
   int maxBitsPerOutput_;
   std::vector<int> outputBitsPerLink_;
@@ -60,9 +78,6 @@ private:
   double zeroSuppresionThreshold_;
   bool saveEncodedValues_;
   bool preserveModuleSum_;
-
-  std::array<int, nTriggerCells_> ae_outputCellU_;
-  std::array<int, nTriggerCells_> ae_outputCellV_;
 
   std::array<double, nEncodedLayerNodes_> ae_encodedLayer_;
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -158,14 +158,22 @@ coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentrat
 )
 
 
-autoencoder_triggerCellRemap = [47, 44, 41, 38, -1, -1, -1, -1,
-                                1, 35, 32, 29, 26, -1, -1, -1,
-                                13,  4, 23, 20, 17, 14, -1, -1,
-                                25, 16,  7, 11,  8,  5,  2, -1,
-                                37, 28, 19, 10,  9, 21, 33, 45,
-                                -1, 40, 31, 22,  6, 18, 30, 42,
-                                -1, -1, 43, 34,  3, 15, 27, 39,
-                                -1, -1, -1, 46,  0, 12, 24, 36]
+autoencoder_triggerCellRemap = [0,16, 32,
+                                1,17, 33,
+                                2,18, 34,
+                                3,19, 35,
+                                4,20, 36,
+                                5,21, 37,
+                                6,22, 38,
+                                7,23, 39,
+                                8,24, 40,
+                                9,25, 41,
+                                10,26, 42,
+                                11,27, 43,
+                                12,28, 44,
+                                13,29, 45,
+                                14,30, 46,
+                                15,31, 47]
 
 autoEncoder_bitsPerOutputLink = cms.vint32([0, 1, 3, 5, 7, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9])
 
@@ -186,6 +194,9 @@ linkToGraphMapping = [0,0,0,1,2,3,3,3,3,3,3,3,3,3,3]
 autoEncoder_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                  Method = cms.vstring(['autoEncoder','autoEncoder','thresholdSelect']),
                                  cellRemap = cms.vint32(autoencoder_triggerCellRemap),
+                                 cellRemapNoDuplicates = cms.vint32(autoencoder_triggerCellRemap),
+                                 encoderShape = cms.vuint32(1,4,4,3),
+                                 decoderShape = cms.vuint32(1,16),
                                  nBitsPerInput = cms.int32(8),
                                  maxBitsPerOutput = cms.int32(9),
                                  bitsPerLink = autoEncoder_bitsPerOutputLink,


### PR DESCRIPTION
Update to how remapping of the trigger cells into tensors is handled to allow for more autoencoder architectures to be run.  

Instead of a cellRemap array that specifies the tensor element that each cell U/V coordinate gets assigned to, the new cellRemap is the same length as the input tensor, and specifies the index from the trigger cell list to be loaded into that element (with the trigger cell list as a flat array, arranged similar to the geometry impl-1 tc numbering).  This allows for cell values to be duplicated into multiple locations within the input tensor, which is required in some architectures to maintain neighbors at boundaries of HGROCS.  This new scheme mimics the procedure within the keras training, making it simpler to port new trainings to CMSSW, and more closely resembles the process within the ECON.  Values of -1 in cellRemap are for tensor elements which are always 0.

A second mapping array is also now required (cellRemapNoDuplicates), which specifies the cellRemap only for the main values, and leaves out any duplication.  This is used for loading decoded values back into the trigger cell collection in a 1-to-1 fashion. 