### PR TITLE
Developing framework for running emulator outside of CMSSW

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -1,0 +1,30 @@
+#ifndef __L1Trigger_L1THGCal_HGCalAlgoWrapperBase_h__
+#define __L1Trigger_L1THGCal_HGCalAlgoWrapperBase_h__
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+typedef HGCalAlgoWrapperBaseT<
+    std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>,
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>,
+    std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    HGCalHistoClusteringWrapperBase;
+
+typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTowerMap>>,
+                              l1t::HGCalTowerBxCollection,
+                              std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    HGCalTowerMapsWrapperBase;
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory<HGCalHistoClusteringWrapperBase*(const edm::ParameterSet&)>
+    HGCalHistoClusteringWrapperBaseFactory;
+typedef edmplugin::PluginFactory<HGCalTowerMapsWrapperBase*(const edm::ParameterSet&)> HGCalTowerMapsWrapperBaseFactory;
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h
@@ -1,0 +1,23 @@
+#ifndef __L1Trigger_L1THGCal_HGCalAlgoWrapperBaseT_h__
+#define __L1Trigger_L1THGCal_HGCalAlgoWrapperBaseT_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <string>
+
+template <typename InputCollection, typename OutputCollection, typename Tparam>
+class HGCalAlgoWrapperBaseT {
+public:
+  HGCalAlgoWrapperBaseT(const edm::ParameterSet& conf) : name_(conf.getParameter<std::string>("AlgoName")) {}
+
+  virtual ~HGCalAlgoWrapperBaseT() {}
+
+  virtual void configure(const Tparam& parameters) = 0;
+  virtual void process(const InputCollection& inputCollection, OutputCollection& outputCollection) const = 0;
+
+  const std::string& name() const { return name_; }
+
+private:
+  const std::string name_;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
@@ -1,0 +1,61 @@
+#ifndef L1Trigger_L1THGCal_HGCalCluster_SA_h
+#define L1Trigger_L1THGCal_HGCalCluster_SA_h
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalCluster {
+  public:
+    HGCalCluster(float x,
+                 float y,
+                 float z,
+                 int zside,
+                 unsigned int layer,
+                 float eta,
+                 float phi,
+                 float pt,
+                 float mipPt,
+                 unsigned int index_cmssw)
+        : x_(x),
+          y_(y),
+          z_(z),
+          zside_(zside),
+          layer_(layer),
+          eta_(eta),
+          phi_(phi),
+          pt_(pt),
+          mipPt_(mipPt),
+          index_cmssw_(index_cmssw) {}
+
+    ~HGCalCluster(){};
+
+    float x() const { return x_; }
+    float y() const { return y_; }
+    float z() const { return z_; }
+    float zside() const { return zside_; }
+    unsigned int layer() const { return layer_; }
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    float pt() const { return pt_; }
+    float mipPt() const { return mipPt_; }
+    unsigned int index_cmssw() const { return index_cmssw_; }
+
+  private:
+    float x_;
+    float y_;
+    float z_;
+    int zside_;
+    unsigned int layer_;
+    float eta_;
+    float phi_;
+    float pt_;
+    float mipPt_;
+    unsigned int index_cmssw_;
+  };
+
+  typedef std::vector<HGCalCluster> HGCalClusterSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h
@@ -1,0 +1,56 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class ClusterAlgoConfig {
+  public:
+    ClusterAlgoConfig(const double midRadius,
+                      const double dr,
+                      const std::vector<double>& dr_byLayer_coefficientA,
+                      const std::vector<double>& dr_byLayer_coefficientB,
+                      const float ptC3dThreshold)
+        : midRadius_(midRadius),
+          dr_(dr),
+          dr_byLayer_coefficientA_(dr_byLayer_coefficientA),
+          dr_byLayer_coefficientB_(dr_byLayer_coefficientB),
+          ptC3dThreshold_(ptC3dThreshold) {}
+
+    void setParameters(double midRadius,
+                       double dr,
+                       const std::vector<double>& dr_byLayer_coefficientA,
+                       const std::vector<double>& dr_byLayer_coefficientB,
+                       float ptC3dThreshold) {
+      midRadius_ = midRadius;
+      dr_ = dr;
+      dr_byLayer_coefficientA_ = dr_byLayer_coefficientA;
+      dr_byLayer_coefficientB_ = dr_byLayer_coefficientB;
+      ptC3dThreshold_ = ptC3dThreshold;
+    }
+
+    void setParameters(const ClusterAlgoConfig& newConfig) {
+      setParameters(newConfig.midRadius(),
+                    newConfig.dr(),
+                    newConfig.dr_byLayer_coefficientA(),
+                    newConfig.dr_byLayer_coefficientB(),
+                    newConfig.ptC3dThreshold());
+    }
+    double midRadius() const { return midRadius_; }
+    double dr() const { return dr_; }
+    const std::vector<double>& dr_byLayer_coefficientA() const { return dr_byLayer_coefficientA_; }
+    const std::vector<double>& dr_byLayer_coefficientB() const { return dr_byLayer_coefficientB_; }
+    float ptC3dThreshold() const { return ptC3dThreshold_; }
+
+  private:
+    double midRadius_;
+    double dr_;
+    std::vector<double> dr_byLayer_coefficientA_;
+    std::vector<double> dr_byLayer_coefficientB_;
+    float ptC3dThreshold_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
@@ -1,0 +1,33 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+class HGCalHistoClusteringImplSA {
+public:
+  HGCalHistoClusteringImplSA();
+  ~HGCalHistoClusteringImplSA() {}
+
+  void runAlgorithm() const;
+
+  std::vector<l1thgcfirmware::HGCalMulticluster> clusterSeedMulticluster_SA(
+      const std::vector<l1thgcfirmware::HGCalCluster>& clusters,
+      const std::vector<l1thgcfirmware::HGCalSeed>& seeds,
+      std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters,
+      const l1thgcfirmware::ClusterAlgoConfig& configuration) const;
+
+  void finalizeClusters_SA(const std::vector<l1thgcfirmware::HGCalMulticluster>&,
+                           const std::vector<l1thgcfirmware::HGCalCluster>&,
+                           std::vector<l1thgcfirmware::HGCalMulticluster>&,
+                           std::vector<l1thgcfirmware::HGCalCluster>&,
+                           const l1thgcfirmware::ClusterAlgoConfig& configuration) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
@@ -1,0 +1,61 @@
+#ifndef L1Trigger_L1THGCal_HGCalMulticluster_SA_h
+#define L1Trigger_L1THGCal_HGCalMulticluster_SA_h
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalMulticluster {
+  public:
+    HGCalMulticluster()
+        : hOverEValid_(false),
+          centre_x_(0),
+          centre_y_(0),
+          centre_z_(0),
+          centreProj_x_(0),
+          centreProj_y_(0),
+          centreProj_z_(0),
+          mipPt_(0),
+          sumPt_() {}
+
+    HGCalMulticluster(const l1thgcfirmware::HGCalCluster& tc, float fraction = 1.);
+
+    void addConstituent(const l1thgcfirmware::HGCalCluster& tc, bool updateCentre = true, float fraction = 1.);
+
+    ~HGCalMulticluster(){};
+
+    const std::vector<l1thgcfirmware::HGCalCluster>& constituents() const { return constituents_; }
+
+    unsigned size() const { return constituents_.size(); }
+
+    float sumPt() const { return sumPt_; }
+
+  private:
+    float hOverE_;
+    bool hOverEValid_;
+
+    // Could replace this with own simple implementation of GlobalPoint?
+    // Or just a struct?
+    float centre_x_;
+    float centre_y_;
+    float centre_z_;
+
+    float centreProj_x_;
+    float centreProj_y_;
+    float centreProj_z_;
+
+    float mipPt_;
+    float sumPt_;
+
+    std::vector<l1thgcfirmware::HGCalCluster> constituents_;
+
+    void updateP4AndPosition(const l1thgcfirmware::HGCalCluster& tc, bool updateCentre = true, float fraction = 1.);
+  };
+
+  typedef std::vector<HGCalMulticluster> HGCalMulticlusterSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h
@@ -1,0 +1,28 @@
+#ifndef L1Trigger_L1THGCal_HGCalSeed_SA_h
+#define L1Trigger_L1THGCal_HGCalSeed_SA_h
+
+namespace l1thgcfirmware {
+
+  class HGCalSeed {
+  public:
+    HGCalSeed(float x, float y, float z, float energy) : x_(x), y_(y), z_(z), energy_(energy) {}
+
+    ~HGCalSeed(){};
+
+    float x() const { return x_; }
+    float y() const { return y_; }
+    float z() const { return z_; }
+    float energy() const { return energy_; }
+
+  private:
+    float x_;
+    float y_;
+    float z_;
+    float energy_;
+  };
+
+  typedef std::vector<HGCalSeed> HGCalSeedSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
@@ -1,0 +1,16 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTowerMapImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalTowerMapImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+
+class HGCalTowerMapImplSA {
+public:
+  HGCalTowerMapImplSA() {}
+  ~HGCalTowerMapImplSA() {}
+
+  void runAlgorithm(const std::vector<l1thgcfirmware::HGCalTowerMap>& inputTowerMaps_SA,
+                    std::vector<l1thgcfirmware::HGCalTower>& outputTowers_SA) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
@@ -1,0 +1,30 @@
+#ifndef L1Trigger_L1THGCal_HGCalTowerMap_SA_h
+#define L1Trigger_L1THGCal_HGCalTowerMap_SA_h
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalTowerMap {
+  public:
+    HGCalTowerMap(){};
+    HGCalTowerMap(const std::vector<unsigned short>& tower_ids);
+
+    ~HGCalTowerMap(){};
+
+    HGCalTowerMap& operator+=(const HGCalTowerMap& map);
+
+    bool addEt(short bin_id, float etEm, float etHad);
+
+    const std::unordered_map<unsigned short, l1thgcfirmware::HGCalTower>& towers() const { return towerMap_; }
+
+  private:
+    std::unordered_map<unsigned short, l1thgcfirmware::HGCalTower> towerMap_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h
@@ -1,0 +1,15 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTowerMapsConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalTowerMapsConfig_SA_h__
+
+namespace l1thgcfirmware {
+
+  class TowerMapsAlgoConfig {
+  public:
+    TowerMapsAlgoConfig() {}
+
+    void setParameters(const TowerMapsAlgoConfig& newConfig) {}
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -1,0 +1,27 @@
+#ifndef L1Trigger_L1THGCal_HGCalTower_SA_h
+#define L1Trigger_L1THGCal_HGCalTower_SA_h
+
+namespace l1thgcfirmware {
+
+  class HGCalTower {
+  public:
+    HGCalTower() {}
+    HGCalTower(double etEm, double etHad) : etEm_(etEm), etHad_(etHad) {}
+
+    ~HGCalTower(){};
+
+    double etEm() const { return etEm_; };
+    double etHad() const { return etHad_; };
+
+    void addEtEm(double et);
+    void addEtHad(double et);
+
+    HGCalTower& operator+=(const HGCalTower& tower);
+
+  private:
+    double etEm_;
+    double etHad_;
+  };
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -63,7 +63,6 @@ void HGCalBackendLayer2Producer::produce(edm::Event& e, const edm::EventSetup& e
   edm::Handle<l1t::HGCalClusterBxCollection> trigCluster2DBxColl;
 
   e.getByToken(input_clusters_, trigCluster2DBxColl);
-
   backendProcess_->run(trigCluster2DBxColl, be_output, es);
 
   e.put(std::make_unique<l1t::HGCalMulticlusterBxCollection>(std::move(be_output.first)), backendProcess_->name());

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
@@ -1,0 +1,91 @@
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h"
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h"
+
+#include <utility>
+
+class HGCalBackendLayer2Processor3DClusteringSA : public HGCalBackendLayer2ProcessorBase {
+public:
+  HGCalBackendLayer2Processor3DClusteringSA(const edm::ParameterSet& conf)
+      : HGCalBackendLayer2ProcessorBase(conf), conf_(conf) {
+    multiclusteringHistoSeeding_ = std::make_unique<HGCalHistoSeedingImpl>(
+        conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_seeding_parameters"));
+
+    const edm::ParameterSet& clusteringParamConfig =
+        conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_clustering_parameters");
+    const std::string& clusteringAlgoWrapperName = clusteringParamConfig.getParameter<std::string>("AlgoName");
+    multiclusteringHistoClusteringWrapper_ = std::unique_ptr<HGCalHistoClusteringWrapperBase>{
+        HGCalHistoClusteringWrapperBaseFactory::get()->create(clusteringAlgoWrapperName, clusteringParamConfig)};
+
+    for (const auto& interpretationPset : conf.getParameter<std::vector<edm::ParameterSet>>("energy_interpretations")) {
+      std::unique_ptr<HGCalTriggerClusterInterpreterBase> interpreter{
+          HGCalTriggerClusterInterpreterFactory::get()->create(interpretationPset.getParameter<std::string>("type"))};
+      interpreter->initialize(interpretationPset);
+      energy_interpreters_.push_back(std::move(interpreter));
+    }
+  }
+
+  void run(const edm::Handle<l1t::HGCalClusterBxCollection>& collHandle,
+           std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection>& be_output,
+           const edm::EventSetup& es) override {
+    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+    if (multiclusteringHistoSeeding_)
+      multiclusteringHistoSeeding_->eventSetup(es);
+    l1t::HGCalMulticlusterBxCollection& collCluster3D = be_output.first;
+    l1t::HGCalClusterBxCollection& rejectedClusters = be_output.second;
+
+    /* create a persistent vector of pointers to the trigger-cells */
+    std::vector<edm::Ptr<l1t::HGCalCluster>> clustersPtrs;
+    for (unsigned i = 0; i < collHandle->size(); ++i) {
+      edm::Ptr<l1t::HGCalCluster> ptr(collHandle, i);
+      clustersPtrs.push_back(ptr);
+    }
+
+    /* create a vector of seed positions and their energy*/
+    std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
+
+    /* call to multiclustering and compute shower shape*/
+    multiclusteringHistoSeeding_->findHistoSeeds(clustersPtrs, seedPositionsEnergy);
+
+    // Inputs
+    std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>&, const std::vector<std::pair<GlobalPoint, double>>&>
+        inputClustersAndSeeds{clustersPtrs, seedPositionsEnergy};
+    // Outputs
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>
+        outputMulticlustersAndRejectedClusters{collCluster3D, rejectedClusters};
+    // Configuration
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&> configuration{es, conf_};
+
+    // Configure and process
+    multiclusteringHistoClusteringWrapper_->configure(configuration);
+    multiclusteringHistoClusteringWrapper_->process(inputClustersAndSeeds, outputMulticlustersAndRejectedClusters);
+
+    // Call all the energy interpretation modules on the cluster collection
+    for (const auto& interpreter : energy_interpreters_) {
+      interpreter->eventSetup(es);
+      interpreter->interpret(collCluster3D);
+    }
+  }
+
+private:
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+
+  /* algorithms instances */
+  std::unique_ptr<HGCalHistoSeedingImpl> multiclusteringHistoSeeding_;
+
+  std::unique_ptr<HGCalHistoClusteringWrapperBase> multiclusteringHistoClusteringWrapper_;
+
+  std::vector<std::unique_ptr<HGCalTriggerClusterInterpreterBase>> energy_interpreters_;
+
+  const edm::ParameterSet conf_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalBackendLayer2Factory,
+                  HGCalBackendLayer2Processor3DClusteringSA,
+                  "HGCalBackendLayer2Processor3DClusteringSA");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
@@ -1,0 +1,185 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalHistoClusteringWrapper : public HGCalHistoClusteringWrapperBase {
+public:
+  HGCalHistoClusteringWrapper(const edm::ParameterSet& conf);
+  ~HGCalHistoClusteringWrapper() override {}
+
+  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
+
+  void process(const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>,
+                               const std::vector<std::pair<GlobalPoint, double>>>& inputClustersAndSeeds,
+               std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
+                   outputMulticlustersAndRejectedClusters) const override;
+
+private:
+  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                          l1thgcfirmware::HGCalClusterSACollection& clusters_SA,
+                          const std::vector<std::pair<GlobalPoint, double>>& seeds,
+                          l1thgcfirmware::HGCalSeedSACollection& seeds_SA) const;
+  void convertAlgorithmOutputs(const l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_out,
+                               const l1thgcfirmware::HGCalClusterSACollection& rejected_clusters_out,
+                               const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                               l1t::HGCalMulticlusterBxCollection& multiclusters,
+                               l1t::HGCalClusterBxCollection& rejected_clusters) const;
+
+  void clusterizeHisto(const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
+                       const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
+                       l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
+                       l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const;
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  HGCalTriggerTools triggerTools_;
+
+  HGCalHistoClusteringImplSA theAlgo_;
+
+  l1thgcfirmware::ClusterAlgoConfig theConfiguration_;
+
+  static constexpr double kMidRadius_ = 2.3;
+};
+
+HGCalHistoClusteringWrapper::HGCalHistoClusteringWrapper(const edm::ParameterSet& conf)
+    : HGCalHistoClusteringWrapperBase(conf),
+      theAlgo_(),
+      theConfiguration_(kMidRadius_,
+                        conf.getParameter<double>("dR_multicluster"),
+                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
+                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
+                            : std::vector<double>(),
+                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
+                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
+                            : std::vector<double>(),
+                        conf.getParameter<double>("minPt_multicluster")) {}
+
+void HGCalHistoClusteringWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                                                     std::vector<l1thgcfirmware::HGCalCluster>& clusters_SA,
+                                                     const std::vector<std::pair<GlobalPoint, double>>& seeds,
+                                                     std::vector<l1thgcfirmware::HGCalSeed>& seeds_SA) const {
+  clusters_SA.clear();
+  clusters_SA.reserve(clustersPtrs.size());
+  unsigned int clusterIndex = 0;
+  for (const auto& cluster : clustersPtrs) {
+    clusters_SA.emplace_back(cluster->centreProj().x(),
+                             cluster->centreProj().y(),
+                             cluster->centre().z(),
+                             triggerTools_.zside(cluster->detId()),
+                             triggerTools_.layerWithOffset(cluster->detId()),
+                             cluster->eta(),
+                             cluster->phi(),
+                             cluster->pt(),
+                             cluster->mipPt(),
+                             clusterIndex);
+    ++clusterIndex;
+  }
+
+  seeds_SA.clear();
+  seeds_SA.reserve(seeds.size());
+  for (const auto& seed : seeds) {
+    seeds_SA.emplace_back(seed.first.x(), seed.first.y(), seed.first.z(), seed.second);
+  }
+}
+
+void HGCalHistoClusteringWrapper::convertAlgorithmOutputs(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
+    const std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_out,
+    const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+    l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection,
+    l1t::HGCalClusterBxCollection& rejected_clusters) const {
+  // Not doing completely the correct thing here
+  // Taking the multiclusters from the stand alone emulation
+  // Getting their consistuent clusters (stand alone objects)
+  // Linking back to the original CMSSW-type cluster
+  // And creating a CMSSW-type multicluster based from these clusters
+  // So the output multiclusters will not be storing bit accurate quantities (or whatever was derived by the stand along emulation)
+  // As these inherit from L1Candidate, could set their HW quantities to the bit accurate ones
+  for (const auto& rejected_cluster : rejected_clusters_out) {
+    rejected_clusters.push_back(0, *clustersPtrs.at(rejected_cluster.index_cmssw()));
+  }
+
+  std::vector<l1t::HGCalMulticluster> multiclusters;
+  multiclusters.reserve(multiclusters_out.size());
+  for (unsigned int imulticluster = 0; imulticluster < multiclusters_out.size(); ++imulticluster) {
+    bool firstConstituent = true;
+    for (const auto& constituent : multiclusters_out[imulticluster].constituents()) {
+      if (firstConstituent) {
+        multiclusters.emplace_back(clustersPtrs.at(constituent.index_cmssw()), 1.);
+      } else {
+        multiclusters.at(imulticluster).addConstituent(clustersPtrs.at(constituent.index_cmssw()), 1.);
+      }
+      firstConstituent = false;
+    }
+  }
+
+  for (const auto& multicluster : multiclusters) {
+    multiclustersBXCollection.push_back(0, multicluster);
+  }
+}
+
+void HGCalHistoClusteringWrapper::process(
+    const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>&
+        inputClustersAndSeeds,
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
+        outputMulticlustersAndRejectedClusters) const {
+  l1thgcfirmware::HGCalClusterSACollection clusters_SA;
+  l1thgcfirmware::HGCalSeedSACollection seeds_SA;
+  convertCMSSWInputs(inputClustersAndSeeds.first, clusters_SA, inputClustersAndSeeds.second, seeds_SA);
+
+  l1thgcfirmware::HGCalClusterSACollection rejected_clusters_finalized_SA;
+  l1thgcfirmware::HGCalMulticlusterSACollection multiclusters_finalized_SA;
+  clusterizeHisto(clusters_SA, seeds_SA, multiclusters_finalized_SA, rejected_clusters_finalized_SA);
+
+  convertAlgorithmOutputs(multiclusters_finalized_SA,
+                          rejected_clusters_finalized_SA,
+                          inputClustersAndSeeds.first,
+                          outputMulticlustersAndRejectedClusters.first,
+                          outputMulticlustersAndRejectedClusters.second);
+}
+
+void HGCalHistoClusteringWrapper::clusterizeHisto(
+    const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
+    const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
+    l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
+    l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const {
+  // Call SA clustering
+  std::vector<l1thgcfirmware::HGCalCluster> rejected_clusters_vec_SA;
+  std::vector<l1thgcfirmware::HGCalMulticluster> multiclusters_vec_SA =
+      theAlgo_.clusterSeedMulticluster_SA(inputClusters, inputSeeds, rejected_clusters_vec_SA, theConfiguration_);
+
+  theAlgo_.finalizeClusters_SA(
+      multiclusters_vec_SA, rejected_clusters_vec_SA, outputMulticlusters, outputRejectedClusters, theConfiguration_);
+}
+
+void HGCalHistoClusteringWrapper::configure(
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) {
+  eventSetup(configuration.first);
+
+  // theConfiguration_.setParameters( ... );
+
+  if ((!theConfiguration_.dr_byLayer_coefficientA().empty() &&
+       (theConfiguration_.dr_byLayer_coefficientA().size() - 1) < triggerTools_.lastLayerBH()) ||
+      (!theConfiguration_.dr_byLayer_coefficientB().empty() &&
+       (theConfiguration_.dr_byLayer_coefficientB().size() - 1) < triggerTools_.lastLayerBH())) {
+    throw cms::Exception("Configuration")
+        << "The per-layer dR values go up to " << (theConfiguration_.dr_byLayer_coefficientA().size() - 1) << "(A) and "
+        << (theConfiguration_.dr_byLayer_coefficientB().size() - 1) << "(B), while layers go up to "
+        << triggerTools_.lastLayerBH() << "\n";
+  }
+};
+
+DEFINE_EDM_PLUGIN(HGCalHistoClusteringWrapperBaseFactory, HGCalHistoClusteringWrapper, "HGCalHistoClusteringWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -1,0 +1,81 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+#include "DataFormats/L1THGCal/interface/HGCalTower.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h"
+
+class HGCalTowerMapsWrapper : public HGCalTowerMapsWrapperBase {
+public:
+  HGCalTowerMapsWrapper(const edm::ParameterSet& conf);
+  ~HGCalTowerMapsWrapper() override {}
+
+  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) override;
+
+  void process(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputs,
+               l1t::HGCalTowerBxCollection& outputs) const override;
+
+private:
+  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
+                          std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const;
+  void convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towerMaps_SA,
+                               l1t::HGCalTowerBxCollection& outputTowerMaps) const;
+  void eventSetup(const edm::EventSetup& es) {}
+
+  HGCalTowerMapImplSA theAlgo_;
+
+  std::unique_ptr<l1thgcfirmware::TowerMapsAlgoConfig> theConfiguration_;
+};
+
+HGCalTowerMapsWrapper::HGCalTowerMapsWrapper(const edm::ParameterSet& conf) : HGCalTowerMapsWrapperBase(conf) {}
+
+void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
+                                               std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const {
+  for (const auto& map : inputTowerMaps) {
+    std::vector<unsigned short> tower_ids;
+    for (const auto& tower : map->towers()) {
+      tower_ids.push_back(tower.first);
+    }
+
+    l1thgcfirmware::HGCalTowerMap towerMapSA(tower_ids);
+
+    for (const auto& tower : map->towers()) {
+      towerMapSA.addEt(tower.first, tower.second.etEm(), tower.second.etHad());
+    }
+    towerMaps_SA.emplace_back(towerMapSA);
+  }
+}
+
+void HGCalTowerMapsWrapper::convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towers_SA,
+                                                    l1t::HGCalTowerBxCollection& outputTowerMaps) const {
+  for (const auto& towerSA : towers_SA) {
+    // Need to carry eta, phi, ID through the SA emulation
+    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), 0, 0, 0));
+  }
+}
+
+void HGCalTowerMapsWrapper::process(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputs,
+                                    l1t::HGCalTowerBxCollection& outputs) const {
+  std::vector<l1thgcfirmware::HGCalTowerMap> inputs_SA;
+  convertCMSSWInputs(inputs, inputs_SA);
+
+  std::vector<l1thgcfirmware::HGCalTower> outputs_SA;
+  theAlgo_.runAlgorithm(inputs_SA, outputs_SA);
+
+  convertAlgorithmOutputs(outputs_SA, outputs);
+}
+
+void HGCalTowerMapsWrapper::configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) {}
+
+DEFINE_EDM_PLUGIN(HGCalTowerMapsWrapperBaseFactory, HGCalTowerMapsWrapper, "HGCalTowerMapsWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -1,0 +1,53 @@
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+#include "DataFormats/L1THGCal/interface/HGCalTower.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+
+class HGCalTowerProcessorSA : public HGCalTowerProcessorBase {
+public:
+  HGCalTowerProcessorSA(const edm::ParameterSet& conf) : HGCalTowerProcessorBase(conf), conf_(conf) {
+    const std::string towerMapsAlgoName(
+        conf.getParameterSet("towermap_parameters").getParameter<std::string>("AlgoName"));
+    towerMapWrapper_ = std::unique_ptr<HGCalTowerMapsWrapperBase>{HGCalTowerMapsWrapperBaseFactory::get()->create(
+        towerMapsAlgoName, conf.getParameterSet("towermap_parameters"))};
+  }
+
+  void eventSetup(const edm::EventSetup& es) override {}
+
+  void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
+               collHandle,
+           l1t::HGCalTowerBxCollection& collTowers,
+           const edm::EventSetup& es) override {
+    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+
+    auto& towerMapCollHandle = collHandle.first;
+
+    /* create a persistent vector of pointers to the towerMaps */
+    std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+      towerMapsPtrs.emplace_back(towerMapCollHandle, i);
+    }
+
+    // Configuration
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&> configuration{es, conf_};
+    towerMapWrapper_->configure(configuration);
+    towerMapWrapper_->process(towerMapsPtrs, collTowers);
+  }
+
+private:
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+
+  /* Standalone algorithm instance */
+  std::unique_ptr<HGCalTowerMapsWrapperBase> towerMapWrapper_;
+
+  const edm::ParameterSet conf_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTowerFactory, HGCalTowerProcessorSA, "HGCalTowerProcessorSA");

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -110,6 +110,7 @@ phase2_hgcalV10.toModify(histoMax_C3d_seeding_params,
 
 
 histoMaxVariableDR_C3d_params = histoMax_C3d_clustering_params.clone(
+        AlgoName = cms.string('HGCalHistoClusteringWrapper'),
         dR_multicluster = cms.double(0.),
         dR_multicluster_byLayer_coefficientA = cms.vdouble(dr_layerbylayer),
         dR_multicluster_byLayer_coefficientB = cms.vdouble([0]*(MAX_LAYERS+1))

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -14,6 +14,7 @@ L1TTriggerTowerConfig_etaphi = cms.PSet(readMappingFile=cms.bool(False),
 
 towerMap2D_parValues = cms.PSet( useLayerWeights = cms.bool(False),
                                  layerWeights = cms.vdouble(),
+                                  AlgoName = cms.string('HGCalTowerMapsWrapper'),
                                  L1TTriggerTowerConfig = L1TTriggerTowerConfig_etaphi
 )
 

--- a/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
@@ -1,0 +1,5 @@
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+
+EDM_REGISTER_PLUGINFACTORY(HGCalHistoClusteringWrapperBaseFactory, "HGCalHistoClusteringWrapperBaseFactory");
+
+EDM_REGISTER_PLUGINFACTORY(HGCalTowerMapsWrapperBaseFactory, "HGCalTowerMapsWrapperBaseFactory");

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
@@ -1,0 +1,110 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h"
+
+#include <map>
+#include <cmath>
+
+HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA() {}
+
+// void HGCalHistoClusteringImplSA::runAlgorithm() const {
+
+// }
+
+std::vector<l1thgcfirmware::HGCalMulticluster> HGCalHistoClusteringImplSA::clusterSeedMulticluster_SA(
+    const std::vector<l1thgcfirmware::HGCalCluster>& clusters,
+    const std::vector<l1thgcfirmware::HGCalSeed>& seeds,
+    std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters,
+    const l1thgcfirmware::ClusterAlgoConfig& configuration) const {
+  std::map<int, l1thgcfirmware::HGCalMulticluster> mapSeedMulticluster;
+  std::vector<l1thgcfirmware::HGCalMulticluster> multiclustersOut;
+
+  for (const auto& clu : clusters) {
+    int z_side = clu.zside();
+
+    double radiusCoefficientA = configuration.dr_byLayer_coefficientA().empty()
+                                    ? configuration.dr()
+                                    : configuration.dr_byLayer_coefficientA()[clu.layer()];
+    double radiusCoefficientB =
+        configuration.dr_byLayer_coefficientB().empty() ? 0 : configuration.dr_byLayer_coefficientB()[clu.layer()];
+
+    double minDist = radiusCoefficientA + radiusCoefficientB * (configuration.midRadius() - std::abs(clu.eta()));
+
+    std::vector<std::pair<int, double>> targetSeedsEnergy;
+
+    unsigned int iseed = 0;
+    for (const auto& seed : seeds) {
+      if (z_side * seed.z() < 0) {
+        ++iseed;
+        continue;
+      }
+
+      double seedEnergy = seed.energy();
+
+      double d = sqrt((clu.x() - seed.x()) * (clu.x() - seed.x()) + (clu.y() - seed.y()) * (clu.y() - seed.y()));
+
+      if (d < minDist) {
+        // NearestNeighbour
+        minDist = d;
+
+        if (targetSeedsEnergy.empty()) {
+          targetSeedsEnergy.emplace_back(iseed, seedEnergy);
+        } else {
+          targetSeedsEnergy.at(0).first = iseed;
+          targetSeedsEnergy.at(0).second = seedEnergy;
+        }
+      }
+      ++iseed;
+    }
+
+    if (targetSeedsEnergy.empty()) {
+      rejected_clusters.emplace_back(clu);
+      continue;
+    }
+
+    // N.B. as I have only implemented NearestNeighbour option
+    // then targetSeedsEnergy has at most 1 seed for this cluster
+    // Leaving in some redundant functionality in case we need
+    // EnergySplit option
+
+    //Loop over target seeds and divide up the clusters energy
+    double totalTargetSeedEnergy = 0;
+    for (const auto& energy : targetSeedsEnergy) {
+      totalTargetSeedEnergy += energy.second;
+    }
+
+    for (const auto& energy : targetSeedsEnergy) {
+      double seedWeight = 1;
+      if (mapSeedMulticluster[energy.first].size() == 0) {
+        mapSeedMulticluster[energy.first] = l1thgcfirmware::HGCalMulticluster(clu, 1);
+      } else {
+        mapSeedMulticluster[energy.first].addConstituent(clu, true, seedWeight);
+      }
+    }
+  }
+
+  multiclustersOut.reserve(mapSeedMulticluster.size());
+  for (const auto& mclu : mapSeedMulticluster)
+    multiclustersOut.emplace_back(mclu.second);
+
+  return multiclustersOut;
+}
+
+void HGCalHistoClusteringImplSA::finalizeClusters_SA(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_in,
+    const std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_in,
+    std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
+    std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_out,
+    const l1thgcfirmware::ClusterAlgoConfig& configuration) const {
+  for (const auto& tc : rejected_clusters_in) {
+    rejected_clusters_out.push_back(tc);
+  }
+
+  for (const auto& multicluster : multiclusters_in) {
+    if (multicluster.sumPt() > configuration.ptC3dThreshold()) {
+      multiclusters_out.push_back(multicluster);
+    } else {
+      for (const auto& tc : multicluster.constituents()) {
+        rejected_clusters_out.push_back(tc);
+      }
+    }
+  }
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticluster_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticluster_SA.cc
@@ -1,0 +1,55 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+
+#include <cmath>
+
+using namespace l1thgcfirmware;
+
+HGCalMulticluster::HGCalMulticluster(const HGCalCluster& tc, float fraction) {
+  HGCalMulticluster();
+  addConstituent(tc, true, fraction);
+}
+
+void HGCalMulticluster::addConstituent(const HGCalCluster& tc, bool updateCentre, float fraction) {
+  // If no constituents, set seedMiptPt to cluster mipPt
+  if (constituents_.empty()) {
+    // seedMipPt_ = cMipPt;
+    if (!updateCentre) {
+      centre_x_ = tc.x();
+      centre_y_ = tc.y();
+      centre_z_ = tc.z();
+    }
+  }
+  // UpdateP4AndPosition
+  updateP4AndPosition(tc, updateCentre, fraction);
+
+  constituents_.emplace_back(tc);
+}
+
+void HGCalMulticluster::updateP4AndPosition(const HGCalCluster& tc, bool updateCentre, float fraction) {
+  // Get cluster mipPt
+  double cMipt = tc.mipPt() * fraction;
+  double cPt = tc.pt() * fraction;
+  if (updateCentre) {
+    float clusterCentre_x = centre_x_ * mipPt_ + tc.x() * cMipt;
+    float clusterCentre_y = centre_y_ * mipPt_ + tc.y() * cMipt;
+    float clusterCentre_z = centre_z_ * mipPt_ + tc.z() * cMipt;  // Check this!
+
+    if ((mipPt_ + cMipt) > 0) {
+      clusterCentre_x /= (mipPt_ + cMipt);
+      clusterCentre_y /= (mipPt_ + cMipt);
+      clusterCentre_z /= (mipPt_ + cMipt);
+    }
+    centre_x_ = clusterCentre_x;
+    centre_y_ = clusterCentre_y;
+    centre_z_ = clusterCentre_z;
+
+    if (centre_z_ != 0) {
+      centreProj_x_ = centre_x_ / std::abs(centre_z_);
+      centreProj_y_ = centre_y_ / std::abs(centre_z_);
+      centreProj_z_ = centre_z_ / std::abs(centre_z_);
+    }
+  }
+
+  mipPt_ += cMipt;
+  sumPt_ += cPt;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
@@ -1,0 +1,25 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h"
+
+using namespace l1thgcfirmware;
+
+void HGCalTowerMapImplSA::runAlgorithm(const std::vector<HGCalTowerMap>& inputTowerMaps_SA,
+                                       std::vector<HGCalTower>& outputTowers_SA) const {
+  // Need better way to initialise the output tower map
+  if (inputTowerMaps_SA.empty())
+    return;
+  std::vector<unsigned short> tower_ids;
+  for (const auto& tower : inputTowerMaps_SA.front().towers()) {
+    tower_ids.push_back(tower.first);
+  }
+  HGCalTowerMap towerMap(tower_ids);
+
+  for (const auto& map : inputTowerMaps_SA) {
+    towerMap += map;
+  }
+
+  for (const auto& tower : towerMap.towers()) {
+    if (tower.second.etEm() > 0 || tower.second.etHad() > 0) {
+      outputTowers_SA.push_back(tower.second);
+    }
+  }
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
@@ -1,0 +1,31 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+
+#include <unordered_map>
+
+using namespace l1thgcfirmware;
+
+HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids) {
+  for (const auto tower_id : tower_ids) {
+    towerMap_[tower_id] = l1thgcfirmware::HGCalTower(0., 0.);
+  }
+}
+
+HGCalTowerMap& HGCalTowerMap::operator+=(const HGCalTowerMap& map) {
+  for (const auto& tower : map.towers()) {
+    auto this_tower = towerMap_.find(tower.first);
+    if (this_tower != towerMap_.end()) {
+      this_tower->second += tower.second;
+    }
+  }
+
+  return *this;
+}
+
+bool HGCalTowerMap::addEt(short bin_id, float etEm, float etHad) {
+  auto this_tower = towerMap_.find(bin_id);
+  if (this_tower == towerMap_.end())
+    return false;
+  this_tower->second.addEtEm(etEm);
+  this_tower->second.addEtHad(etHad);
+  return true;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTower_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTower_SA.cc
@@ -1,0 +1,14 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+
+using namespace l1thgcfirmware;
+
+HGCalTower& HGCalTower::operator+=(const HGCalTower& tower) {
+  etEm_ += tower.etEm();
+  etHad_ += tower.etHad();
+
+  return *this;
+}
+
+void HGCalTower::addEtEm(double et) { etEm_ += et; }
+
+void HGCalTower::addEtHad(double et) { etHad_ += et; }


### PR DESCRIPTION
First steps towards a framework where the existing clustering step in layer 2 can be run both inside (physics studies, production etc.) and outside of CMSSW (firmware development and debugging).

Summary/details:
- The relevant layer 2 producer is unchanged other than in the configuration, where a new “standalone” processor is picked up
- A new processor is added : HGCalBackendLayer2Processor3DClustering_SA.cc
  -  This can be configured to run the already-existing “HistoC3d” clustering, or the new standalone “SAHistoC3d” clustering.  The seeding is the same for both, and cannot be run outside of CMSSW yet.
  - In the standalone case, I still call a function called “clusterizeHisto”, with the same interface (function arguments) as the original case, but the class this function belongs to is now a wrapper class, rather than the direct implementation of the algorithm.
- A new wrapper class for the clustering implementation is added : HGCalHistoClusteringWrapper.h/cc
  - This converts the CMSSW inputs (and any required constants) into CMSSW-independent objects
  - The new classes for these objects are : HGCalCluster_SA.h and HGCalSeed_SA.h
  - For now, these are a simple version of the existing HGCalCluster.h DataFormats class and a new class for the seeds, containing the basic minimum quantities needed to run the existing clustering.  These are perhaps the classes that will also convert floating point quantities into whatever is used by the firmware (if it’s not already done earlier).
  - These classes could also in the future include information on how the objects are distributed on links, ordering of the objects going into the algorithm, store info if any objects were lost due to truncation.
- The CMSSW-independent inputs are passed to the new clustering implementation HGCalHistoClusteringImpl_SA.h/cc
  - This runs essentially the same algorithm as the original clustering currently in CMSSW.  However the finalizeClusters method doesn’t calculate any of the shower shapes or quality flags, which can be added in the future (or included when the emulation of the actual firmware is implemented).
- The output from the clustering is converted back into the CMSSW format in the wrapper class.  I have cheated a little here, as I am taking the CMSSW-independent clusters that form the output multiclusters, recovering the pointer/reference back to the original CMSSW clusters, and creating the output multiclusters in the CMSSW format from these.  This was something I wanted to test, and as the standalone implementation is identical to the original implementation of the clustering, it shouldn’t matter for now.
- I checked that this standalone implementation finds the same number of clusters as the original implementation, and that the standard ntuples are populated when using the standalone implementation.
- I have also checked that I can run this new implementation outside of CMSSW.
  - I have put a very simple case (running one event with minimal setup) here : L1Trigger/L1THGCal/test/SARunning