### PR TITLE
Tower update: include all TCs into TSs

### DIFF
--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -32,6 +32,7 @@ public:
 
 private:
   bool fixedDataSizePerHGCROC_;
+  bool allTrigCellsInTrigSums_;
   std::vector<unsigned> coarsenTriggerCells_;
   static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kNSubDetectors_ = 3;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -12,6 +12,7 @@
 class HGCalTowerProcessor : public HGCalTowerProcessorBase {
 public:
   HGCalTowerProcessor(const edm::ParameterSet& conf) : HGCalTowerProcessorBase(conf) {
+    includeTrigCells_ = conf.getParameter<bool>("includeTrigCells"),
     towermap2D_ = std::make_unique<HGCalTowerMap2DImpl>(conf.getParameterSet("towermap_parameters"));
     towermap3D_ = std::make_unique<HGCalTowerMap3DImpl>();
   }
@@ -33,33 +34,39 @@ public:
       towerMapsPtrs.emplace_back(towerMapCollHandle, i);
     }
 
-    /* create additional TowerMaps from the unclustered TCs */
+    if (includeTrigCells_) {
+      /* create additional TowerMaps from the unclustered TCs */
 
-    // translate our HGCalClusters into HGCalTriggerCells
-    std::vector<edm::Ptr<l1t::HGCalTriggerCell>> trigCellVec;
-    for (unsigned i = 0; i < unclTCsCollHandle->size(); ++i) {
-      edm::Ptr<l1t::HGCalCluster> ptr(unclTCsCollHandle, i);
-      for (const auto& itTC : ptr->constituents()) {
-        trigCellVec.push_back(itTC.second);
+      // translate our HGCalClusters into HGCalTriggerCells
+      std::vector<edm::Ptr<l1t::HGCalTriggerCell>> trigCellVec;
+      for (unsigned i = 0; i < unclTCsCollHandle->size(); ++i) {
+        edm::Ptr<l1t::HGCalCluster> ptr(unclTCsCollHandle, i);
+        for (const auto& itTC : ptr->constituents()) {
+          trigCellVec.push_back(itTC.second);
+        }
       }
+
+      // fill the TowerMaps with the HGCalTriggersCells
+      l1t::HGCalTowerMapBxCollection towerMapsFromUnclTCs;
+      towermap2D_->buildTowerMap2D(trigCellVec, towerMapsFromUnclTCs);
+
+      /* merge the two sets of TowerMaps */
+      unsigned int towerMapsPtrsSize = towerMapsPtrs.size();
+      for (unsigned int i = 0; i < towerMapsFromUnclTCs.size(); ++i) {
+        towerMapsPtrs.emplace_back(&(towerMapsFromUnclTCs[i]), i + towerMapsPtrsSize);
+      }
+
+      /* call to towerMap3D clustering */
+      towermap3D_->buildTowerMap3D(towerMapsPtrs, collTowers);
+    } else {
+      /* call to towerMap3D clustering */
+      towermap3D_->buildTowerMap3D(towerMapsPtrs, collTowers);
     }
-
-    // fill the TowerMaps with the HGCalTriggersCells
-    l1t::HGCalTowerMapBxCollection towerMapsFromUnclTCs;
-    towermap2D_->buildTowerMap2D(trigCellVec, towerMapsFromUnclTCs);
-
-    /* merge the two sets of TowerMaps */
-    unsigned int towerMapsPtrsSize = towerMapsPtrs.size();
-    for (unsigned int i = 0; i < towerMapsFromUnclTCs.size(); ++i) {
-      towerMapsPtrs.emplace_back(&(towerMapsFromUnclTCs[i]), i + towerMapsPtrsSize);
-    }
-
-    /* call to towerMap3D clustering */
-    towermap3D_->buildTowerMap3D(towerMapsPtrs, collTowers);
   }
 
 private:
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  bool includeTrigCells_;
 
   /* algorithms instances */
   std::unique_ptr<HGCalTowerMap2DImpl> towermap2D_;

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -8,6 +8,7 @@ DEFINE_EDM_PLUGIN(HGCalConcentratorFactory, HGCalConcentratorProcessorSelection,
 HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf)
     : HGCalConcentratorProcessorBase(conf),
       fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+      allTrigCellsInTrigSums_(conf.getParameter<bool>("allTrigCellsInTrigSums")),
       coarsenTriggerCells_(conf.getParameter<std::vector<unsigned>>("coarsenTriggerCells")),
       selectionType_(kNSubDetectors_) {
   std::vector<std::string> selectionType(conf.getParameter<std::vector<std::string>>("Method"));
@@ -164,6 +165,9 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
 
     // trigger sum
     if (trigSumImpl_) {
+      if (allTrigCellsInTrigSums_) {  // merge the selected and not-selected vectors
+        trigCellVecNotSelected.insert(trigCellVecNotSelected.end(), trigCellVecOutput.begin(), trigCellVecOutput.end());
+      }
       trigSumImpl_->doSum(module_trigcell.first, trigCellVecNotSelected, trigSumsVecOutput);
     }
 

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -165,10 +165,11 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
 
     // trigger sum
     if (trigSumImpl_) {
-      if (allTrigCellsInTrigSums_) {  // merge the selected and not-selected vectors
-        trigCellVecNotSelected.insert(trigCellVecNotSelected.end(), trigCellVecOutput.begin(), trigCellVecOutput.end());
+      if (allTrigCellsInTrigSums_) {  // using all TCs
+        trigSumImpl_->doSum(module_trigcell.first, module_trigcell.second, trigSumsVecOutput);
+      } else {  // using only unselected TCs
+        trigSumImpl_->doSum(module_trigcell.first, trigCellVecNotSelected, trigSumsVecOutput);
       }
-      trigSumImpl_->doSum(module_trigcell.first, trigCellVecNotSelected, trigSumsVecOutput);
     }
 
     for (const auto& trigCell : trigCellVecOutput) {

--- a/L1Trigger/L1THGCal/python/customTriggerSums.py
+++ b/L1Trigger/L1THGCal/python/customTriggerSums.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+import math
+
+def custom_partial_trigger_sums(process):
+    process.tower.includeTrigCells = cms.bool(True)
+    process.hgcalTowerProducer.ProcessorParameters.includeTrigCells = cms.bool(True)
+    process.hgcalTowerProducerHFNose.ProcessorParameters.includeTrigCells = cms.bool(True)
+    process.threshold_conc_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.best_conc_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.supertc_conc_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.custom_conc_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.coarsetc_onebitfraction_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.coarsetc_equalshare_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.autoEncoder_conc_proc.allTrigCellsInTrigSums = cms.bool(False)
+    process.hgcalConcentratorProducer.ProcessorParameters.allTrigCellsInTrigSums = cms.bool(False)
+    process.hgcalConcentratorProducerHFNose.ProcessorParameters.allTrigCellsInTrigSums = cms.bool(False)
+    return process
+
+def custom_full_trigger_sums(process):
+    process.tower.includeTrigCells = cms.bool(False)
+    process.hgcalTowerProducer.ProcessorParameters.includeTrigCells = cms.bool(False)
+    process.hgcalTowerProducerHFNose.ProcessorParameters.includeTrigCells = cms.bool(False)
+    process.threshold_conc_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.best_conc_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.supertc_conc_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.custom_conc_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.coarsetc_onebitfraction_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.coarsetc_equalshare_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.autoEncoder_conc_proc.allTrigCellsInTrigSums = cms.bool(True)
+    process.hgcalConcentratorProducer.ProcessorParameters.allTrigCellsInTrigSums = cms.bool(True)
+    process.hgcalConcentratorProducerHFNose.ProcessorParameters.allTrigCellsInTrigSums = cms.bool(True)
+    return process

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -32,6 +32,7 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                threshold_scintillator = cms.double(2.), # MipT
                                coarsenTriggerCells = cms.vuint32(0,0,0),
                                fixedDataSizePerHGCROC = cms.bool(False),
+                               allTrigCellsInTrigSums = cms.bool(False),
                                ctcSize = cms.vuint32(CTC_SIZE),
                                )
 
@@ -81,6 +82,7 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           NData = cms.vuint32(bestchoice_ndata_decentralized),
                           coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
+                          allTrigCellsInTrigSums = cms.bool(False),
                           coarseTCCompression = coarseTCCompression_proc.clone(),
                           superTCCalibration_ee = vfe_proc.calibrationCfg_ee.clone(),
                           superTCCalibration_hesi = vfe_proc.calibrationCfg_hesi.clone(),
@@ -95,6 +97,7 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              stcSize = cms.vuint32(STC_SIZE),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(False),
+                             allTrigCellsInTrigSums = cms.bool(False),
                              coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
@@ -111,6 +114,7 @@ custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProces
                           threshold_scintillator = cms.double(2.), # MipT
                           coarsenTriggerCells = cms.vuint32(0,0,0),
                           fixedDataSizePerHGCROC = cms.bool(False),
+                          allTrigCellsInTrigSums = cms.bool(False),
                           type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
                           stcSize = cms.vuint32(STC_SIZE),
                           ctcSize = cms.vuint32(CTC_SIZE),
@@ -129,6 +133,7 @@ coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcen
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
+                             allTrigCellsInTrigSums = cms.bool(False),
                              coarsenTriggerCells = cms.vuint32(0,0,0),
                              oneBitFractionThreshold = cms.double(0.125),
                              oneBitFractionLowValue = cms.double(0.0625),
@@ -148,6 +153,7 @@ coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentrat
                              stcSize = cms.vuint32([4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3),
                              ctcSize = cms.vuint32(CTC_SIZE),
                              fixedDataSizePerHGCROC = cms.bool(True),
+                             allTrigCellsInTrigSums = cms.bool(False),
                              coarsenTriggerCells = cms.vuint32(0,0,0),
                              superTCCompression = superTCCompression_proc.clone(),
                              coarseTCCompression = coarseTCCompression_proc.clone(),
@@ -211,6 +217,7 @@ autoEncoder_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorP
                                  stcSize = supertc_conc_proc.stcSize,
                                  ctcSize = supertc_conc_proc.ctcSize,
                                  fixedDataSizePerHGCROC = supertc_conc_proc.fixedDataSizePerHGCROC,
+                                 allTrigCellsInTrigSums = supertc_conc_proc.allTrigCellsInTrigSums,
                                  coarsenTriggerCells = supertc_conc_proc.coarsenTriggerCells,
                                  superTCCompression = superTCCompression_proc.clone(),
                                  coarseTCCompression = coarseTCCompression_proc.clone(),

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 import L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi as hgcalTowerMapProducer_cfi
 
 tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
+      includeTrigCells = cms.bool(True),
       towermap_parameters = hgcalTowerMapProducer_cfi.towerMap2D_parValues.clone()
                   )
 


### PR DESCRIPTION
#### PR description:
This PR adds the possibility to include all trigger cells into the trigger sums (instead of only the unselected TCs). Tower building is then also modified accordingly and only includes trigger sums in this case. A `customTriggerSums.py` file is added to select one option or the other. The default behaviour is unchanged with this PR and corresponds to "partial trigger sums".

#### PR validation:
- passed `scram b code-checks`, `scram b code-format`
- no warnings or errors in compilation
- Validation using [testHGCalL1T_RelValV11_cfg.py](https://github.com/PFCal-dev/cmssw/blob/hgc-tpg-devel-CMSSW_11_2_0_pre5/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV11_cfg.py): 
  - confirm that default behaviour is unchanged
  - with "full trigger sums", results are as expected (larger number of trigger sums, with higher energy; fewer, less energetic towers)

