### PR TITLE
Geometry module, link and board mapping updates - 2

### DIFF
--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="SimDataFormats/CaloTest"/>
 <use name="PhysicsTools/TensorFlow" />
+<use name="json" />
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_v1.json
+++ b/L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_v1.json
@@ -1,0 +1,18128 @@
+{
+    "Stage2": [
+        {
+            "Stage1Links": [
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false},
+                {"SameSector": true},
+                {"SameSector": true},
+                {"SameSector": false}
+            ]
+        }
+    ],
+    "Stage1Links": [
+        {"Stage1": 0, "Stage2SameSector": true},
+        {"Stage1": 0, "Stage2SameSector": true},
+        {"Stage1": 0, "Stage2SameSector": false},
+        {"Stage1": 1, "Stage2SameSector": true},
+        {"Stage1": 1, "Stage2SameSector": true},
+        {"Stage1": 1, "Stage2SameSector": false},
+        {"Stage1": 2, "Stage2SameSector": true},
+        {"Stage1": 2, "Stage2SameSector": true},
+        {"Stage1": 2, "Stage2SameSector": false},
+        {"Stage1": 3, "Stage2SameSector": true},
+        {"Stage1": 3, "Stage2SameSector": true},
+        {"Stage1": 3, "Stage2SameSector": false},
+        {"Stage1": 4, "Stage2SameSector": true},
+        {"Stage1": 4, "Stage2SameSector": true},
+        {"Stage1": 4, "Stage2SameSector": false},
+        {"Stage1": 5, "Stage2SameSector": true},
+        {"Stage1": 5, "Stage2SameSector": true},
+        {"Stage1": 5, "Stage2SameSector": false},
+        {"Stage1": 6, "Stage2SameSector": true},
+        {"Stage1": 6, "Stage2SameSector": true},
+        {"Stage1": 6, "Stage2SameSector": false},
+        {"Stage1": 7, "Stage2SameSector": true},
+        {"Stage1": 7, "Stage2SameSector": true},
+        {"Stage1": 7, "Stage2SameSector": false},
+        {"Stage1": 8, "Stage2SameSector": true},
+        {"Stage1": 8, "Stage2SameSector": true},
+        {"Stage1": 8, "Stage2SameSector": false},
+        {"Stage1": 9, "Stage2SameSector": true},
+        {"Stage1": 9, "Stage2SameSector": true},
+        {"Stage1": 9, "Stage2SameSector": false},
+        {"Stage1": 10, "Stage2SameSector": true},
+        {"Stage1": 10, "Stage2SameSector": true},
+        {"Stage1": 10, "Stage2SameSector": false},
+        {"Stage1": 11, "Stage2SameSector": true},
+        {"Stage1": 11, "Stage2SameSector": true},
+        {"Stage1": 11, "Stage2SameSector": false},
+        {"Stage1": 12, "Stage2SameSector": true},
+        {"Stage1": 12, "Stage2SameSector": true},
+        {"Stage1": 12, "Stage2SameSector": false},
+        {"Stage1": 13, "Stage2SameSector": true},
+        {"Stage1": 13, "Stage2SameSector": true},
+        {"Stage1": 13, "Stage2SameSector": false},
+        {"Stage1": 14, "Stage2SameSector": true},
+        {"Stage1": 14, "Stage2SameSector": true},
+        {"Stage1": 14, "Stage2SameSector": false},
+        {"Stage1": 15, "Stage2SameSector": true},
+        {"Stage1": 15, "Stage2SameSector": true},
+        {"Stage1": 15, "Stage2SameSector": false},
+        {"Stage1": 16, "Stage2SameSector": true},
+        {"Stage1": 16, "Stage2SameSector": true},
+        {"Stage1": 16, "Stage2SameSector": false},
+        {"Stage1": 17, "Stage2SameSector": true},
+        {"Stage1": 17, "Stage2SameSector": true},
+        {"Stage1": 17, "Stage2SameSector": false},
+        {"Stage1": 18, "Stage2SameSector": true},
+        {"Stage1": 18, "Stage2SameSector": true},
+        {"Stage1": 18, "Stage2SameSector": false},
+        {"Stage1": 19, "Stage2SameSector": true},
+        {"Stage1": 19, "Stage2SameSector": true},
+        {"Stage1": 19, "Stage2SameSector": false},
+        {"Stage1": 20, "Stage2SameSector": true},
+        {"Stage1": 20, "Stage2SameSector": true},
+        {"Stage1": 20, "Stage2SameSector": false},
+        {"Stage1": 21, "Stage2SameSector": true},
+        {"Stage1": 21, "Stage2SameSector": true},
+        {"Stage1": 21, "Stage2SameSector": false},
+        {"Stage1": 22, "Stage2SameSector": true},
+        {"Stage1": 22, "Stage2SameSector": true},
+        {"Stage1": 22, "Stage2SameSector": false},
+        {"Stage1": 23, "Stage2SameSector": true},
+        {"Stage1": 23, "Stage2SameSector": true},
+        {"Stage1": 23, "Stage2SameSector": false}
+    ],
+    "Stage1": [
+        {"Stage1Links": [0, 1, 2], "lpgbts": [30, 1336, 1337, 159, 160, 161, 283, 1488, 1312, 1313, 1573, 862, 863, 1098, 388, 389, 1571, 310, 1356, 1357, 1495, 819, 1084, 1085, 1086, 1087, 922, 1040, 1202, 462, 463, 1267, 1268, 336, 337, 1425, 776, 94, 95, 668, 669, 213, 214, 215, 734, 733, 126, 127, 128, 129, 1234, 1235, 995, 996, 163, 1238, 1239, 1548, 1072, 1073, 946, 280, 1466, 1263, 1264]},
+        {"Stage1Links": [3, 4, 5], "lpgbts": [1479, 726, 727, 1056, 774, 245, 833, 374, 375, 345, 509, 1499, 135, 136, 137, 1581, 1541, 829, 830, 238, 1038, 1421, 978, 1115, 1229, 813, 559, 292, 630, 631, 134, 358, 359, 512, 456, 457, 649, 781, 782, 294, 951, 952, 1476, 507, 482, 483, 1443, 246, 1001, 1002, 914, 915, 771, 772, 599, 20, 21, 363, 364, 408, 409, 989, 906, 907, 1065]},
+        {"Stage1Links": [6, 7, 8], "lpgbts": [36, 37, 816, 817, 684, 200, 201, 202, 203, 557, 26, 981, 982, 918, 1578, 749, 1544, 1559, 636, 637, 87, 88, 89, 1490, 1513, 739, 740, 1041, 1042, 1130, 1131, 870, 871, 1172, 1173, 1059, 1060, 1076, 1077, 859, 852, 853, 1427, 1471, 939, 940, 1053, 1054, 1557, 836, 1057, 1058, 857, 517, 247, 919, 1391, 170, 171, 259, 260, 261, 414, 415, 944, 864, 865, 1350, 1351]},
+        {"Stage1Links": [9, 10, 11], "lpgbts": [231, 821, 822, 1148, 1149, 226, 904, 905, 1500, 332, 900, 1165, 496, 497, 872, 873, 470, 471, 664, 665, 1470, 285, 624, 625, 1378, 1493, 1018, 436, 437, 176, 1430, 534, 535, 920, 1162, 494, 495, 371, 372, 373, 987, 32, 392, 393, 1426, 1037, 187, 1242, 1012, 567, 1079, 475, 1277, 1278, 700, 701, 484, 485, 1474, 378, 1124, 518, 674, 675, 422, 423]},
+        {"Stage1Links": [12, 13, 14], "lpgbts": [1404, 1010, 438, 439, 550, 1294, 1221, 1222, 1503, 63, 64, 65, 148, 1027, 1035, 935, 936, 390, 391, 731, 686, 504, 301, 33, 1535, 1063, 1064, 300, 626, 627, 1274, 293, 468, 469, 244, 172, 173, 834, 947, 948, 1380, 777, 778, 216, 1552, 1449, 188, 1283, 999, 1000, 831, 832, 876, 877, 1431, 1397, 1496, 207, 208, 209, 1542, 1039, 1005, 1006]},
+        {"Stage1Links": [15, 16, 17], "lpgbts": [1447, 424, 425, 1580, 1319, 1206, 820, 314, 315, 316, 1346, 1347, 1205, 528, 529, 284, 1455, 179, 983, 984, 1428, 643, 514, 1051, 1052, 644, 645, 1520, 714, 715, 274, 275, 1300, 1301, 1481, 1069, 536, 537, 181, 243, 672, 673, 966, 1251, 1252, 1405, 1406, 1136, 1137, 769, 770, 1403, 298, 299, 40, 41, 1091, 474, 1382, 912, 913, 1213, 1512, 66, 90, 91]},
+        {"Stage1Links": [18, 19, 20], "lpgbts": [165, 1272, 230, 317, 318, 319, 272, 273, 652, 1554, 580, 581, 699, 1316, 1317, 815, 1032, 1033, 185, 1164, 1464, 1453, 1259, 1260, 434, 435, 1393, 1489, 1216, 696, 977, 775, 732, 1269, 1270, 1106, 1107, 1518, 1182, 1183, 1422, 1096, 753, 1408, 902, 967, 1290, 1291, 217, 154, 155, 651, 1292, 1293, 1387, 1170, 1171, 1097, 287, 521, 1374, 100, 1505, 180, 1352, 1353]},
+        {"Stage1Links": [21, 22, 23], "lpgbts": [282, 720, 721, 313, 186, 773, 969, 702, 703, 1543, 442, 443, 1407, 574, 575, 350, 1482, 835, 114, 971, 690, 691, 448, 449, 662, 663, 122, 123, 124, 125, 1583, 797, 724, 725, 416, 417, 1196, 963, 750, 737, 738, 1143, 382, 383, 1333, 754, 1585, 1475, 1462, 858, 184, 961, 962, 1331, 522, 523, 1562, 1179, 1101, 1276, 1328, 1218, 1150, 839, 1289, 1418, 229, 882]},
+        {"Stage1Links": [24, 25, 26], "lpgbts": [183, 1549, 1450, 404, 405, 1209, 1210, 1125, 83, 1342, 1343, 1386, 910, 911, 993, 994, 1434, 1174, 182, 1402, 1214, 232, 745, 746, 1381, 362, 1166, 1167, 823, 824, 1487, 1410, 1082, 1083, 50, 51, 1088, 233, 1110, 1081, 1261, 1262, 1089, 1112, 1504, 12, 1192, 1193, 1519, 1176, 193, 194, 195, 1178, 1111, 1118, 1119, 676, 677, 108, 109, 560, 974, 975, 78, 79]},
+        {"Stage1Links": [27, 28, 29], "lpgbts": [1108, 1473, 276, 277, 1454, 1561, 379, 783, 784, 340, 341, 338, 339, 1483, 848, 849, 1553, 1565, 970, 656, 657, 1564, 798, 799, 376, 377, 96, 97, 515, 972, 49, 1522, 466, 467, 1365, 538, 539, 735, 736, 1187, 410, 411, 706, 707, 1432, 923, 472, 473, 189, 190, 191, 942, 660, 661, 478, 479, 866, 867, 511, 1067, 722, 723, 289, 837, 741, 742]},
+        {"Stage1Links": [30, 31, 32], "lpgbts": [500, 501, 818, 368, 369, 370, 1376, 1416, 810, 811, 1236, 698, 685, 654, 1446, 553, 342, 1231, 506, 1389, 1390, 1160, 1161, 1398, 81, 82, 1116, 1117, 596, 1400, 964, 464, 465, 218, 84, 85, 86, 597, 15, 1003, 1004, 598, 1360, 1361, 306, 307, 1456, 1436, 1030, 1031, 1159, 610, 1095, 1532, 286, 1568, 812, 1203, 1526, 666, 667, 1127, 1497]},
+        {"Stage1Links": [33, 34, 35], "lpgbts": [1138, 1139, 638, 639, 844, 845, 572, 573, 400, 401, 16, 17, 459, 704, 705, 1492, 751, 1401, 530, 531, 346, 791, 792, 295, 796, 356, 357, 548, 549, 1237, 1525, 116, 117, 118, 1197, 1472, 616, 617, 564, 565, 653, 1100, 210, 211, 212, 1025, 1026, 921, 558, 348, 6, 7, 609, 718, 719, 1469, 480, 481, 1394, 386, 387, 594, 595, 582, 583, 1320, 898, 899]},
+        {"Stage1Links": [36, 37, 38], "lpgbts": [1126, 1388, 1358, 1359, 99, 152, 153, 1330, 1334, 1335, 1286, 98, 933, 934, 1369, 763, 764, 1396, 540, 541, 1417, 1534, 767, 768, 1498, 328, 329, 302, 146, 147, 1399, 893, 894, 119, 120, 121, 1507, 263, 264, 265, 1287, 600, 601, 1022, 1023, 1515, 814, 1409, 678, 679, 1375, 1332, 562, 563, 937, 938, 240, 365, 1288, 1385, 608, 1232, 840, 841, 1451, 1435]},
+        {"Stage1Links": [39, 40, 41], "lpgbts": [28, 67, 68, 69, 551, 846, 847, 1508, 883, 884, 800, 801, 291, 110, 111, 607, 556, 303, 343, 1460, 354, 355, 955, 956, 1043, 1265, 1266, 885, 886, 13, 14, 614, 615, 991, 992, 166, 167, 1424, 1445, 785, 786, 605, 1377, 418, 419, 868, 869, 454, 455, 351, 1021, 687, 516, 761, 762, 1314, 1315, 861, 1225, 1226, 941, 1516, 931, 932, 1134, 1135]},
+        {"Stage1Links": [42, 43, 44], "lpgbts": [1574, 880, 174, 175, 1215, 1092, 1186, 1180, 510, 326, 327, 52, 53, 380, 1245, 1246, 258, 1413, 1344, 1345, 331, 747, 748, 476, 477, 789, 790, 1298, 1299, 1437, 1501, 92, 93, 1480, 1240, 1241, 1217, 366, 367, 1536, 759, 760, 1296, 1297, 1539, 1567, 1302, 1303, 901, 694, 11, 458, 566, 1147, 320, 31, 842, 843, 1340, 1341, 988, 1531, 546, 547, 24, 25]},
+        {"Stage1Links": [45, 46, 47], "lpgbts": [241, 168, 169, 1074, 1075, 1486, 743, 744, 802, 803, 131, 132, 133, 632, 633, 47, 1102, 1103, 269, 270, 271, 62, 1364, 755, 756, 606, 46, 396, 397, 353, 1433, 1198, 1199, 1550, 526, 527, 1566, 220, 221, 697, 1114, 1157, 1545, 860, 1014, 1015, 1459, 1128, 1129, 1395, 1233, 787, 788, 1448, 1080, 1013, 1142, 695, 1528, 1140, 1563, 968, 1168, 1169, 304, 305]},
+        {"Stage1Links": [48, 49, 50], "lpgbts": [1523, 688, 689, 1120, 1121, 1230, 1275, 1158, 333, 9, 10, 1155, 1156, 1243, 1509, 1295, 1326, 1327, 219, 444, 445, 113, 1329, 1028, 1029, 149, 150, 825, 826, 1132, 8, 1207, 1208, 586, 587, 344, 716, 717, 1322, 44, 45, 308, 309, 461, 957, 958, 1529, 1211, 1212, 1494, 997, 998, 321, 322, 242, 1438, 874, 875, 827, 828, 1442, 112, 1036, 712, 713, 234, 646, 647]},
+        {"Stage1Links": [51, 52, 53], "lpgbts": [1338, 1339, 1366, 1367, 249, 650, 710, 711, 151, 794, 1175, 640, 290, 262, 48, 324, 325, 729, 1584, 945, 1348, 1349, 1362, 1363, 1383, 1384, 1484, 655, 1220, 1558, 1420, 1304, 1305, 18, 19, 1310, 1311, 1551, 250, 251, 252, 253, 1094, 1547, 296, 297, 1569, 622, 623, 1555, 1540, 102, 103, 104, 1070, 1071, 323, 236, 1572, 592, 593, 1582, 1046, 1047]},
+        {"Stage1Links": [54, 55, 56], "lpgbts": [795, 177, 178, 288, 450, 451, 432, 433, 1253, 1254, 554, 1249, 1250, 1145, 1354, 1355, 889, 890, 1570, 428, 429, 1306, 1307, 1467, 1392, 728, 311, 312, 1370, 1371, 488, 489, 1521, 1093, 54, 55, 56, 57, 804, 805, 1556, 881, 347, 555, 1579, 1457, 1368, 248, 22, 23, 1184, 1185, 225, 1537, 1429, 973, 222, 612, 613, 1247, 1248, 611, 568, 569, 544, 545]},
+        {"Stage1Links": [57, 58, 59], "lpgbts": [1020, 578, 579, 27, 1219, 552, 897, 924, 460, 1321, 162, 618, 619, 1151, 1152, 1511, 1188, 1189, 752, 1285, 138, 139, 140, 141, 757, 758, 360, 361, 508, 891, 892, 1524, 1412, 1414, 1279, 1280, 1144, 223, 224, 1223, 1224, 641, 38, 39, 1379, 1146, 1458, 1419, 887, 888, 3, 4, 5, 204, 205, 206, 1411, 850, 851, 838, 349, 1255, 1256, 1181, 452, 453, 1439, 1502]},
+        {"Stage1Links": [60, 61, 62], "lpgbts": [588, 589, 1530, 903, 1204, 682, 683, 708, 709, 1478, 1281, 1282, 1485, 979, 980, 520, 80, 42, 43, 1257, 1258, 670, 671, 927, 928, 1546, 854, 855, 1163, 943, 1284, 584, 585, 1122, 29, 1440, 0, 1, 2, 1576, 602, 603, 278, 279, 235, 394, 395, 765, 766, 1318, 1560, 1016, 1017, 590, 591, 576, 577, 440, 441, 1538, 384, 385, 58, 59, 60, 61]},
+        {"Stage1Links": [63, 64, 65], "lpgbts": [402, 403, 693, 1514, 1048, 1099, 1090, 239, 570, 571, 628, 629, 105, 106, 107, 990, 1372, 1373, 513, 1423, 658, 659, 34, 35, 1324, 1325, 1049, 1050, 398, 399, 266, 267, 268, 381, 1506, 953, 954, 808, 809, 1465, 1575, 1477, 254, 255, 256, 257, 1109, 524, 525, 505, 1141, 1066, 1271, 806, 807, 1177, 1078, 1044, 1045, 965, 498, 499, 692, 561, 1273, 1415]},
+        {"Stage1Links": [66, 67, 68], "lpgbts": [446, 447, 1323, 430, 431, 1452, 1011, 192, 604, 620, 621, 281, 532, 533, 959, 960, 228, 925, 926, 985, 986, 1200, 1201, 1577, 492, 493, 1468, 1533, 101, 908, 909, 1055, 142, 143, 144, 145, 486, 487, 929, 930, 196, 197, 198, 199, 542, 543, 1024, 1113, 352, 1244, 1491, 426, 427, 1461, 1227, 1228, 227, 1123, 519, 412, 413, 895, 896, 680, 681, 330]},
+        {"Stage1Links": [69, 70, 71], "lpgbts": [642, 1009, 115, 1153, 1154, 334, 335, 74, 75, 76, 77, 1104, 1105, 1517, 156, 157, 158, 878, 1194, 1195, 976, 70, 71, 72, 73, 949, 950, 1463, 1308, 1309, 1007, 1008, 237, 1019, 490, 491, 1510, 1527, 916, 917, 779, 780, 1190, 1191, 730, 406, 407, 793, 1061, 1062, 634, 635, 1441, 502, 503, 648, 1444, 856, 164, 130, 1133, 1034, 1068, 420, 421, 879]}
+    ],
+    "lpgbt": [
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 1},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 1},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 1},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 1},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 1},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 1},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 1},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 1},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 1},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 1},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 1}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 3},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 3},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 3},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 3},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 3},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 3},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 3},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 3},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 3},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 3},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 3},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 3}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 5},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 5},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 5},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 5},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 5},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 5},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 5},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 5},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 5},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 5},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 5}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 7},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 7},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 7},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 7},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 7},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 7},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 7},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 7},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 7},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 7}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 9},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 9},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 9},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 9},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 9},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 9},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 9},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 9},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 9}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 11},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 11},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 11},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 11},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 11},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 11},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 11}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 13},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 13},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 13},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 13},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 13}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 15},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 15},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 15},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 15}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 17},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 17},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 17},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 17}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 19},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 19},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 19},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 19},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 19},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 19},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 19}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 21},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 21},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 21},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 21},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 21}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 23},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 23},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 23},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 23},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 23}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 25},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 25},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 25},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 25},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 25},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 25},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 25},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 25}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 27},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 27},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 27},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 27},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 27},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 27},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 27},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 27}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 29},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 29},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 29}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 10, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 5, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 9, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 2, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 8, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 3, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 30},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 30},
+                {"isSilicon": true, "u": 7, "v": 12, "layer": 30},
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 30}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 0, "v": 9, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 31},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 31},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 31}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 10, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 2, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 10, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 9, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 2, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 3, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 32},
+                {"isSilicon": true, "u": 8, "v": 12, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 32},
+                {"isSilicon": true, "u": 4, "v": 12, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 32},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 32},
+                {"isSilicon": true, "u": 7, "v": 12, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 32},
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 32}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 0, "v": 9, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 33},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 33},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 33},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 33}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 10, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 2, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 10, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 9, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 12, "v": 4, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 12, "v": 5, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 12, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 1, "v": 11, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 3, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 2, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 11, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 10, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 4, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 9, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 8, "v": 12, "layer": 34},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 34},
+                {"isSilicon": true, "u": 6, "v": 12, "layer": 34},
+                {"isSilicon": true, "u": 7, "v": 12, "layer": 34}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 0, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 1, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 9, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 2, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 12, "v": 3, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 12, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 12, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 2, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 10, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 0, "v": 10, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 10, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 1, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 9, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 2, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 8, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 3, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 35},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 35},
+                {"isSilicon": true, "u": 7, "v": 12, "layer": 35},
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 35}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 1, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 1, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 3, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 11, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 11, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 3, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 9, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 12, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 5, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 12, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 10, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 8, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 4, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 8, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 12, "v": 8, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 11, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 7, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 12, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 13, "v": 8, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 12, "v": 5, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 11, "v": 12, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 1, "v": 12, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 12, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 2, "v": 12, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 10, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 3, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 9, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 12, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 4, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 8, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 13, "layer": 36},
+                {"isSilicon": true, "u": 7, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 5, "v": 12, "layer": 36},
+                {"isSilicon": true, "u": 6, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 13, "layer": 36}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 37},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 37},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 37},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 37},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 37},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 38},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 38},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 38},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 38},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 38},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 38},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 38},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 38},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 0, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 1, "layer": 39},
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 2, "layer": 39},
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 39},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 39},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 39},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 39},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 39},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 39},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 1, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 9, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 1, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 9, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 2, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 8, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 3, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 10, "v": 7, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 4, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 10, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 9, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 1, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 40},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 40},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 40},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 40},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 40},
+                {"isSilicon": true, "u": 7, "v": 11, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 40},
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 40},
+                {"isSilicon": true, "u": 6, "v": 11, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 11, "layer": 40},
+                {"isSilicon": true, "u": 4, "v": 11, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 0, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 0, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 41},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 41},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 41},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 41},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 41},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 41},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 1, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 8, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 2, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 8, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 3, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 9, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 4, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 9, "v": 6, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 8, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 42},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 1, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 7, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 42},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 2, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 42},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 42},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 3, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 42},
+                {"isSilicon": true, "u": 5, "v": 9, "layer": 42},
+                {"isSilicon": true, "u": 6, "v": 10, "layer": 42},
+                {"isSilicon": true, "u": 4, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 10, "layer": 42},
+                {"isSilicon": true, "u": 4, "v": 10, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 43},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 43},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 43},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 43},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 43},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 43},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 43},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 43},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 43},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 43},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 43},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 43},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 44},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 44},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 44},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 44},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 44},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 44},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 44},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 44},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 0, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 45},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 45},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 45},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 45},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 45},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 45},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 45},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 45},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 45},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 45},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 45},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 45},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 1, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 2, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 8, "v": 6, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 3, "layer": 46},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 8, "v": 5, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": true, "u": 7, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 46},
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 46},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 46},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 46},
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 46},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 46},
+                {"isSilicon": true, "u": 5, "v": 8, "layer": 46},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 46},
+                {"isSilicon": true, "u": 4, "v": 8, "layer": 46},
+                {"isSilicon": true, "u": 3, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 47},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 47},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 47},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 47},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 47},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 47},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 47},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 47},
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 47},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 47},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 48},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 48},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 48},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 48},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 48},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 48},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 48},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 48},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 48},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 48},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 0, "layer": 49},
+                {"isSilicon": true, "u": 4, "v": 0, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 0, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 0, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 2, "layer": 49},
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 49},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 0, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 0, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 0, "v": 5, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 49},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 3, "layer": 49},
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 49},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 4, "layer": 49},
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 49},
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 49},
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 49},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 49},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 1, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 1, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 1, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 2, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 2, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 2, "layer": 50},
+                {"isSilicon": true, "u": 7, "v": 2, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 3, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 7, "v": 6, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 6, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 1, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 1, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 1, "v": 6, "layer": 50},
+                {"isSilicon": true, "u": 1, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 2, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 2, "v": 6, "layer": 50},
+                {"isSilicon": true, "u": 2, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 4, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 6, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": true, "u": 3, "v": 5, "layer": 50},
+                {"isSilicon": true, "u": 3, "v": 6, "layer": 50},
+                {"isSilicon": true, "u": 3, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": true, "u": 4, "v": 6, "layer": 50},
+                {"isSilicon": true, "u": 5, "v": 7, "layer": 50},
+                {"isSilicon": true, "u": 4, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": true, "u": 5, "v": 3, "layer": 50},
+                {"isSilicon": true, "u": 6, "v": 3, "layer": 50},
+                {"isSilicon": true, "u": 7, "v": 3, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": true, "u": 6, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 7, "v": 4, "layer": 50},
+                {"isSilicon": true, "u": 7, "v": 5, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 37},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 37}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 38},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 38}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 39},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 39}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 40},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 40}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 41},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 41}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 42},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 42}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 3,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 43},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 43}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 44},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 44}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 13,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 19,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 11,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 45},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 45}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 23,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 16,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 12,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 46},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 46}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 8,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 47},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 47}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 4,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 6,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 48},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 48}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 9,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 15,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 10,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 0,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 49},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 49}
+            ]
+        },
+        {
+            "Stage1": 14,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 0, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 0, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 21,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 1, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 1, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 20,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 2, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 2, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 22,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 3, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 3, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 2,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 4, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 4, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 18,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 5, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 5, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 5,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 6, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 6, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 1,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 7, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 7, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 8, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 8, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 9, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 9, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 17,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 10, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 10, "layer": 50}
+            ]
+        },
+        {
+            "Stage1": 7,
+            "Modules": [
+                {"isSilicon": false, "u": 0, "v": 11, "layer": 50},
+                {"isSilicon": false, "u": 1, "v": 11, "layer": 50}
+            ]
+        }
+    ],
+    "Module": [
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 1, "lpgbts": [{"id": 0, "nElinks": 6}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 1, "lpgbts": [{"id": 0, "nElinks": 1}, {"id": 1, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 1, "lpgbts": [{"id": 1, "nElinks": 1}, {"id": 2, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 1, "lpgbts": [{"id": 3, "nElinks": 6}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 1, "lpgbts": [{"id": 3, "nElinks": 1}, {"id": 4, "nElinks": 6}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 1, "lpgbts": [{"id": 4, "nElinks": 1}, {"id": 5, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 1, "lpgbts": [{"id": 6, "nElinks": 7}, {"id": 7, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 1, "lpgbts": [{"id": 7, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 1, "lpgbts": [{"id": 8, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 1, "lpgbts": [{"id": 9, "nElinks": 7}, {"id": 10, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 1, "lpgbts": [{"id": 10, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 1, "lpgbts": [{"id": 11, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 1, "lpgbts": [{"id": 12, "nElinks": 7}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 1, "lpgbts": [{"id": 13, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 1, "lpgbts": [{"id": 13, "nElinks": 2}, {"id": 14, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 1, "lpgbts": [{"id": 15, "nElinks": 7}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 1, "lpgbts": [{"id": 16, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 1, "lpgbts": [{"id": 16, "nElinks": 2}, {"id": 17, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 1, "lpgbts": [{"id": 18, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 1, "lpgbts": [{"id": 18, "nElinks": 3}, {"id": 19, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 1, "lpgbts": [{"id": 19, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 1, "lpgbts": [{"id": 20, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 1, "lpgbts": [{"id": 20, "nElinks": 3}, {"id": 21, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 1, "lpgbts": [{"id": 21, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 1, "lpgbts": [{"id": 22, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 1, "lpgbts": [{"id": 22, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 1, "lpgbts": [{"id": 22, "nElinks": 1}, {"id": 23, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 1, "lpgbts": [{"id": 23, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 1, "lpgbts": [{"id": 24, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 1, "lpgbts": [{"id": 24, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 1, "lpgbts": [{"id": 24, "nElinks": 1}, {"id": 25, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 1, "lpgbts": [{"id": 25, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 1, "lpgbts": [{"id": 26, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 1, "lpgbts": [{"id": 26, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 1, "lpgbts": [{"id": 27, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 1, "lpgbts": [{"id": 27, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 1, "lpgbts": [{"id": 27, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 1, "lpgbts": [{"id": 28, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 1, "lpgbts": [{"id": 28, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 1, "lpgbts": [{"id": 29, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 1, "lpgbts": [{"id": 29, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 1, "lpgbts": [{"id": 29, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 1, "lpgbts": [{"id": 30, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 1, "lpgbts": [{"id": 30, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 1, "lpgbts": [{"id": 30, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 1, "lpgbts": [{"id": 31, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 1, "lpgbts": [{"id": 32, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 1, "lpgbts": [{"id": 32, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 1, "lpgbts": [{"id": 32, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 1, "lpgbts": [{"id": 33, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 1, "lpgbts": [{"id": 34, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 1, "lpgbts": [{"id": 34, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 1, "lpgbts": [{"id": 34, "nElinks": 1}, {"id": 35, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 1, "lpgbts": [{"id": 35, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 1, "lpgbts": [{"id": 36, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 1, "lpgbts": [{"id": 36, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 1, "lpgbts": [{"id": 36, "nElinks": 1}, {"id": 37, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 1, "lpgbts": [{"id": 37, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 1, "lpgbts": [{"id": 38, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 1, "lpgbts": [{"id": 38, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 1, "lpgbts": [{"id": 38, "nElinks": 1}, {"id": 39, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 1, "lpgbts": [{"id": 39, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 1, "lpgbts": [{"id": 40, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 1, "lpgbts": [{"id": 40, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 1, "lpgbts": [{"id": 40, "nElinks": 1}, {"id": 41, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 1, "lpgbts": [{"id": 41, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 1, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 1, "lpgbts": [{"id": 42, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 1, "lpgbts": [{"id": 42, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 1, "lpgbts": [{"id": 42, "nElinks": 1}, {"id": 43, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 1, "lpgbts": [{"id": 43, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 1, "lpgbts": [{"id": 43, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 1, "lpgbts": [{"id": 44, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 1, "lpgbts": [{"id": 44, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 1, "lpgbts": [{"id": 44, "nElinks": 1}, {"id": 45, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 1, "lpgbts": [{"id": 45, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 1, "lpgbts": [{"id": 45, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 1, "lpgbts": [{"id": 46, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 1, "lpgbts": [{"id": 46, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 1, "lpgbts": [{"id": 46, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 1, "lpgbts": [{"id": 47, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 1, "lpgbts": [{"id": 48, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 1, "lpgbts": [{"id": 48, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 1, "lpgbts": [{"id": 48, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 1, "lpgbts": [{"id": 49, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 1, "lpgbts": [{"id": 50, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 1, "lpgbts": [{"id": 50, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 1, "lpgbts": [{"id": 50, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 1, "lpgbts": [{"id": 50, "nElinks": 1}, {"id": 51, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 1, "lpgbts": [{"id": 51, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 1, "lpgbts": [{"id": 51, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 1, "lpgbts": [{"id": 52, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 1, "lpgbts": [{"id": 52, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 1, "lpgbts": [{"id": 52, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 1, "lpgbts": [{"id": 52, "nElinks": 1}, {"id": 53, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 1, "lpgbts": [{"id": 53, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 1, "lpgbts": [{"id": 53, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 2, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 3, "lpgbts": [{"id": 54, "nElinks": 7}, {"id": 55, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 3, "lpgbts": [{"id": 55, "nElinks": 4}, {"id": 56, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 3, "lpgbts": [{"id": 56, "nElinks": 2}, {"id": 57, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 3, "lpgbts": [{"id": 58, "nElinks": 7}, {"id": 59, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 3, "lpgbts": [{"id": 59, "nElinks": 4}, {"id": 60, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 3, "lpgbts": [{"id": 60, "nElinks": 2}, {"id": 61, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 3, "lpgbts": [{"id": 62, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 3, "lpgbts": [{"id": 63, "nElinks": 7}, {"id": 64, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 3, "lpgbts": [{"id": 64, "nElinks": 4}, {"id": 65, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 3, "lpgbts": [{"id": 66, "nElinks": 7}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 3, "lpgbts": [{"id": 67, "nElinks": 7}, {"id": 68, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 3, "lpgbts": [{"id": 68, "nElinks": 4}, {"id": 69, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 3, "lpgbts": [{"id": 70, "nElinks": 7}, {"id": 71, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 3, "lpgbts": [{"id": 71, "nElinks": 4}, {"id": 72, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 3, "lpgbts": [{"id": 72, "nElinks": 4}, {"id": 73, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 3, "lpgbts": [{"id": 74, "nElinks": 7}, {"id": 75, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 3, "lpgbts": [{"id": 75, "nElinks": 4}, {"id": 76, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 3, "lpgbts": [{"id": 76, "nElinks": 4}, {"id": 77, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 3, "lpgbts": [{"id": 78, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 3, "lpgbts": [{"id": 78, "nElinks": 1}, {"id": 79, "nElinks": 7}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 3, "lpgbts": [{"id": 80, "nElinks": 6}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 3, "lpgbts": [{"id": 81, "nElinks": 6}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 3, "lpgbts": [{"id": 81, "nElinks": 1}, {"id": 82, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 3, "lpgbts": [{"id": 83, "nElinks": 6}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 3, "lpgbts": [{"id": 84, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 3, "lpgbts": [{"id": 84, "nElinks": 2}, {"id": 85, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 3, "lpgbts": [{"id": 85, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 3, "lpgbts": [{"id": 85, "nElinks": 2}, {"id": 86, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 3, "lpgbts": [{"id": 86, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 3, "lpgbts": [{"id": 87, "nElinks": 5}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 3, "lpgbts": [{"id": 87, "nElinks": 2}, {"id": 88, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 3, "lpgbts": [{"id": 88, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 3, "lpgbts": [{"id": 88, "nElinks": 2}, {"id": 89, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 3, "lpgbts": [{"id": 89, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 3, "lpgbts": [{"id": 90, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 3, "lpgbts": [{"id": 90, "nElinks": 2}, {"id": 91, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 3, "lpgbts": [{"id": 91, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 3, "lpgbts": [{"id": 91, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 3, "lpgbts": [{"id": 92, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 3, "lpgbts": [{"id": 92, "nElinks": 2}, {"id": 93, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 3, "lpgbts": [{"id": 93, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 3, "lpgbts": [{"id": 93, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 3, "lpgbts": [{"id": 94, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 3, "lpgbts": [{"id": 94, "nElinks": 2}, {"id": 95, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 3, "lpgbts": [{"id": 95, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 3, "lpgbts": [{"id": 95, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 3, "lpgbts": [{"id": 96, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 3, "lpgbts": [{"id": 96, "nElinks": 2}, {"id": 97, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 3, "lpgbts": [{"id": 97, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 3, "lpgbts": [{"id": 97, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 3, "lpgbts": [{"id": 98, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 3, "lpgbts": [{"id": 98, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 3, "lpgbts": [{"id": 99, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 3, "lpgbts": [{"id": 99, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 3, "lpgbts": [{"id": 100, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 3, "lpgbts": [{"id": 100, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 3, "lpgbts": [{"id": 101, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 3, "lpgbts": [{"id": 101, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 3, "lpgbts": [{"id": 102, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 3, "lpgbts": [{"id": 102, "nElinks": 2}, {"id": 103, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 3, "lpgbts": [{"id": 103, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 3, "lpgbts": [{"id": 103, "nElinks": 2}, {"id": 104, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 3, "lpgbts": [{"id": 104, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 3, "lpgbts": [{"id": 105, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 3, "lpgbts": [{"id": 105, "nElinks": 2}, {"id": 106, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 3, "lpgbts": [{"id": 106, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 3, "lpgbts": [{"id": 106, "nElinks": 2}, {"id": 107, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 3, "lpgbts": [{"id": 107, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 3, "lpgbts": [{"id": 108, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 3, "lpgbts": [{"id": 108, "nElinks": 2}, {"id": 109, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 3, "lpgbts": [{"id": 109, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 3, "lpgbts": [{"id": 109, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 3, "lpgbts": [{"id": 110, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 3, "lpgbts": [{"id": 110, "nElinks": 2}, {"id": 111, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 3, "lpgbts": [{"id": 111, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 3, "lpgbts": [{"id": 111, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 3, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 3, "lpgbts": [{"id": 112, "nElinks": 4}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 3, "lpgbts": [{"id": 112, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 3, "lpgbts": [{"id": 113, "nElinks": 3}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 3, "lpgbts": [{"id": 113, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 3, "lpgbts": [{"id": 114, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 3, "lpgbts": [{"id": 114, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 3, "lpgbts": [{"id": 115, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 3, "lpgbts": [{"id": 115, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 3, "lpgbts": [{"id": 116, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 3, "lpgbts": [{"id": 116, "nElinks": 3}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 3, "lpgbts": [{"id": 116, "nElinks": 1}, {"id": 117, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 3, "lpgbts": [{"id": 117, "nElinks": 3}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 3, "lpgbts": [{"id": 117, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 3, "lpgbts": [{"id": 117, "nElinks": 1}, {"id": 118, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 3, "lpgbts": [{"id": 119, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 3, "lpgbts": [{"id": 119, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 3, "lpgbts": [{"id": 119, "nElinks": 1}, {"id": 120, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 3, "lpgbts": [{"id": 120, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 3, "lpgbts": [{"id": 120, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 3, "lpgbts": [{"id": 120, "nElinks": 1}, {"id": 121, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 4, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 5, "lpgbts": [{"id": 122, "nElinks": 7}, {"id": 123, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 5, "lpgbts": [{"id": 123, "nElinks": 4}, {"id": 124, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 5, "lpgbts": [{"id": 124, "nElinks": 2}, {"id": 125, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 5, "lpgbts": [{"id": 126, "nElinks": 7}, {"id": 127, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 5, "lpgbts": [{"id": 127, "nElinks": 4}, {"id": 128, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 5, "lpgbts": [{"id": 128, "nElinks": 2}, {"id": 129, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 5, "lpgbts": [{"id": 130, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 5, "lpgbts": [{"id": 131, "nElinks": 7}, {"id": 132, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 5, "lpgbts": [{"id": 132, "nElinks": 3}, {"id": 133, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 5, "lpgbts": [{"id": 134, "nElinks": 7}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 5, "lpgbts": [{"id": 135, "nElinks": 7}, {"id": 136, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 5, "lpgbts": [{"id": 136, "nElinks": 3}, {"id": 137, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 5, "lpgbts": [{"id": 138, "nElinks": 7}, {"id": 139, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 5, "lpgbts": [{"id": 139, "nElinks": 3}, {"id": 140, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 5, "lpgbts": [{"id": 140, "nElinks": 3}, {"id": 141, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 5, "lpgbts": [{"id": 142, "nElinks": 7}, {"id": 143, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 5, "lpgbts": [{"id": 143, "nElinks": 3}, {"id": 144, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 5, "lpgbts": [{"id": 144, "nElinks": 3}, {"id": 145, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 5, "lpgbts": [{"id": 146, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 5, "lpgbts": [{"id": 146, "nElinks": 1}, {"id": 147, "nElinks": 7}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 5, "lpgbts": [{"id": 148, "nElinks": 6}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 5, "lpgbts": [{"id": 149, "nElinks": 6}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 5, "lpgbts": [{"id": 149, "nElinks": 1}, {"id": 150, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 5, "lpgbts": [{"id": 151, "nElinks": 6}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 5, "lpgbts": [{"id": 152, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 5, "lpgbts": [{"id": 152, "nElinks": 2}, {"id": 153, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 5, "lpgbts": [{"id": 153, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 5, "lpgbts": [{"id": 153, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 5, "lpgbts": [{"id": 154, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 5, "lpgbts": [{"id": 154, "nElinks": 2}, {"id": 155, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 5, "lpgbts": [{"id": 155, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 5, "lpgbts": [{"id": 155, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 5, "lpgbts": [{"id": 156, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 5, "lpgbts": [{"id": 156, "nElinks": 2}, {"id": 157, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 5, "lpgbts": [{"id": 157, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 5, "lpgbts": [{"id": 157, "nElinks": 2}, {"id": 158, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 5, "lpgbts": [{"id": 158, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 5, "lpgbts": [{"id": 159, "nElinks": 5}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 5, "lpgbts": [{"id": 159, "nElinks": 2}, {"id": 160, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 5, "lpgbts": [{"id": 160, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 5, "lpgbts": [{"id": 160, "nElinks": 2}, {"id": 161, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 5, "lpgbts": [{"id": 161, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 5, "lpgbts": [{"id": 162, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 5, "lpgbts": [{"id": 162, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 5, "lpgbts": [{"id": 163, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 5, "lpgbts": [{"id": 163, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 5, "lpgbts": [{"id": 164, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 5, "lpgbts": [{"id": 164, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 5, "lpgbts": [{"id": 165, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 5, "lpgbts": [{"id": 165, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 5, "lpgbts": [{"id": 166, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 5, "lpgbts": [{"id": 166, "nElinks": 2}, {"id": 167, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 5, "lpgbts": [{"id": 167, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 5, "lpgbts": [{"id": 167, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 5, "lpgbts": [{"id": 168, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 5, "lpgbts": [{"id": 168, "nElinks": 2}, {"id": 169, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 5, "lpgbts": [{"id": 169, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 5, "lpgbts": [{"id": 169, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 5, "lpgbts": [{"id": 170, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 5, "lpgbts": [{"id": 170, "nElinks": 2}, {"id": 171, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 5, "lpgbts": [{"id": 171, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 5, "lpgbts": [{"id": 171, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 5, "lpgbts": [{"id": 172, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 5, "lpgbts": [{"id": 172, "nElinks": 2}, {"id": 173, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 5, "lpgbts": [{"id": 173, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 5, "lpgbts": [{"id": 173, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 5, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 5, "lpgbts": [{"id": 174, "nElinks": 5}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 5, "lpgbts": [{"id": 174, "nElinks": 2}, {"id": 175, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 5, "lpgbts": [{"id": 175, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 5, "lpgbts": [{"id": 175, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 5, "lpgbts": [{"id": 176, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 5, "lpgbts": [{"id": 177, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 5, "lpgbts": [{"id": 177, "nElinks": 2}, {"id": 178, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 5, "lpgbts": [{"id": 178, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 5, "lpgbts": [{"id": 178, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 5, "lpgbts": [{"id": 179, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 5, "lpgbts": [{"id": 180, "nElinks": 4}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 5, "lpgbts": [{"id": 180, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 5, "lpgbts": [{"id": 181, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 5, "lpgbts": [{"id": 181, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 5, "lpgbts": [{"id": 182, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 5, "lpgbts": [{"id": 182, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 5, "lpgbts": [{"id": 183, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 5, "lpgbts": [{"id": 183, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 5, "lpgbts": [{"id": 184, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 5, "lpgbts": [{"id": 184, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 5, "lpgbts": [{"id": 184, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 5, "lpgbts": [{"id": 185, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 5, "lpgbts": [{"id": 185, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 5, "lpgbts": [{"id": 185, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 5, "lpgbts": [{"id": 186, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 5, "lpgbts": [{"id": 186, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 5, "lpgbts": [{"id": 186, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 5, "lpgbts": [{"id": 187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 5, "lpgbts": [{"id": 187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 5, "lpgbts": [{"id": 187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 6, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 7, "lpgbts": [{"id": 188, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 7, "lpgbts": [{"id": 189, "nElinks": 7}, {"id": 190, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 7, "lpgbts": [{"id": 190, "nElinks": 4}, {"id": 191, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 7, "lpgbts": [{"id": 192, "nElinks": 7}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 7, "lpgbts": [{"id": 193, "nElinks": 7}, {"id": 194, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 7, "lpgbts": [{"id": 194, "nElinks": 4}, {"id": 195, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 7, "lpgbts": [{"id": 196, "nElinks": 7}, {"id": 197, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 7, "lpgbts": [{"id": 197, "nElinks": 4}, {"id": 198, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 7, "lpgbts": [{"id": 198, "nElinks": 3}, {"id": 199, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 7, "lpgbts": [{"id": 200, "nElinks": 7}, {"id": 201, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 7, "lpgbts": [{"id": 201, "nElinks": 4}, {"id": 202, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 7, "lpgbts": [{"id": 202, "nElinks": 3}, {"id": 203, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 7, "lpgbts": [{"id": 204, "nElinks": 7}, {"id": 205, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 7, "lpgbts": [{"id": 205, "nElinks": 4}, {"id": 206, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 7, "lpgbts": [{"id": 206, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 7, "lpgbts": [{"id": 207, "nElinks": 7}, {"id": 208, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 7, "lpgbts": [{"id": 208, "nElinks": 4}, {"id": 209, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 7, "lpgbts": [{"id": 209, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 7, "lpgbts": [{"id": 210, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 7, "lpgbts": [{"id": 210, "nElinks": 2}, {"id": 211, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 7, "lpgbts": [{"id": 211, "nElinks": 2}, {"id": 212, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 7, "lpgbts": [{"id": 213, "nElinks": 5}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 7, "lpgbts": [{"id": 213, "nElinks": 2}, {"id": 214, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 7, "lpgbts": [{"id": 214, "nElinks": 2}, {"id": 215, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 7, "lpgbts": [{"id": 216, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 7, "lpgbts": [{"id": 216, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 7, "lpgbts": [{"id": 217, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 7, "lpgbts": [{"id": 217, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 7, "lpgbts": [{"id": 218, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 7, "lpgbts": [{"id": 218, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 7, "lpgbts": [{"id": 219, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 7, "lpgbts": [{"id": 219, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 7, "lpgbts": [{"id": 220, "nElinks": 5}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 7, "lpgbts": [{"id": 220, "nElinks": 2}, {"id": 221, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 7, "lpgbts": [{"id": 221, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 7, "lpgbts": [{"id": 221, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 7, "lpgbts": [{"id": 222, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 7, "lpgbts": [{"id": 223, "nElinks": 5}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 7, "lpgbts": [{"id": 223, "nElinks": 2}, {"id": 224, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 7, "lpgbts": [{"id": 224, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 7, "lpgbts": [{"id": 224, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 7, "lpgbts": [{"id": 225, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 7, "lpgbts": [{"id": 226, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 7, "lpgbts": [{"id": 226, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 7, "lpgbts": [{"id": 227, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 7, "lpgbts": [{"id": 227, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 7, "lpgbts": [{"id": 228, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 7, "lpgbts": [{"id": 228, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 7, "lpgbts": [{"id": 229, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 7, "lpgbts": [{"id": 229, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 7, "lpgbts": [{"id": 230, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 7, "lpgbts": [{"id": 230, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 7, "lpgbts": [{"id": 231, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 7, "lpgbts": [{"id": 231, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 7, "lpgbts": [{"id": 232, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 7, "lpgbts": [{"id": 232, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 7, "lpgbts": [{"id": 233, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 7, "lpgbts": [{"id": 233, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 7, "lpgbts": [{"id": 234, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 7, "lpgbts": [{"id": 234, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 7, "lpgbts": [{"id": 235, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 7, "lpgbts": [{"id": 235, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 7, "lpgbts": [{"id": 236, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 7, "lpgbts": [{"id": 236, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 7, "lpgbts": [{"id": 237, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 7, "lpgbts": [{"id": 237, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 7, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 7, "lpgbts": [{"id": 238, "nElinks": 4}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 7, "lpgbts": [{"id": 238, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 7, "lpgbts": [{"id": 239, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 7, "lpgbts": [{"id": 239, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 7, "lpgbts": [{"id": 239, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 7, "lpgbts": [{"id": 240, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 7, "lpgbts": [{"id": 240, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 7, "lpgbts": [{"id": 241, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 7, "lpgbts": [{"id": 241, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 7, "lpgbts": [{"id": 241, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 7, "lpgbts": [{"id": 242, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 7, "lpgbts": [{"id": 242, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 7, "lpgbts": [{"id": 242, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 7, "lpgbts": [{"id": 243, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 7, "lpgbts": [{"id": 244, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 7, "lpgbts": [{"id": 244, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 7, "lpgbts": [{"id": 244, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 7, "lpgbts": [{"id": 245, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 7, "lpgbts": [{"id": 246, "nElinks": 3}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 7, "lpgbts": [{"id": 246, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 7, "lpgbts": [{"id": 246, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 7, "lpgbts": [{"id": 247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 7, "lpgbts": [{"id": 247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 7, "lpgbts": [{"id": 247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 7, "lpgbts": [{"id": 248, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 7, "lpgbts": [{"id": 248, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 7, "lpgbts": [{"id": 248, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 7, "lpgbts": [{"id": 249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 7, "lpgbts": [{"id": 249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 7, "lpgbts": [{"id": 249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 8, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 9, "lpgbts": [{"id": 250, "nElinks": 7}, {"id": 251, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 9, "lpgbts": [{"id": 251, "nElinks": 4}, {"id": 252, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 9, "lpgbts": [{"id": 252, "nElinks": 4}, {"id": 253, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 9, "lpgbts": [{"id": 254, "nElinks": 7}, {"id": 255, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 9, "lpgbts": [{"id": 255, "nElinks": 4}, {"id": 256, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 9, "lpgbts": [{"id": 256, "nElinks": 4}, {"id": 257, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 9, "lpgbts": [{"id": 258, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 9, "lpgbts": [{"id": 259, "nElinks": 7}, {"id": 260, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 9, "lpgbts": [{"id": 260, "nElinks": 5}, {"id": 261, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 9, "lpgbts": [{"id": 262, "nElinks": 7}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 9, "lpgbts": [{"id": 263, "nElinks": 7}, {"id": 264, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 9, "lpgbts": [{"id": 264, "nElinks": 5}, {"id": 265, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 9, "lpgbts": [{"id": 266, "nElinks": 7}, {"id": 267, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 9, "lpgbts": [{"id": 267, "nElinks": 5}, {"id": 268, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 9, "lpgbts": [{"id": 268, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 9, "lpgbts": [{"id": 269, "nElinks": 7}, {"id": 270, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 9, "lpgbts": [{"id": 270, "nElinks": 5}, {"id": 271, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 9, "lpgbts": [{"id": 271, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 9, "lpgbts": [{"id": 272, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 9, "lpgbts": [{"id": 272, "nElinks": 3}, {"id": 273, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 9, "lpgbts": [{"id": 273, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 9, "lpgbts": [{"id": 274, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 9, "lpgbts": [{"id": 274, "nElinks": 3}, {"id": 275, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 9, "lpgbts": [{"id": 275, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 9, "lpgbts": [{"id": 276, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 9, "lpgbts": [{"id": 276, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 9, "lpgbts": [{"id": 276, "nElinks": 1}, {"id": 277, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 9, "lpgbts": [{"id": 277, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 9, "lpgbts": [{"id": 277, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 9, "lpgbts": [{"id": 278, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 9, "lpgbts": [{"id": 278, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 9, "lpgbts": [{"id": 278, "nElinks": 1}, {"id": 279, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 9, "lpgbts": [{"id": 279, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 9, "lpgbts": [{"id": 279, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 9, "lpgbts": [{"id": 280, "nElinks": 4}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 9, "lpgbts": [{"id": 280, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 9, "lpgbts": [{"id": 281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 9, "lpgbts": [{"id": 281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 9, "lpgbts": [{"id": 281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 9, "lpgbts": [{"id": 282, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 9, "lpgbts": [{"id": 282, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 9, "lpgbts": [{"id": 283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 9, "lpgbts": [{"id": 283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 9, "lpgbts": [{"id": 283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 9, "lpgbts": [{"id": 284, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 9, "lpgbts": [{"id": 284, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 9, "lpgbts": [{"id": 284, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 9, "lpgbts": [{"id": 285, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 9, "lpgbts": [{"id": 286, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 9, "lpgbts": [{"id": 286, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 9, "lpgbts": [{"id": 286, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 9, "lpgbts": [{"id": 287, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 9, "lpgbts": [{"id": 288, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 9, "lpgbts": [{"id": 288, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 9, "lpgbts": [{"id": 288, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 9, "lpgbts": [{"id": 289, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 9, "lpgbts": [{"id": 289, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 9, "lpgbts": [{"id": 290, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 9, "lpgbts": [{"id": 290, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 9, "lpgbts": [{"id": 290, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 9, "lpgbts": [{"id": 291, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 9, "lpgbts": [{"id": 291, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 9, "lpgbts": [{"id": 292, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 9, "lpgbts": [{"id": 292, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 9, "lpgbts": [{"id": 292, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 9, "lpgbts": [{"id": 293, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 9, "lpgbts": [{"id": 293, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 9, "lpgbts": [{"id": 294, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 9, "lpgbts": [{"id": 294, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 9, "lpgbts": [{"id": 294, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 9, "lpgbts": [{"id": 295, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 9, "lpgbts": [{"id": 295, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 9, "lpgbts": [{"id": 296, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 9, "lpgbts": [{"id": 296, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 9, "lpgbts": [{"id": 296, "nElinks": 1}, {"id": 297, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 9, "lpgbts": [{"id": 297, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 9, "lpgbts": [{"id": 297, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 9, "lpgbts": [{"id": 298, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 9, "lpgbts": [{"id": 298, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 9, "lpgbts": [{"id": 298, "nElinks": 1}, {"id": 299, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 9, "lpgbts": [{"id": 299, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 9, "lpgbts": [{"id": 299, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 9, "lpgbts": [{"id": 300, "nElinks": 3}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 9, "lpgbts": [{"id": 300, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 9, "lpgbts": [{"id": 300, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 9, "lpgbts": [{"id": 301, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 9, "lpgbts": [{"id": 302, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 9, "lpgbts": [{"id": 302, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 9, "lpgbts": [{"id": 302, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 9, "lpgbts": [{"id": 303, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 9, "lpgbts": [{"id": 304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 9, "lpgbts": [{"id": 304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 9, "lpgbts": [{"id": 304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 9, "lpgbts": [{"id": 304, "nElinks": 1}, {"id": 305, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 9, "lpgbts": [{"id": 305, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 9, "lpgbts": [{"id": 305, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 9, "lpgbts": [{"id": 306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 9, "lpgbts": [{"id": 306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 9, "lpgbts": [{"id": 306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 9, "lpgbts": [{"id": 306, "nElinks": 1}, {"id": 307, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 9, "lpgbts": [{"id": 307, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 9, "lpgbts": [{"id": 307, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 10, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 11, "lpgbts": [{"id": 308, "nElinks": 7}, {"id": 309, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 11, "lpgbts": [{"id": 309, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 11, "lpgbts": [{"id": 310, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 11, "lpgbts": [{"id": 311, "nElinks": 7}, {"id": 312, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 11, "lpgbts": [{"id": 312, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 11, "lpgbts": [{"id": 313, "nElinks": 4}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 11, "lpgbts": [{"id": 314, "nElinks": 6}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 11, "lpgbts": [{"id": 314, "nElinks": 1}, {"id": 315, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 11, "lpgbts": [{"id": 315, "nElinks": 1}, {"id": 316, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 11, "lpgbts": [{"id": 316, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 11, "lpgbts": [{"id": 317, "nElinks": 6}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 11, "lpgbts": [{"id": 317, "nElinks": 1}, {"id": 318, "nElinks": 6}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 11, "lpgbts": [{"id": 318, "nElinks": 1}, {"id": 319, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 11, "lpgbts": [{"id": 319, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 11, "lpgbts": [{"id": 320, "nElinks": 7}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 11, "lpgbts": [{"id": 321, "nElinks": 5}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 11, "lpgbts": [{"id": 321, "nElinks": 2}, {"id": 322, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 11, "lpgbts": [{"id": 323, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 11, "lpgbts": [{"id": 324, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 11, "lpgbts": [{"id": 324, "nElinks": 2}, {"id": 325, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 11, "lpgbts": [{"id": 326, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 11, "lpgbts": [{"id": 326, "nElinks": 4}, {"id": 327, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 11, "lpgbts": [{"id": 327, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 11, "lpgbts": [{"id": 328, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 11, "lpgbts": [{"id": 328, "nElinks": 4}, {"id": 329, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 11, "lpgbts": [{"id": 329, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 11, "lpgbts": [{"id": 330, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 11, "lpgbts": [{"id": 330, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 11, "lpgbts": [{"id": 330, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 11, "lpgbts": [{"id": 331, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 11, "lpgbts": [{"id": 331, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 11, "lpgbts": [{"id": 332, "nElinks": 3}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 11, "lpgbts": [{"id": 332, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 11, "lpgbts": [{"id": 332, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 11, "lpgbts": [{"id": 333, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 11, "lpgbts": [{"id": 333, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 11, "lpgbts": [{"id": 334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 11, "lpgbts": [{"id": 334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 11, "lpgbts": [{"id": 334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 11, "lpgbts": [{"id": 334, "nElinks": 1}, {"id": 335, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 11, "lpgbts": [{"id": 336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 11, "lpgbts": [{"id": 336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 11, "lpgbts": [{"id": 336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 11, "lpgbts": [{"id": 336, "nElinks": 1}, {"id": 337, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 11, "lpgbts": [{"id": 338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 11, "lpgbts": [{"id": 338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 11, "lpgbts": [{"id": 338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 11, "lpgbts": [{"id": 338, "nElinks": 1}, {"id": 339, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 11, "lpgbts": [{"id": 340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 11, "lpgbts": [{"id": 340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 11, "lpgbts": [{"id": 340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 11, "lpgbts": [{"id": 340, "nElinks": 1}, {"id": 341, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 11, "lpgbts": [{"id": 342, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 11, "lpgbts": [{"id": 342, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 11, "lpgbts": [{"id": 342, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 11, "lpgbts": [{"id": 343, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 11, "lpgbts": [{"id": 343, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 11, "lpgbts": [{"id": 344, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 11, "lpgbts": [{"id": 344, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 11, "lpgbts": [{"id": 344, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 11, "lpgbts": [{"id": 345, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 11, "lpgbts": [{"id": 345, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 11, "lpgbts": [{"id": 346, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 11, "lpgbts": [{"id": 346, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 11, "lpgbts": [{"id": 346, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 11, "lpgbts": [{"id": 347, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 11, "lpgbts": [{"id": 347, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 11, "lpgbts": [{"id": 348, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 11, "lpgbts": [{"id": 348, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 11, "lpgbts": [{"id": 348, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 11, "lpgbts": [{"id": 349, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 11, "lpgbts": [{"id": 349, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 11, "lpgbts": [{"id": 350, "nElinks": 3}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 11, "lpgbts": [{"id": 350, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 11, "lpgbts": [{"id": 350, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 11, "lpgbts": [{"id": 351, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 11, "lpgbts": [{"id": 351, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 11, "lpgbts": [{"id": 352, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 11, "lpgbts": [{"id": 352, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 11, "lpgbts": [{"id": 352, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 11, "lpgbts": [{"id": 353, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 11, "lpgbts": [{"id": 353, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 11, "lpgbts": [{"id": 354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 11, "lpgbts": [{"id": 354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 11, "lpgbts": [{"id": 354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 11, "lpgbts": [{"id": 354, "nElinks": 1}, {"id": 355, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 11, "lpgbts": [{"id": 356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 11, "lpgbts": [{"id": 356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 11, "lpgbts": [{"id": 356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 11, "lpgbts": [{"id": 356, "nElinks": 1}, {"id": 357, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 11, "lpgbts": [{"id": 358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 11, "lpgbts": [{"id": 358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 11, "lpgbts": [{"id": 358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 11, "lpgbts": [{"id": 358, "nElinks": 1}, {"id": 359, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 11, "lpgbts": [{"id": 359, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 11, "lpgbts": [{"id": 359, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 11, "lpgbts": [{"id": 360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 11, "lpgbts": [{"id": 360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 11, "lpgbts": [{"id": 360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 11, "lpgbts": [{"id": 360, "nElinks": 1}, {"id": 361, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 11, "lpgbts": [{"id": 361, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 11, "lpgbts": [{"id": 361, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 12, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 13, "lpgbts": [{"id": 362, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 13, "lpgbts": [{"id": 363, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 13, "lpgbts": [{"id": 363, "nElinks": 2}, {"id": 364, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 13, "lpgbts": [{"id": 365, "nElinks": 7}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 13, "lpgbts": [{"id": 366, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 13, "lpgbts": [{"id": 366, "nElinks": 2}, {"id": 367, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 13, "lpgbts": [{"id": 368, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 13, "lpgbts": [{"id": 368, "nElinks": 2}, {"id": 369, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 13, "lpgbts": [{"id": 369, "nElinks": 3}, {"id": 370, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 13, "lpgbts": [{"id": 370, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 13, "lpgbts": [{"id": 371, "nElinks": 5}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 13, "lpgbts": [{"id": 371, "nElinks": 2}, {"id": 372, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 13, "lpgbts": [{"id": 372, "nElinks": 3}, {"id": 373, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 13, "lpgbts": [{"id": 373, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 13, "lpgbts": [{"id": 374, "nElinks": 6}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 13, "lpgbts": [{"id": 374, "nElinks": 1}, {"id": 375, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 13, "lpgbts": [{"id": 375, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 13, "lpgbts": [{"id": 376, "nElinks": 6}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 13, "lpgbts": [{"id": 376, "nElinks": 1}, {"id": 377, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 13, "lpgbts": [{"id": 377, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 13, "lpgbts": [{"id": 378, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 13, "lpgbts": [{"id": 378, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 13, "lpgbts": [{"id": 379, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 13, "lpgbts": [{"id": 380, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 13, "lpgbts": [{"id": 380, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 13, "lpgbts": [{"id": 381, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 13, "lpgbts": [{"id": 382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 13, "lpgbts": [{"id": 382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 13, "lpgbts": [{"id": 382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 13, "lpgbts": [{"id": 382, "nElinks": 1}, {"id": 383, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 13, "lpgbts": [{"id": 383, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 13, "lpgbts": [{"id": 384, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 13, "lpgbts": [{"id": 384, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 13, "lpgbts": [{"id": 384, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 13, "lpgbts": [{"id": 384, "nElinks": 1}, {"id": 385, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 13, "lpgbts": [{"id": 385, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 13, "lpgbts": [{"id": 386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 13, "lpgbts": [{"id": 386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 13, "lpgbts": [{"id": 386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 13, "lpgbts": [{"id": 386, "nElinks": 1}, {"id": 387, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 13, "lpgbts": [{"id": 388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 13, "lpgbts": [{"id": 388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 13, "lpgbts": [{"id": 388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 13, "lpgbts": [{"id": 388, "nElinks": 1}, {"id": 389, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 13, "lpgbts": [{"id": 390, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 13, "lpgbts": [{"id": 390, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 13, "lpgbts": [{"id": 390, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 13, "lpgbts": [{"id": 390, "nElinks": 1}, {"id": 391, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 13, "lpgbts": [{"id": 392, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 13, "lpgbts": [{"id": 392, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 13, "lpgbts": [{"id": 392, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 13, "lpgbts": [{"id": 392, "nElinks": 1}, {"id": 393, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 13, "lpgbts": [{"id": 394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 13, "lpgbts": [{"id": 394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 13, "lpgbts": [{"id": 394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 13, "lpgbts": [{"id": 394, "nElinks": 1}, {"id": 395, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 13, "lpgbts": [{"id": 395, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 13, "lpgbts": [{"id": 396, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 13, "lpgbts": [{"id": 396, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 13, "lpgbts": [{"id": 396, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 13, "lpgbts": [{"id": 396, "nElinks": 1}, {"id": 397, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 13, "lpgbts": [{"id": 397, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 13, "lpgbts": [{"id": 398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 13, "lpgbts": [{"id": 398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 13, "lpgbts": [{"id": 398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 13, "lpgbts": [{"id": 398, "nElinks": 1}, {"id": 399, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 13, "lpgbts": [{"id": 399, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 13, "lpgbts": [{"id": 400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 13, "lpgbts": [{"id": 400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 13, "lpgbts": [{"id": 400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 13, "lpgbts": [{"id": 400, "nElinks": 1}, {"id": 401, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 13, "lpgbts": [{"id": 401, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 13, "lpgbts": [{"id": 402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 13, "lpgbts": [{"id": 402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 13, "lpgbts": [{"id": 402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 13, "lpgbts": [{"id": 402, "nElinks": 1}, {"id": 403, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 13, "lpgbts": [{"id": 403, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 13, "lpgbts": [{"id": 404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 13, "lpgbts": [{"id": 404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 13, "lpgbts": [{"id": 404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 13, "lpgbts": [{"id": 404, "nElinks": 1}, {"id": 405, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 13, "lpgbts": [{"id": 405, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 13, "lpgbts": [{"id": 406, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 13, "lpgbts": [{"id": 406, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 13, "lpgbts": [{"id": 406, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 13, "lpgbts": [{"id": 406, "nElinks": 1}, {"id": 407, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 13, "lpgbts": [{"id": 408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 13, "lpgbts": [{"id": 408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 13, "lpgbts": [{"id": 408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 13, "lpgbts": [{"id": 408, "nElinks": 1}, {"id": 409, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 13, "lpgbts": [{"id": 410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 13, "lpgbts": [{"id": 410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 13, "lpgbts": [{"id": 410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 13, "lpgbts": [{"id": 410, "nElinks": 1}, {"id": 411, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 13, "lpgbts": [{"id": 411, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 13, "lpgbts": [{"id": 411, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 13, "lpgbts": [{"id": 412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 13, "lpgbts": [{"id": 412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 13, "lpgbts": [{"id": 412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 13, "lpgbts": [{"id": 412, "nElinks": 1}, {"id": 413, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 13, "lpgbts": [{"id": 413, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 13, "lpgbts": [{"id": 413, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 14, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 15, "lpgbts": [{"id": 414, "nElinks": 6}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 15, "lpgbts": [{"id": 414, "nElinks": 1}, {"id": 415, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 15, "lpgbts": [{"id": 415, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 15, "lpgbts": [{"id": 416, "nElinks": 6}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 15, "lpgbts": [{"id": 416, "nElinks": 1}, {"id": 417, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 15, "lpgbts": [{"id": 417, "nElinks": 3}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 15, "lpgbts": [{"id": 418, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 15, "lpgbts": [{"id": 418, "nElinks": 3}, {"id": 419, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 15, "lpgbts": [{"id": 419, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 15, "lpgbts": [{"id": 419, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 15, "lpgbts": [{"id": 420, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 15, "lpgbts": [{"id": 420, "nElinks": 3}, {"id": 421, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 15, "lpgbts": [{"id": 421, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 15, "lpgbts": [{"id": 421, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 15, "lpgbts": [{"id": 422, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 15, "lpgbts": [{"id": 422, "nElinks": 2}, {"id": 423, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 15, "lpgbts": [{"id": 423, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 15, "lpgbts": [{"id": 424, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 15, "lpgbts": [{"id": 424, "nElinks": 2}, {"id": 425, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 15, "lpgbts": [{"id": 425, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 15, "lpgbts": [{"id": 426, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 15, "lpgbts": [{"id": 426, "nElinks": 4}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 15, "lpgbts": [{"id": 426, "nElinks": 1}, {"id": 427, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 15, "lpgbts": [{"id": 428, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 15, "lpgbts": [{"id": 428, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 15, "lpgbts": [{"id": 428, "nElinks": 1}, {"id": 429, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 15, "lpgbts": [{"id": 430, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 15, "lpgbts": [{"id": 430, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 15, "lpgbts": [{"id": 430, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 15, "lpgbts": [{"id": 430, "nElinks": 1}, {"id": 431, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 15, "lpgbts": [{"id": 431, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 15, "lpgbts": [{"id": 432, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 15, "lpgbts": [{"id": 432, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 15, "lpgbts": [{"id": 432, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 15, "lpgbts": [{"id": 432, "nElinks": 1}, {"id": 433, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 15, "lpgbts": [{"id": 433, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 15, "lpgbts": [{"id": 434, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 15, "lpgbts": [{"id": 434, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 15, "lpgbts": [{"id": 434, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 15, "lpgbts": [{"id": 434, "nElinks": 1}, {"id": 435, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 15, "lpgbts": [{"id": 436, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 15, "lpgbts": [{"id": 436, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 15, "lpgbts": [{"id": 436, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 15, "lpgbts": [{"id": 436, "nElinks": 1}, {"id": 437, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 15, "lpgbts": [{"id": 438, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 15, "lpgbts": [{"id": 438, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 15, "lpgbts": [{"id": 438, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 15, "lpgbts": [{"id": 438, "nElinks": 1}, {"id": 439, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 15, "lpgbts": [{"id": 440, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 15, "lpgbts": [{"id": 440, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 15, "lpgbts": [{"id": 440, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 15, "lpgbts": [{"id": 440, "nElinks": 1}, {"id": 441, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 15, "lpgbts": [{"id": 442, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 15, "lpgbts": [{"id": 442, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 15, "lpgbts": [{"id": 442, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 15, "lpgbts": [{"id": 442, "nElinks": 1}, {"id": 443, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 15, "lpgbts": [{"id": 443, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 15, "lpgbts": [{"id": 444, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 15, "lpgbts": [{"id": 444, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 15, "lpgbts": [{"id": 444, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 15, "lpgbts": [{"id": 444, "nElinks": 1}, {"id": 445, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 15, "lpgbts": [{"id": 445, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 15, "lpgbts": [{"id": 446, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 15, "lpgbts": [{"id": 446, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 15, "lpgbts": [{"id": 446, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 15, "lpgbts": [{"id": 446, "nElinks": 1}, {"id": 447, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 15, "lpgbts": [{"id": 447, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 15, "lpgbts": [{"id": 448, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 15, "lpgbts": [{"id": 448, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 15, "lpgbts": [{"id": 448, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 15, "lpgbts": [{"id": 448, "nElinks": 1}, {"id": 449, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 15, "lpgbts": [{"id": 449, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 15, "lpgbts": [{"id": 450, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 15, "lpgbts": [{"id": 450, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 15, "lpgbts": [{"id": 450, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 15, "lpgbts": [{"id": 450, "nElinks": 1}, {"id": 451, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 15, "lpgbts": [{"id": 451, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 15, "lpgbts": [{"id": 452, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 15, "lpgbts": [{"id": 452, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 15, "lpgbts": [{"id": 452, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 15, "lpgbts": [{"id": 452, "nElinks": 1}, {"id": 453, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 15, "lpgbts": [{"id": 453, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 15, "lpgbts": [{"id": 454, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 15, "lpgbts": [{"id": 454, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 15, "lpgbts": [{"id": 454, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 15, "lpgbts": [{"id": 454, "nElinks": 1}, {"id": 455, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 15, "lpgbts": [{"id": 456, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 15, "lpgbts": [{"id": 456, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 15, "lpgbts": [{"id": 456, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 15, "lpgbts": [{"id": 456, "nElinks": 1}, {"id": 457, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 15, "lpgbts": [{"id": 458, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 15, "lpgbts": [{"id": 458, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 15, "lpgbts": [{"id": 458, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 15, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 15, "lpgbts": [{"id": 459, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 15, "lpgbts": [{"id": 459, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 15, "lpgbts": [{"id": 459, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 15, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 15, "lpgbts": [{"id": 460, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 15, "lpgbts": [{"id": 460, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 15, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 15, "lpgbts": [{"id": 460, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 15, "lpgbts": [{"id": 461, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 15, "lpgbts": [{"id": 461, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 15, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 15, "lpgbts": [{"id": 461, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 16, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 17, "lpgbts": [{"id": 462, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 17, "lpgbts": [{"id": 462, "nElinks": 2}, {"id": 463, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 17, "lpgbts": [{"id": 463, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 17, "lpgbts": [{"id": 464, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 17, "lpgbts": [{"id": 464, "nElinks": 2}, {"id": 465, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 17, "lpgbts": [{"id": 465, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 17, "lpgbts": [{"id": 466, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 17, "lpgbts": [{"id": 466, "nElinks": 4}, {"id": 467, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 17, "lpgbts": [{"id": 467, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 17, "lpgbts": [{"id": 467, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 17, "lpgbts": [{"id": 468, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 17, "lpgbts": [{"id": 468, "nElinks": 4}, {"id": 469, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 17, "lpgbts": [{"id": 469, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 17, "lpgbts": [{"id": 469, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 17, "lpgbts": [{"id": 470, "nElinks": 5}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 17, "lpgbts": [{"id": 470, "nElinks": 2}, {"id": 471, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 17, "lpgbts": [{"id": 471, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 17, "lpgbts": [{"id": 472, "nElinks": 5}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 17, "lpgbts": [{"id": 472, "nElinks": 2}, {"id": 473, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 17, "lpgbts": [{"id": 473, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 17, "lpgbts": [{"id": 474, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 17, "lpgbts": [{"id": 474, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 17, "lpgbts": [{"id": 474, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 17, "lpgbts": [{"id": 475, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 17, "lpgbts": [{"id": 475, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 17, "lpgbts": [{"id": 475, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 17, "lpgbts": [{"id": 476, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 17, "lpgbts": [{"id": 476, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 17, "lpgbts": [{"id": 476, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 17, "lpgbts": [{"id": 476, "nElinks": 1}, {"id": 477, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 17, "lpgbts": [{"id": 477, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 17, "lpgbts": [{"id": 478, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 17, "lpgbts": [{"id": 478, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 17, "lpgbts": [{"id": 478, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 17, "lpgbts": [{"id": 478, "nElinks": 1}, {"id": 479, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 17, "lpgbts": [{"id": 479, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 17, "lpgbts": [{"id": 480, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 17, "lpgbts": [{"id": 480, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 17, "lpgbts": [{"id": 480, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 17, "lpgbts": [{"id": 480, "nElinks": 1}, {"id": 481, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 17, "lpgbts": [{"id": 482, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 17, "lpgbts": [{"id": 482, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 17, "lpgbts": [{"id": 482, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 17, "lpgbts": [{"id": 482, "nElinks": 1}, {"id": 483, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 17, "lpgbts": [{"id": 484, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 17, "lpgbts": [{"id": 484, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 17, "lpgbts": [{"id": 484, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 17, "lpgbts": [{"id": 484, "nElinks": 1}, {"id": 485, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 17, "lpgbts": [{"id": 486, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 17, "lpgbts": [{"id": 486, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 17, "lpgbts": [{"id": 486, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 17, "lpgbts": [{"id": 486, "nElinks": 1}, {"id": 487, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 17, "lpgbts": [{"id": 488, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 17, "lpgbts": [{"id": 488, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 17, "lpgbts": [{"id": 488, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 17, "lpgbts": [{"id": 488, "nElinks": 1}, {"id": 489, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 17, "lpgbts": [{"id": 489, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 17, "lpgbts": [{"id": 490, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 17, "lpgbts": [{"id": 490, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 17, "lpgbts": [{"id": 490, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 17, "lpgbts": [{"id": 490, "nElinks": 1}, {"id": 491, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 17, "lpgbts": [{"id": 491, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 17, "lpgbts": [{"id": 492, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 17, "lpgbts": [{"id": 492, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 17, "lpgbts": [{"id": 492, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 17, "lpgbts": [{"id": 492, "nElinks": 1}, {"id": 493, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 17, "lpgbts": [{"id": 493, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 17, "lpgbts": [{"id": 494, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 17, "lpgbts": [{"id": 494, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 17, "lpgbts": [{"id": 494, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 17, "lpgbts": [{"id": 494, "nElinks": 1}, {"id": 495, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 17, "lpgbts": [{"id": 495, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 17, "lpgbts": [{"id": 496, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 17, "lpgbts": [{"id": 496, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 17, "lpgbts": [{"id": 496, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 17, "lpgbts": [{"id": 496, "nElinks": 1}, {"id": 497, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 17, "lpgbts": [{"id": 497, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 17, "lpgbts": [{"id": 498, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 17, "lpgbts": [{"id": 498, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 17, "lpgbts": [{"id": 498, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 17, "lpgbts": [{"id": 498, "nElinks": 1}, {"id": 499, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 17, "lpgbts": [{"id": 499, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 17, "lpgbts": [{"id": 500, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 17, "lpgbts": [{"id": 500, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 17, "lpgbts": [{"id": 500, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 17, "lpgbts": [{"id": 500, "nElinks": 1}, {"id": 501, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 17, "lpgbts": [{"id": 502, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 17, "lpgbts": [{"id": 502, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 17, "lpgbts": [{"id": 502, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 17, "lpgbts": [{"id": 502, "nElinks": 1}, {"id": 503, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 17, "lpgbts": [{"id": 504, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 17, "lpgbts": [{"id": 504, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 17, "lpgbts": [{"id": 504, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 17, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 17, "lpgbts": [{"id": 505, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 17, "lpgbts": [{"id": 505, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 17, "lpgbts": [{"id": 505, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 17, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 17, "lpgbts": [{"id": 506, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 17, "lpgbts": [{"id": 506, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 17, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 17, "lpgbts": [{"id": 506, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 17, "lpgbts": [{"id": 507, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 17, "lpgbts": [{"id": 507, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 17, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 17, "lpgbts": [{"id": 507, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 18, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 19, "lpgbts": [{"id": 508, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 19, "lpgbts": [{"id": 508, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 19, "lpgbts": [{"id": 509, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 19, "lpgbts": [{"id": 510, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 19, "lpgbts": [{"id": 510, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 19, "lpgbts": [{"id": 511, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 19, "lpgbts": [{"id": 512, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 19, "lpgbts": [{"id": 512, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 19, "lpgbts": [{"id": 513, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 19, "lpgbts": [{"id": 513, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 19, "lpgbts": [{"id": 514, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 19, "lpgbts": [{"id": 514, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 19, "lpgbts": [{"id": 515, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 19, "lpgbts": [{"id": 515, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 19, "lpgbts": [{"id": 516, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 19, "lpgbts": [{"id": 516, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 19, "lpgbts": [{"id": 517, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 19, "lpgbts": [{"id": 518, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 19, "lpgbts": [{"id": 518, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 19, "lpgbts": [{"id": 519, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 19, "lpgbts": [{"id": 520, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 19, "lpgbts": [{"id": 520, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 19, "lpgbts": [{"id": 520, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 19, "lpgbts": [{"id": 521, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 19, "lpgbts": [{"id": 521, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 19, "lpgbts": [{"id": 521, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 19, "lpgbts": [{"id": 522, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 19, "lpgbts": [{"id": 522, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 19, "lpgbts": [{"id": 522, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 19, "lpgbts": [{"id": 522, "nElinks": 1}, {"id": 523, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 19, "lpgbts": [{"id": 523, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 19, "lpgbts": [{"id": 524, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 19, "lpgbts": [{"id": 524, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 19, "lpgbts": [{"id": 524, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 19, "lpgbts": [{"id": 524, "nElinks": 1}, {"id": 525, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 19, "lpgbts": [{"id": 525, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 19, "lpgbts": [{"id": 526, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 19, "lpgbts": [{"id": 526, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 19, "lpgbts": [{"id": 526, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 19, "lpgbts": [{"id": 526, "nElinks": 1}, {"id": 527, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 19, "lpgbts": [{"id": 528, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 19, "lpgbts": [{"id": 528, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 19, "lpgbts": [{"id": 528, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 19, "lpgbts": [{"id": 528, "nElinks": 1}, {"id": 529, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 19, "lpgbts": [{"id": 530, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 19, "lpgbts": [{"id": 530, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 19, "lpgbts": [{"id": 530, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 19, "lpgbts": [{"id": 530, "nElinks": 1}, {"id": 531, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 19, "lpgbts": [{"id": 532, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 19, "lpgbts": [{"id": 532, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 19, "lpgbts": [{"id": 532, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 19, "lpgbts": [{"id": 532, "nElinks": 1}, {"id": 533, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 19, "lpgbts": [{"id": 534, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 19, "lpgbts": [{"id": 534, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 19, "lpgbts": [{"id": 534, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 19, "lpgbts": [{"id": 534, "nElinks": 1}, {"id": 535, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 19, "lpgbts": [{"id": 535, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 19, "lpgbts": [{"id": 536, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 19, "lpgbts": [{"id": 536, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 19, "lpgbts": [{"id": 536, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 19, "lpgbts": [{"id": 536, "nElinks": 1}, {"id": 537, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 19, "lpgbts": [{"id": 537, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 19, "lpgbts": [{"id": 538, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 19, "lpgbts": [{"id": 538, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 19, "lpgbts": [{"id": 538, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 19, "lpgbts": [{"id": 538, "nElinks": 1}, {"id": 539, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 19, "lpgbts": [{"id": 539, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 19, "lpgbts": [{"id": 540, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 19, "lpgbts": [{"id": 540, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 19, "lpgbts": [{"id": 540, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 19, "lpgbts": [{"id": 540, "nElinks": 1}, {"id": 541, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 19, "lpgbts": [{"id": 541, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 19, "lpgbts": [{"id": 542, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 19, "lpgbts": [{"id": 542, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 19, "lpgbts": [{"id": 542, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 19, "lpgbts": [{"id": 542, "nElinks": 1}, {"id": 543, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 19, "lpgbts": [{"id": 543, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 19, "lpgbts": [{"id": 544, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 19, "lpgbts": [{"id": 544, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 19, "lpgbts": [{"id": 544, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 19, "lpgbts": [{"id": 544, "nElinks": 1}, {"id": 545, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 19, "lpgbts": [{"id": 545, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 19, "lpgbts": [{"id": 546, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 19, "lpgbts": [{"id": 546, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 19, "lpgbts": [{"id": 546, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 19, "lpgbts": [{"id": 546, "nElinks": 1}, {"id": 547, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 19, "lpgbts": [{"id": 548, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 19, "lpgbts": [{"id": 548, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 19, "lpgbts": [{"id": 548, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 19, "lpgbts": [{"id": 548, "nElinks": 1}, {"id": 549, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 19, "lpgbts": [{"id": 550, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 19, "lpgbts": [{"id": 550, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 19, "lpgbts": [{"id": 550, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 19, "lpgbts": [{"id": 551, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 19, "lpgbts": [{"id": 551, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 19, "lpgbts": [{"id": 551, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 19, "lpgbts": [{"id": 552, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 19, "lpgbts": [{"id": 552, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 19, "lpgbts": [{"id": 552, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 19, "lpgbts": [{"id": 553, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 19, "lpgbts": [{"id": 553, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 19, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 19, "lpgbts": [{"id": 553, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 20, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 21, "lpgbts": [{"id": 554, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 21, "lpgbts": [{"id": 554, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 21, "lpgbts": [{"id": 555, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 21, "lpgbts": [{"id": 556, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 21, "lpgbts": [{"id": 556, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 21, "lpgbts": [{"id": 557, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 21, "lpgbts": [{"id": 558, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 21, "lpgbts": [{"id": 558, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 21, "lpgbts": [{"id": 559, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 21, "lpgbts": [{"id": 559, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 21, "lpgbts": [{"id": 560, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 21, "lpgbts": [{"id": 560, "nElinks": 4}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 21, "lpgbts": [{"id": 561, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 21, "lpgbts": [{"id": 561, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 21, "lpgbts": [{"id": 562, "nElinks": 4}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 21, "lpgbts": [{"id": 562, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 21, "lpgbts": [{"id": 562, "nElinks": 1}, {"id": 563, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 21, "lpgbts": [{"id": 564, "nElinks": 4}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 21, "lpgbts": [{"id": 564, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 21, "lpgbts": [{"id": 564, "nElinks": 1}, {"id": 565, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 21, "lpgbts": [{"id": 566, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 21, "lpgbts": [{"id": 566, "nElinks": 3}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 21, "lpgbts": [{"id": 566, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 21, "lpgbts": [{"id": 567, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 21, "lpgbts": [{"id": 567, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 21, "lpgbts": [{"id": 567, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 21, "lpgbts": [{"id": 568, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 21, "lpgbts": [{"id": 568, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 21, "lpgbts": [{"id": 568, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 21, "lpgbts": [{"id": 568, "nElinks": 1}, {"id": 569, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 21, "lpgbts": [{"id": 569, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 21, "lpgbts": [{"id": 570, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 21, "lpgbts": [{"id": 570, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 21, "lpgbts": [{"id": 570, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 21, "lpgbts": [{"id": 570, "nElinks": 1}, {"id": 571, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 21, "lpgbts": [{"id": 571, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 21, "lpgbts": [{"id": 572, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 21, "lpgbts": [{"id": 572, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 21, "lpgbts": [{"id": 572, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 21, "lpgbts": [{"id": 572, "nElinks": 1}, {"id": 573, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 21, "lpgbts": [{"id": 574, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 21, "lpgbts": [{"id": 574, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 21, "lpgbts": [{"id": 574, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 21, "lpgbts": [{"id": 574, "nElinks": 1}, {"id": 575, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 21, "lpgbts": [{"id": 576, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 21, "lpgbts": [{"id": 576, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 21, "lpgbts": [{"id": 576, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 21, "lpgbts": [{"id": 576, "nElinks": 1}, {"id": 577, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 21, "lpgbts": [{"id": 577, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 21, "lpgbts": [{"id": 578, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 21, "lpgbts": [{"id": 578, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 21, "lpgbts": [{"id": 578, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 21, "lpgbts": [{"id": 578, "nElinks": 1}, {"id": 579, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 21, "lpgbts": [{"id": 579, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 21, "lpgbts": [{"id": 580, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 21, "lpgbts": [{"id": 580, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 21, "lpgbts": [{"id": 580, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 21, "lpgbts": [{"id": 580, "nElinks": 1}, {"id": 581, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 21, "lpgbts": [{"id": 581, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 21, "lpgbts": [{"id": 582, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 21, "lpgbts": [{"id": 582, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 21, "lpgbts": [{"id": 582, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 21, "lpgbts": [{"id": 582, "nElinks": 1}, {"id": 583, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 21, "lpgbts": [{"id": 583, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 21, "lpgbts": [{"id": 584, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 21, "lpgbts": [{"id": 584, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 21, "lpgbts": [{"id": 584, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 21, "lpgbts": [{"id": 584, "nElinks": 1}, {"id": 585, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 21, "lpgbts": [{"id": 585, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 21, "lpgbts": [{"id": 586, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 21, "lpgbts": [{"id": 586, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 21, "lpgbts": [{"id": 586, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 21, "lpgbts": [{"id": 586, "nElinks": 1}, {"id": 587, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 21, "lpgbts": [{"id": 587, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 21, "lpgbts": [{"id": 588, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 21, "lpgbts": [{"id": 588, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 21, "lpgbts": [{"id": 588, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 21, "lpgbts": [{"id": 588, "nElinks": 1}, {"id": 589, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 21, "lpgbts": [{"id": 589, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 21, "lpgbts": [{"id": 590, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 21, "lpgbts": [{"id": 590, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 21, "lpgbts": [{"id": 590, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 21, "lpgbts": [{"id": 590, "nElinks": 1}, {"id": 591, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 21, "lpgbts": [{"id": 591, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 21, "lpgbts": [{"id": 592, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 21, "lpgbts": [{"id": 592, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 21, "lpgbts": [{"id": 592, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 21, "lpgbts": [{"id": 592, "nElinks": 1}, {"id": 593, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 21, "lpgbts": [{"id": 594, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 21, "lpgbts": [{"id": 594, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 21, "lpgbts": [{"id": 594, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 21, "lpgbts": [{"id": 594, "nElinks": 1}, {"id": 595, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 21, "lpgbts": [{"id": 596, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 21, "lpgbts": [{"id": 596, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 21, "lpgbts": [{"id": 596, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 21, "lpgbts": [{"id": 597, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 21, "lpgbts": [{"id": 597, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 21, "lpgbts": [{"id": 597, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 21, "lpgbts": [{"id": 598, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 21, "lpgbts": [{"id": 598, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 21, "lpgbts": [{"id": 598, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 21, "lpgbts": [{"id": 599, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 21, "lpgbts": [{"id": 599, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 21, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 21, "lpgbts": [{"id": 599, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 22, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 23, "lpgbts": [{"id": 600, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 23, "lpgbts": [{"id": 600, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 23, "lpgbts": [{"id": 600, "nElinks": 1}, {"id": 601, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 23, "lpgbts": [{"id": 602, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 23, "lpgbts": [{"id": 602, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 23, "lpgbts": [{"id": 602, "nElinks": 1}, {"id": 603, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 23, "lpgbts": [{"id": 604, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 23, "lpgbts": [{"id": 604, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 23, "lpgbts": [{"id": 604, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 23, "lpgbts": [{"id": 605, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 23, "lpgbts": [{"id": 606, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 23, "lpgbts": [{"id": 606, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 23, "lpgbts": [{"id": 606, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 23, "lpgbts": [{"id": 607, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 23, "lpgbts": [{"id": 608, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 23, "lpgbts": [{"id": 608, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 23, "lpgbts": [{"id": 608, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 23, "lpgbts": [{"id": 609, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 23, "lpgbts": [{"id": 609, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 23, "lpgbts": [{"id": 609, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 23, "lpgbts": [{"id": 610, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 23, "lpgbts": [{"id": 610, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 23, "lpgbts": [{"id": 610, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 23, "lpgbts": [{"id": 611, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 23, "lpgbts": [{"id": 611, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 23, "lpgbts": [{"id": 611, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 23, "lpgbts": [{"id": 612, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 23, "lpgbts": [{"id": 612, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 23, "lpgbts": [{"id": 612, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 23, "lpgbts": [{"id": 612, "nElinks": 1}, {"id": 613, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 23, "lpgbts": [{"id": 613, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 23, "lpgbts": [{"id": 614, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 23, "lpgbts": [{"id": 614, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 23, "lpgbts": [{"id": 614, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 23, "lpgbts": [{"id": 614, "nElinks": 1}, {"id": 615, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 23, "lpgbts": [{"id": 615, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 23, "lpgbts": [{"id": 616, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 23, "lpgbts": [{"id": 616, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 23, "lpgbts": [{"id": 616, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 23, "lpgbts": [{"id": 616, "nElinks": 1}, {"id": 617, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 23, "lpgbts": [{"id": 618, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 23, "lpgbts": [{"id": 618, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 23, "lpgbts": [{"id": 618, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 23, "lpgbts": [{"id": 618, "nElinks": 1}, {"id": 619, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 23, "lpgbts": [{"id": 620, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 23, "lpgbts": [{"id": 620, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 23, "lpgbts": [{"id": 620, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 23, "lpgbts": [{"id": 620, "nElinks": 1}, {"id": 621, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 23, "lpgbts": [{"id": 621, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 23, "lpgbts": [{"id": 622, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 23, "lpgbts": [{"id": 622, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 23, "lpgbts": [{"id": 622, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 23, "lpgbts": [{"id": 622, "nElinks": 1}, {"id": 623, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 23, "lpgbts": [{"id": 623, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 23, "lpgbts": [{"id": 624, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 23, "lpgbts": [{"id": 624, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 23, "lpgbts": [{"id": 624, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 23, "lpgbts": [{"id": 624, "nElinks": 1}, {"id": 625, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 23, "lpgbts": [{"id": 625, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 23, "lpgbts": [{"id": 626, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 23, "lpgbts": [{"id": 626, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 23, "lpgbts": [{"id": 626, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 23, "lpgbts": [{"id": 626, "nElinks": 1}, {"id": 627, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 23, "lpgbts": [{"id": 627, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 23, "lpgbts": [{"id": 628, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 23, "lpgbts": [{"id": 628, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 23, "lpgbts": [{"id": 628, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 23, "lpgbts": [{"id": 628, "nElinks": 1}, {"id": 629, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 23, "lpgbts": [{"id": 629, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 23, "lpgbts": [{"id": 630, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 23, "lpgbts": [{"id": 630, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 23, "lpgbts": [{"id": 630, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 23, "lpgbts": [{"id": 630, "nElinks": 1}, {"id": 631, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 23, "lpgbts": [{"id": 631, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 23, "lpgbts": [{"id": 632, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 23, "lpgbts": [{"id": 632, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 23, "lpgbts": [{"id": 632, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 23, "lpgbts": [{"id": 632, "nElinks": 1}, {"id": 633, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 23, "lpgbts": [{"id": 633, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 23, "lpgbts": [{"id": 634, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 23, "lpgbts": [{"id": 634, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 23, "lpgbts": [{"id": 634, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 23, "lpgbts": [{"id": 634, "nElinks": 1}, {"id": 635, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 23, "lpgbts": [{"id": 635, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 23, "lpgbts": [{"id": 636, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 23, "lpgbts": [{"id": 636, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 23, "lpgbts": [{"id": 636, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 23, "lpgbts": [{"id": 636, "nElinks": 1}, {"id": 637, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 23, "lpgbts": [{"id": 638, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 23, "lpgbts": [{"id": 638, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 23, "lpgbts": [{"id": 638, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 23, "lpgbts": [{"id": 638, "nElinks": 1}, {"id": 639, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 23, "lpgbts": [{"id": 640, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 23, "lpgbts": [{"id": 640, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 23, "lpgbts": [{"id": 640, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 23, "lpgbts": [{"id": 641, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 23, "lpgbts": [{"id": 641, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 23, "lpgbts": [{"id": 641, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 23, "lpgbts": [{"id": 642, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 23, "lpgbts": [{"id": 642, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 23, "lpgbts": [{"id": 642, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 23, "lpgbts": [{"id": 643, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 23, "lpgbts": [{"id": 643, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 23, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 23, "lpgbts": [{"id": 643, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 24, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 25, "lpgbts": [{"id": 644, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 25, "lpgbts": [{"id": 644, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 25, "lpgbts": [{"id": 644, "nElinks": 1}, {"id": 645, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 25, "lpgbts": [{"id": 646, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 25, "lpgbts": [{"id": 646, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 25, "lpgbts": [{"id": 646, "nElinks": 1}, {"id": 647, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 25, "lpgbts": [{"id": 648, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 25, "lpgbts": [{"id": 648, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 25, "lpgbts": [{"id": 648, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 25, "lpgbts": [{"id": 649, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 25, "lpgbts": [{"id": 650, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 25, "lpgbts": [{"id": 650, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 25, "lpgbts": [{"id": 650, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 25, "lpgbts": [{"id": 651, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 25, "lpgbts": [{"id": 652, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 25, "lpgbts": [{"id": 652, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 25, "lpgbts": [{"id": 652, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 25, "lpgbts": [{"id": 653, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 25, "lpgbts": [{"id": 653, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 25, "lpgbts": [{"id": 653, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 25, "lpgbts": [{"id": 654, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 25, "lpgbts": [{"id": 654, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 25, "lpgbts": [{"id": 654, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 25, "lpgbts": [{"id": 655, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 25, "lpgbts": [{"id": 655, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 25, "lpgbts": [{"id": 655, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 25, "lpgbts": [{"id": 656, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 25, "lpgbts": [{"id": 656, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 25, "lpgbts": [{"id": 656, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 25, "lpgbts": [{"id": 656, "nElinks": 1}, {"id": 657, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 25, "lpgbts": [{"id": 657, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 25, "lpgbts": [{"id": 658, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 25, "lpgbts": [{"id": 658, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 25, "lpgbts": [{"id": 658, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 25, "lpgbts": [{"id": 658, "nElinks": 1}, {"id": 659, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 25, "lpgbts": [{"id": 659, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 25, "lpgbts": [{"id": 660, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 25, "lpgbts": [{"id": 660, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 25, "lpgbts": [{"id": 660, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 25, "lpgbts": [{"id": 660, "nElinks": 1}, {"id": 661, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 25, "lpgbts": [{"id": 662, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 25, "lpgbts": [{"id": 662, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 25, "lpgbts": [{"id": 662, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 25, "lpgbts": [{"id": 662, "nElinks": 1}, {"id": 663, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 25, "lpgbts": [{"id": 664, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 25, "lpgbts": [{"id": 664, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 25, "lpgbts": [{"id": 664, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 25, "lpgbts": [{"id": 664, "nElinks": 1}, {"id": 665, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 25, "lpgbts": [{"id": 665, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 25, "lpgbts": [{"id": 666, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 25, "lpgbts": [{"id": 666, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 25, "lpgbts": [{"id": 666, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 25, "lpgbts": [{"id": 666, "nElinks": 1}, {"id": 667, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 25, "lpgbts": [{"id": 667, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 25, "lpgbts": [{"id": 668, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 25, "lpgbts": [{"id": 668, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 25, "lpgbts": [{"id": 668, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 25, "lpgbts": [{"id": 668, "nElinks": 1}, {"id": 669, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 25, "lpgbts": [{"id": 669, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 25, "lpgbts": [{"id": 670, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 25, "lpgbts": [{"id": 670, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 25, "lpgbts": [{"id": 670, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 25, "lpgbts": [{"id": 670, "nElinks": 1}, {"id": 671, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 25, "lpgbts": [{"id": 671, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 25, "lpgbts": [{"id": 672, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 25, "lpgbts": [{"id": 672, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 25, "lpgbts": [{"id": 672, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 25, "lpgbts": [{"id": 672, "nElinks": 1}, {"id": 673, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 25, "lpgbts": [{"id": 673, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 25, "lpgbts": [{"id": 674, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 25, "lpgbts": [{"id": 674, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 25, "lpgbts": [{"id": 674, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 25, "lpgbts": [{"id": 674, "nElinks": 1}, {"id": 675, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 25, "lpgbts": [{"id": 675, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 25, "lpgbts": [{"id": 676, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 25, "lpgbts": [{"id": 676, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 25, "lpgbts": [{"id": 676, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 25, "lpgbts": [{"id": 676, "nElinks": 1}, {"id": 677, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 25, "lpgbts": [{"id": 677, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 25, "lpgbts": [{"id": 678, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 25, "lpgbts": [{"id": 678, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 25, "lpgbts": [{"id": 678, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 25, "lpgbts": [{"id": 678, "nElinks": 1}, {"id": 679, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 25, "lpgbts": [{"id": 679, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 25, "lpgbts": [{"id": 680, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 25, "lpgbts": [{"id": 680, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 25, "lpgbts": [{"id": 680, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 25, "lpgbts": [{"id": 680, "nElinks": 1}, {"id": 681, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 25, "lpgbts": [{"id": 682, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 25, "lpgbts": [{"id": 682, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 25, "lpgbts": [{"id": 682, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 25, "lpgbts": [{"id": 682, "nElinks": 1}, {"id": 683, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 25, "lpgbts": [{"id": 684, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 25, "lpgbts": [{"id": 684, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 25, "lpgbts": [{"id": 684, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 25, "lpgbts": [{"id": 684, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 25, "lpgbts": [{"id": 685, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 25, "lpgbts": [{"id": 685, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 25, "lpgbts": [{"id": 685, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 25, "lpgbts": [{"id": 685, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 25, "lpgbts": [{"id": 686, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 25, "lpgbts": [{"id": 686, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 25, "lpgbts": [{"id": 686, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 25, "lpgbts": [{"id": 686, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 25, "lpgbts": [{"id": 687, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 25, "lpgbts": [{"id": 687, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 25, "lpgbts": [{"id": 687, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 25, "lpgbts": [{"id": 687, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 25, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 26, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 27, "lpgbts": [{"id": 688, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 27, "lpgbts": [{"id": 688, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 27, "lpgbts": [{"id": 688, "nElinks": 1}, {"id": 689, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 27, "lpgbts": [{"id": 690, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 27, "lpgbts": [{"id": 690, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 27, "lpgbts": [{"id": 690, "nElinks": 1}, {"id": 691, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 27, "lpgbts": [{"id": 692, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 27, "lpgbts": [{"id": 692, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 27, "lpgbts": [{"id": 692, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 27, "lpgbts": [{"id": 693, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 27, "lpgbts": [{"id": 694, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 27, "lpgbts": [{"id": 694, "nElinks": 3}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 27, "lpgbts": [{"id": 694, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 27, "lpgbts": [{"id": 695, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 27, "lpgbts": [{"id": 696, "nElinks": 3}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 27, "lpgbts": [{"id": 696, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 27, "lpgbts": [{"id": 696, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 27, "lpgbts": [{"id": 697, "nElinks": 3}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 27, "lpgbts": [{"id": 697, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 27, "lpgbts": [{"id": 697, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 27, "lpgbts": [{"id": 698, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 27, "lpgbts": [{"id": 698, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 27, "lpgbts": [{"id": 698, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 27, "lpgbts": [{"id": 699, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 27, "lpgbts": [{"id": 699, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 27, "lpgbts": [{"id": 699, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 27, "lpgbts": [{"id": 700, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 27, "lpgbts": [{"id": 700, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 27, "lpgbts": [{"id": 700, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 27, "lpgbts": [{"id": 700, "nElinks": 1}, {"id": 701, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 27, "lpgbts": [{"id": 701, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 27, "lpgbts": [{"id": 702, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 27, "lpgbts": [{"id": 702, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 27, "lpgbts": [{"id": 702, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 27, "lpgbts": [{"id": 702, "nElinks": 1}, {"id": 703, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 27, "lpgbts": [{"id": 703, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 27, "lpgbts": [{"id": 704, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 27, "lpgbts": [{"id": 704, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 27, "lpgbts": [{"id": 704, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 27, "lpgbts": [{"id": 704, "nElinks": 1}, {"id": 705, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 27, "lpgbts": [{"id": 705, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 27, "lpgbts": [{"id": 706, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 27, "lpgbts": [{"id": 706, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 27, "lpgbts": [{"id": 706, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 27, "lpgbts": [{"id": 706, "nElinks": 1}, {"id": 707, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 27, "lpgbts": [{"id": 707, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 27, "lpgbts": [{"id": 708, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 27, "lpgbts": [{"id": 708, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 27, "lpgbts": [{"id": 708, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 27, "lpgbts": [{"id": 708, "nElinks": 1}, {"id": 709, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 27, "lpgbts": [{"id": 709, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 27, "lpgbts": [{"id": 710, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 27, "lpgbts": [{"id": 710, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 27, "lpgbts": [{"id": 710, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 27, "lpgbts": [{"id": 710, "nElinks": 1}, {"id": 711, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 27, "lpgbts": [{"id": 711, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 27, "lpgbts": [{"id": 712, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 27, "lpgbts": [{"id": 712, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 27, "lpgbts": [{"id": 712, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 27, "lpgbts": [{"id": 712, "nElinks": 1}, {"id": 713, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 27, "lpgbts": [{"id": 713, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 27, "lpgbts": [{"id": 714, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 27, "lpgbts": [{"id": 714, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 27, "lpgbts": [{"id": 714, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 27, "lpgbts": [{"id": 714, "nElinks": 1}, {"id": 715, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 27, "lpgbts": [{"id": 715, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 27, "lpgbts": [{"id": 716, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 27, "lpgbts": [{"id": 716, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 27, "lpgbts": [{"id": 716, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 27, "lpgbts": [{"id": 716, "nElinks": 1}, {"id": 717, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 27, "lpgbts": [{"id": 717, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 27, "lpgbts": [{"id": 718, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 27, "lpgbts": [{"id": 718, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 27, "lpgbts": [{"id": 718, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 27, "lpgbts": [{"id": 718, "nElinks": 1}, {"id": 719, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 27, "lpgbts": [{"id": 719, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 27, "lpgbts": [{"id": 720, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 27, "lpgbts": [{"id": 720, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 27, "lpgbts": [{"id": 720, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 27, "lpgbts": [{"id": 720, "nElinks": 1}, {"id": 721, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 27, "lpgbts": [{"id": 721, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 27, "lpgbts": [{"id": 722, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 27, "lpgbts": [{"id": 722, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 27, "lpgbts": [{"id": 722, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 27, "lpgbts": [{"id": 722, "nElinks": 1}, {"id": 723, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 27, "lpgbts": [{"id": 723, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 27, "lpgbts": [{"id": 724, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 27, "lpgbts": [{"id": 724, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 27, "lpgbts": [{"id": 724, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 27, "lpgbts": [{"id": 724, "nElinks": 1}, {"id": 725, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 27, "lpgbts": [{"id": 726, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 27, "lpgbts": [{"id": 726, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 27, "lpgbts": [{"id": 726, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 27, "lpgbts": [{"id": 726, "nElinks": 1}, {"id": 727, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 27, "lpgbts": [{"id": 728, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 27, "lpgbts": [{"id": 728, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 27, "lpgbts": [{"id": 728, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 27, "lpgbts": [{"id": 728, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 27, "lpgbts": [{"id": 729, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 27, "lpgbts": [{"id": 729, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 27, "lpgbts": [{"id": 729, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 27, "lpgbts": [{"id": 729, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 27, "lpgbts": [{"id": 730, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 27, "lpgbts": [{"id": 730, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 27, "lpgbts": [{"id": 730, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 27, "lpgbts": [{"id": 730, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 27, "lpgbts": [{"id": 731, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 27, "lpgbts": [{"id": 731, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 27, "lpgbts": [{"id": 731, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 27, "lpgbts": [{"id": 731, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 27, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 28, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 29, "lpgbts": [{"id": 732, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 29, "lpgbts": [{"id": 732, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 29, "lpgbts": [{"id": 732, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 29, "lpgbts": [{"id": 733, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 29, "lpgbts": [{"id": 733, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 29, "lpgbts": [{"id": 733, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 29, "lpgbts": [{"id": 734, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 29, "lpgbts": [{"id": 734, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 29, "lpgbts": [{"id": 734, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 29, "lpgbts": [{"id": 735, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 29, "lpgbts": [{"id": 735, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 29, "lpgbts": [{"id": 735, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 29, "lpgbts": [{"id": 735, "nElinks": 1}, {"id": 736, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 29, "lpgbts": [{"id": 736, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 29, "lpgbts": [{"id": 737, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 29, "lpgbts": [{"id": 737, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 29, "lpgbts": [{"id": 737, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 29, "lpgbts": [{"id": 737, "nElinks": 1}, {"id": 738, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 29, "lpgbts": [{"id": 738, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 29, "lpgbts": [{"id": 739, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 29, "lpgbts": [{"id": 739, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 29, "lpgbts": [{"id": 739, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 29, "lpgbts": [{"id": 739, "nElinks": 1}, {"id": 740, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 29, "lpgbts": [{"id": 740, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 29, "lpgbts": [{"id": 740, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 29, "lpgbts": [{"id": 741, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 29, "lpgbts": [{"id": 741, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 29, "lpgbts": [{"id": 741, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 29, "lpgbts": [{"id": 741, "nElinks": 1}, {"id": 742, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 29, "lpgbts": [{"id": 742, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 29, "lpgbts": [{"id": 742, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 29, "lpgbts": [{"id": 743, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 29, "lpgbts": [{"id": 743, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 29, "lpgbts": [{"id": 743, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 29, "lpgbts": [{"id": 743, "nElinks": 1}, {"id": 744, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 29, "lpgbts": [{"id": 744, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 29, "lpgbts": [{"id": 744, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 29, "lpgbts": [{"id": 745, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 29, "lpgbts": [{"id": 745, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 29, "lpgbts": [{"id": 745, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 29, "lpgbts": [{"id": 745, "nElinks": 1}, {"id": 746, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 29, "lpgbts": [{"id": 746, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 29, "lpgbts": [{"id": 747, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 29, "lpgbts": [{"id": 747, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 29, "lpgbts": [{"id": 747, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 29, "lpgbts": [{"id": 747, "nElinks": 1}, {"id": 748, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 29, "lpgbts": [{"id": 749, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 29, "lpgbts": [{"id": 749, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 29, "lpgbts": [{"id": 749, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 29, "lpgbts": [{"id": 750, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 29, "lpgbts": [{"id": 750, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 29, "lpgbts": [{"id": 750, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 29, "lpgbts": [{"id": 751, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 29, "lpgbts": [{"id": 751, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 29, "lpgbts": [{"id": 751, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 29, "lpgbts": [{"id": 752, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 29, "lpgbts": [{"id": 752, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 29, "lpgbts": [{"id": 752, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 29, "lpgbts": [{"id": 753, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 29, "lpgbts": [{"id": 753, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 29, "lpgbts": [{"id": 753, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 29, "lpgbts": [{"id": 754, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 29, "lpgbts": [{"id": 754, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 29, "lpgbts": [{"id": 754, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 29, "lpgbts": [{"id": 755, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 29, "lpgbts": [{"id": 755, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 29, "lpgbts": [{"id": 755, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 29, "lpgbts": [{"id": 755, "nElinks": 1}, {"id": 756, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 29, "lpgbts": [{"id": 757, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 29, "lpgbts": [{"id": 757, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 29, "lpgbts": [{"id": 757, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 29, "lpgbts": [{"id": 757, "nElinks": 1}, {"id": 758, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 9, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 29, "lpgbts": [{"id": 759, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 29, "lpgbts": [{"id": 759, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 29, "lpgbts": [{"id": 759, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 29, "lpgbts": [{"id": 759, "nElinks": 1}, {"id": 760, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 29, "lpgbts": [{"id": 760, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 29, "lpgbts": [{"id": 761, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 29, "lpgbts": [{"id": 761, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 29, "lpgbts": [{"id": 761, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 29, "lpgbts": [{"id": 761, "nElinks": 1}, {"id": 762, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 29, "lpgbts": [{"id": 762, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 29, "lpgbts": [{"id": 763, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 29, "lpgbts": [{"id": 763, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 29, "lpgbts": [{"id": 763, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 29, "lpgbts": [{"id": 763, "nElinks": 1}, {"id": 764, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 29, "lpgbts": [{"id": 764, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 29, "lpgbts": [{"id": 764, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 29, "lpgbts": [{"id": 765, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 29, "lpgbts": [{"id": 765, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 29, "lpgbts": [{"id": 765, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 29, "lpgbts": [{"id": 765, "nElinks": 1}, {"id": 766, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 29, "lpgbts": [{"id": 766, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 29, "lpgbts": [{"id": 766, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 29, "lpgbts": [{"id": 767, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 29, "lpgbts": [{"id": 767, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 29, "lpgbts": [{"id": 767, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 29, "lpgbts": [{"id": 767, "nElinks": 1}, {"id": 768, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 29, "lpgbts": [{"id": 768, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 29, "lpgbts": [{"id": 769, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 29, "lpgbts": [{"id": 769, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 29, "lpgbts": [{"id": 769, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 29, "lpgbts": [{"id": 769, "nElinks": 1}, {"id": 770, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 29, "lpgbts": [{"id": 771, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 29, "lpgbts": [{"id": 771, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 29, "lpgbts": [{"id": 771, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 29, "lpgbts": [{"id": 771, "nElinks": 1}, {"id": 772, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 29, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 29, "lpgbts": [{"id": 772, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 30, "lpgbts": [{"id": 773, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 30, "lpgbts": [{"id": 773, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 30, "lpgbts": [{"id": 773, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 30, "lpgbts": [{"id": 774, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 30, "lpgbts": [{"id": 774, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 30, "lpgbts": [{"id": 774, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 30, "lpgbts": [{"id": 775, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 30, "lpgbts": [{"id": 775, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 30, "lpgbts": [{"id": 775, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 30, "lpgbts": [{"id": 776, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 30, "lpgbts": [{"id": 776, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 30, "lpgbts": [{"id": 776, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 30, "lpgbts": [{"id": 777, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 30, "lpgbts": [{"id": 777, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 30, "lpgbts": [{"id": 777, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 30, "lpgbts": [{"id": 777, "nElinks": 1}, {"id": 778, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 30, "lpgbts": [{"id": 778, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 30, "lpgbts": [{"id": 779, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 30, "lpgbts": [{"id": 779, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 30, "lpgbts": [{"id": 779, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 30, "lpgbts": [{"id": 779, "nElinks": 1}, {"id": 780, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 10, "layer": 30, "lpgbts": [{"id": 780, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 30, "lpgbts": [{"id": 781, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 30, "lpgbts": [{"id": 781, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 30, "lpgbts": [{"id": 781, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 30, "lpgbts": [{"id": 781, "nElinks": 1}, {"id": 782, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 30, "lpgbts": [{"id": 782, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 30, "lpgbts": [{"id": 783, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 30, "lpgbts": [{"id": 783, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 30, "lpgbts": [{"id": 783, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 30, "lpgbts": [{"id": 783, "nElinks": 1}, {"id": 784, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 30, "lpgbts": [{"id": 784, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 10, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 30, "lpgbts": [{"id": 785, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 30, "lpgbts": [{"id": 785, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 30, "lpgbts": [{"id": 785, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 30, "lpgbts": [{"id": 785, "nElinks": 1}, {"id": 786, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 30, "lpgbts": [{"id": 786, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 30, "lpgbts": [{"id": 786, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 30, "lpgbts": [{"id": 787, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 30, "lpgbts": [{"id": 787, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 30, "lpgbts": [{"id": 787, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 30, "lpgbts": [{"id": 787, "nElinks": 1}, {"id": 788, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 30, "lpgbts": [{"id": 788, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 9, "layer": 30, "lpgbts": [{"id": 788, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 30, "lpgbts": [{"id": 789, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 30, "lpgbts": [{"id": 789, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 30, "lpgbts": [{"id": 789, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 30, "lpgbts": [{"id": 789, "nElinks": 1}, {"id": 790, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 30, "lpgbts": [{"id": 790, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 30, "lpgbts": [{"id": 791, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 30, "lpgbts": [{"id": 791, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 30, "lpgbts": [{"id": 791, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 30, "lpgbts": [{"id": 791, "nElinks": 1}, {"id": 792, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 30, "lpgbts": [{"id": 793, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 30, "lpgbts": [{"id": 793, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 30, "lpgbts": [{"id": 793, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 5, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 30, "lpgbts": [{"id": 794, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 30, "lpgbts": [{"id": 794, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 30, "lpgbts": [{"id": 794, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 8, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 30, "lpgbts": [{"id": 795, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 30, "lpgbts": [{"id": 795, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 30, "lpgbts": [{"id": 795, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 30, "lpgbts": [{"id": 796, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 30, "lpgbts": [{"id": 796, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 30, "lpgbts": [{"id": 796, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 30, "lpgbts": [{"id": 797, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 30, "lpgbts": [{"id": 797, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 30, "lpgbts": [{"id": 797, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 30, "lpgbts": [{"id": 798, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 30, "lpgbts": [{"id": 798, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 30, "lpgbts": [{"id": 798, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 30, "lpgbts": [{"id": 798, "nElinks": 1}, {"id": 799, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 30, "lpgbts": [{"id": 799, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 30, "lpgbts": [{"id": 800, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 30, "lpgbts": [{"id": 800, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 30, "lpgbts": [{"id": 800, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 30, "lpgbts": [{"id": 800, "nElinks": 1}, {"id": 801, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 30, "lpgbts": [{"id": 801, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 30, "lpgbts": [{"id": 802, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 30, "lpgbts": [{"id": 802, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 30, "lpgbts": [{"id": 802, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 30, "lpgbts": [{"id": 802, "nElinks": 1}, {"id": 803, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 30, "lpgbts": [{"id": 803, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 11, "layer": 30, "lpgbts": [{"id": 803, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 30, "lpgbts": [{"id": 804, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 30, "lpgbts": [{"id": 804, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 30, "lpgbts": [{"id": 804, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 30, "lpgbts": [{"id": 804, "nElinks": 1}, {"id": 805, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 30, "lpgbts": [{"id": 805, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 11, "layer": 30, "lpgbts": [{"id": 805, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 30, "lpgbts": [{"id": 806, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 30, "lpgbts": [{"id": 806, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 30, "lpgbts": [{"id": 806, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 30, "lpgbts": [{"id": 806, "nElinks": 1}, {"id": 807, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 30, "lpgbts": [{"id": 807, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 30, "lpgbts": [{"id": 807, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 30, "lpgbts": [{"id": 808, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 30, "lpgbts": [{"id": 808, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 30, "lpgbts": [{"id": 808, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 30, "lpgbts": [{"id": 808, "nElinks": 1}, {"id": 809, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 30, "lpgbts": [{"id": 809, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 30, "lpgbts": [{"id": 810, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 30, "lpgbts": [{"id": 810, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 30, "lpgbts": [{"id": 810, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 30, "lpgbts": [{"id": 810, "nElinks": 1}, {"id": 811, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 12, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 30, "lpgbts": [{"id": 812, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 30, "lpgbts": [{"id": 812, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 30, "lpgbts": [{"id": 812, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 12, "layer": 30, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 30, "lpgbts": [{"id": 813, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 30, "lpgbts": [{"id": 813, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 12, "layer": 30, "lpgbts": [{"id": 813, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 30, "lpgbts": [{"id": 813, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 12, "layer": 30, "lpgbts": [{"id": 814, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 31, "lpgbts": [{"id": 815, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 31, "lpgbts": [{"id": 815, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 31, "lpgbts": [{"id": 815, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 31, "lpgbts": [{"id": 816, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 31, "lpgbts": [{"id": 816, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 31, "lpgbts": [{"id": 816, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 31, "lpgbts": [{"id": 816, "nElinks": 1}, {"id": 817, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 31, "lpgbts": [{"id": 817, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 0, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 31, "lpgbts": [{"id": 818, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 31, "lpgbts": [{"id": 818, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 31, "lpgbts": [{"id": 818, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 31, "lpgbts": [{"id": 819, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 31, "lpgbts": [{"id": 819, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 31, "lpgbts": [{"id": 819, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 31, "lpgbts": [{"id": 820, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 31, "lpgbts": [{"id": 820, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 31, "lpgbts": [{"id": 820, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 31, "lpgbts": [{"id": 821, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 31, "lpgbts": [{"id": 821, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 31, "lpgbts": [{"id": 821, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 31, "lpgbts": [{"id": 821, "nElinks": 1}, {"id": 822, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 31, "lpgbts": [{"id": 822, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 31, "lpgbts": [{"id": 823, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 31, "lpgbts": [{"id": 823, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 31, "lpgbts": [{"id": 823, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 31, "lpgbts": [{"id": 823, "nElinks": 1}, {"id": 824, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 31, "lpgbts": [{"id": 824, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 31, "lpgbts": [{"id": 825, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 31, "lpgbts": [{"id": 825, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 31, "lpgbts": [{"id": 825, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 31, "lpgbts": [{"id": 825, "nElinks": 1}, {"id": 826, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 31, "lpgbts": [{"id": 826, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 31, "lpgbts": [{"id": 827, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 31, "lpgbts": [{"id": 827, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 31, "lpgbts": [{"id": 827, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 31, "lpgbts": [{"id": 827, "nElinks": 1}, {"id": 828, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 31, "lpgbts": [{"id": 828, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 31, "lpgbts": [{"id": 829, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 31, "lpgbts": [{"id": 829, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 31, "lpgbts": [{"id": 829, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 31, "lpgbts": [{"id": 829, "nElinks": 1}, {"id": 830, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 31, "lpgbts": [{"id": 830, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 31, "lpgbts": [{"id": 831, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 31, "lpgbts": [{"id": 831, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 31, "lpgbts": [{"id": 831, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 31, "lpgbts": [{"id": 831, "nElinks": 1}, {"id": 832, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 31, "lpgbts": [{"id": 832, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 31, "lpgbts": [{"id": 833, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 31, "lpgbts": [{"id": 833, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 31, "lpgbts": [{"id": 833, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 31, "lpgbts": [{"id": 833, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 31, "lpgbts": [{"id": 834, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 31, "lpgbts": [{"id": 834, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 31, "lpgbts": [{"id": 834, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 31, "lpgbts": [{"id": 834, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 31, "lpgbts": [{"id": 835, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 31, "lpgbts": [{"id": 836, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 31, "lpgbts": [{"id": 836, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 31, "lpgbts": [{"id": 836, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 31, "lpgbts": [{"id": 837, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 31, "lpgbts": [{"id": 837, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 31, "lpgbts": [{"id": 837, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 31, "lpgbts": [{"id": 838, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 31, "lpgbts": [{"id": 838, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 31, "lpgbts": [{"id": 838, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 31, "lpgbts": [{"id": 839, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 31, "lpgbts": [{"id": 839, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 31, "lpgbts": [{"id": 839, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 31, "lpgbts": [{"id": 840, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 31, "lpgbts": [{"id": 840, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 31, "lpgbts": [{"id": 840, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 31, "lpgbts": [{"id": 840, "nElinks": 1}, {"id": 841, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 9, "layer": 31, "lpgbts": [{"id": 841, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 31, "lpgbts": [{"id": 842, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 31, "lpgbts": [{"id": 842, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 31, "lpgbts": [{"id": 842, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 31, "lpgbts": [{"id": 842, "nElinks": 1}, {"id": 843, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 31, "lpgbts": [{"id": 843, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 31, "lpgbts": [{"id": 844, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 31, "lpgbts": [{"id": 844, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 31, "lpgbts": [{"id": 844, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 31, "lpgbts": [{"id": 844, "nElinks": 1}, {"id": 845, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 31, "lpgbts": [{"id": 845, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 31, "lpgbts": [{"id": 845, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 31, "lpgbts": [{"id": 846, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 31, "lpgbts": [{"id": 846, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 31, "lpgbts": [{"id": 846, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 31, "lpgbts": [{"id": 846, "nElinks": 1}, {"id": 847, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 31, "lpgbts": [{"id": 847, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 31, "lpgbts": [{"id": 847, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 31, "lpgbts": [{"id": 848, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 31, "lpgbts": [{"id": 848, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 31, "lpgbts": [{"id": 848, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 31, "lpgbts": [{"id": 848, "nElinks": 1}, {"id": 849, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 31, "lpgbts": [{"id": 849, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 31, "lpgbts": [{"id": 849, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 31, "lpgbts": [{"id": 850, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 31, "lpgbts": [{"id": 850, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 31, "lpgbts": [{"id": 850, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 31, "lpgbts": [{"id": 850, "nElinks": 1}, {"id": 851, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 31, "lpgbts": [{"id": 851, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 31, "lpgbts": [{"id": 851, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 31, "lpgbts": [{"id": 852, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 31, "lpgbts": [{"id": 852, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 31, "lpgbts": [{"id": 852, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 31, "lpgbts": [{"id": 852, "nElinks": 1}, {"id": 853, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 31, "lpgbts": [{"id": 853, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 31, "lpgbts": [{"id": 854, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 31, "lpgbts": [{"id": 854, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 31, "lpgbts": [{"id": 854, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 31, "lpgbts": [{"id": 854, "nElinks": 1}, {"id": 855, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 31, "lpgbts": [{"id": 856, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 31, "lpgbts": [{"id": 856, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 31, "lpgbts": [{"id": 856, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 31, "lpgbts": [{"id": 857, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 31, "lpgbts": [{"id": 857, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 31, "lpgbts": [{"id": 857, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 31, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 32, "lpgbts": [{"id": 858, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 32, "lpgbts": [{"id": 858, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 32, "lpgbts": [{"id": 858, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 32, "lpgbts": [{"id": 859, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 32, "lpgbts": [{"id": 859, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 32, "lpgbts": [{"id": 859, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 32, "lpgbts": [{"id": 860, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 32, "lpgbts": [{"id": 860, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 32, "lpgbts": [{"id": 860, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 32, "lpgbts": [{"id": 861, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 32, "lpgbts": [{"id": 861, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 32, "lpgbts": [{"id": 861, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 32, "lpgbts": [{"id": 862, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 32, "lpgbts": [{"id": 862, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 32, "lpgbts": [{"id": 862, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 32, "lpgbts": [{"id": 862, "nElinks": 1}, {"id": 863, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 32, "lpgbts": [{"id": 863, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 32, "lpgbts": [{"id": 864, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 32, "lpgbts": [{"id": 864, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 32, "lpgbts": [{"id": 864, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 32, "lpgbts": [{"id": 864, "nElinks": 1}, {"id": 865, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 10, "layer": 32, "lpgbts": [{"id": 865, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 32, "lpgbts": [{"id": 866, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 32, "lpgbts": [{"id": 866, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 32, "lpgbts": [{"id": 866, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 32, "lpgbts": [{"id": 866, "nElinks": 1}, {"id": 867, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 32, "lpgbts": [{"id": 867, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 32, "lpgbts": [{"id": 867, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 32, "lpgbts": [{"id": 868, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 32, "lpgbts": [{"id": 868, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 32, "lpgbts": [{"id": 868, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 32, "lpgbts": [{"id": 868, "nElinks": 1}, {"id": 869, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 32, "lpgbts": [{"id": 869, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 10, "layer": 32, "lpgbts": [{"id": 869, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 32, "lpgbts": [{"id": 870, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 32, "lpgbts": [{"id": 870, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 32, "lpgbts": [{"id": 870, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 32, "lpgbts": [{"id": 870, "nElinks": 1}, {"id": 871, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 32, "lpgbts": [{"id": 871, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 32, "lpgbts": [{"id": 871, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 32, "lpgbts": [{"id": 872, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 32, "lpgbts": [{"id": 872, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 32, "lpgbts": [{"id": 872, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 32, "lpgbts": [{"id": 872, "nElinks": 1}, {"id": 873, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 32, "lpgbts": [{"id": 873, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 9, "layer": 32, "lpgbts": [{"id": 873, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 32, "lpgbts": [{"id": 874, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 32, "lpgbts": [{"id": 874, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 32, "lpgbts": [{"id": 874, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 32, "lpgbts": [{"id": 874, "nElinks": 1}, {"id": 875, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 32, "lpgbts": [{"id": 875, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 4, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 32, "lpgbts": [{"id": 876, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 32, "lpgbts": [{"id": 876, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 32, "lpgbts": [{"id": 876, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 32, "lpgbts": [{"id": 876, "nElinks": 1}, {"id": 877, "nElinks": 1}]},
+        {"isSilicon": true, "u": 12, "v": 9, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 32, "lpgbts": [{"id": 878, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 32, "lpgbts": [{"id": 878, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 32, "lpgbts": [{"id": 878, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 8, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 32, "lpgbts": [{"id": 879, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 32, "lpgbts": [{"id": 879, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 5, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 32, "lpgbts": [{"id": 879, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 32, "lpgbts": [{"id": 880, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 32, "lpgbts": [{"id": 880, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 32, "lpgbts": [{"id": 880, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 32, "lpgbts": [{"id": 881, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 32, "lpgbts": [{"id": 881, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 32, "lpgbts": [{"id": 881, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 32, "lpgbts": [{"id": 882, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 32, "lpgbts": [{"id": 882, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 32, "lpgbts": [{"id": 882, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 32, "lpgbts": [{"id": 883, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 32, "lpgbts": [{"id": 883, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 32, "lpgbts": [{"id": 883, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 32, "lpgbts": [{"id": 883, "nElinks": 1}, {"id": 884, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 32, "lpgbts": [{"id": 884, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 11, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 32, "lpgbts": [{"id": 885, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 32, "lpgbts": [{"id": 885, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 32, "lpgbts": [{"id": 885, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 32, "lpgbts": [{"id": 885, "nElinks": 1}, {"id": 886, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 32, "lpgbts": [{"id": 886, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 11, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 32, "lpgbts": [{"id": 887, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 32, "lpgbts": [{"id": 887, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 32, "lpgbts": [{"id": 887, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 32, "lpgbts": [{"id": 887, "nElinks": 1}, {"id": 888, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 32, "lpgbts": [{"id": 888, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 11, "layer": 32, "lpgbts": [{"id": 888, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 32, "lpgbts": [{"id": 889, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 32, "lpgbts": [{"id": 889, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 32, "lpgbts": [{"id": 889, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 32, "lpgbts": [{"id": 889, "nElinks": 1}, {"id": 890, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 32, "lpgbts": [{"id": 890, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 11, "layer": 32, "lpgbts": [{"id": 890, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 32, "lpgbts": [{"id": 891, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 32, "lpgbts": [{"id": 891, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 32, "lpgbts": [{"id": 891, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 32, "lpgbts": [{"id": 891, "nElinks": 1}, {"id": 892, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 32, "lpgbts": [{"id": 892, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 32, "lpgbts": [{"id": 892, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 12, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 32, "lpgbts": [{"id": 893, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 32, "lpgbts": [{"id": 893, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 32, "lpgbts": [{"id": 893, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 32, "lpgbts": [{"id": 893, "nElinks": 1}, {"id": 894, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 32, "lpgbts": [{"id": 894, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 12, "layer": 32, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 32, "lpgbts": [{"id": 895, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 32, "lpgbts": [{"id": 895, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 32, "lpgbts": [{"id": 895, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 32, "lpgbts": [{"id": 895, "nElinks": 1}, {"id": 896, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 12, "layer": 32, "lpgbts": [{"id": 896, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 32, "lpgbts": [{"id": 897, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 32, "lpgbts": [{"id": 897, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 32, "lpgbts": [{"id": 897, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 12, "layer": 32, "lpgbts": [{"id": 897, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 32, "lpgbts": [{"id": 898, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 32, "lpgbts": [{"id": 898, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 12, "layer": 32, "lpgbts": [{"id": 898, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 32, "lpgbts": [{"id": 898, "nElinks": 1}, {"id": 899, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 12, "layer": 32, "lpgbts": [{"id": 899, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 33, "lpgbts": [{"id": 900, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 33, "lpgbts": [{"id": 900, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 33, "lpgbts": [{"id": 900, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 33, "lpgbts": [{"id": 901, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 33, "lpgbts": [{"id": 901, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 33, "lpgbts": [{"id": 901, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 33, "lpgbts": [{"id": 902, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 33, "lpgbts": [{"id": 902, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 33, "lpgbts": [{"id": 902, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 33, "lpgbts": [{"id": 903, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 33, "lpgbts": [{"id": 903, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 33, "lpgbts": [{"id": 903, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 33, "lpgbts": [{"id": 904, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 33, "lpgbts": [{"id": 904, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 33, "lpgbts": [{"id": 904, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 33, "lpgbts": [{"id": 904, "nElinks": 1}, {"id": 905, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 33, "lpgbts": [{"id": 905, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 0, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 33, "lpgbts": [{"id": 906, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 33, "lpgbts": [{"id": 906, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 33, "lpgbts": [{"id": 906, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 33, "lpgbts": [{"id": 906, "nElinks": 1}, {"id": 907, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 33, "lpgbts": [{"id": 907, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 33, "lpgbts": [{"id": 908, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 33, "lpgbts": [{"id": 908, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 33, "lpgbts": [{"id": 908, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 33, "lpgbts": [{"id": 908, "nElinks": 1}, {"id": 909, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 33, "lpgbts": [{"id": 909, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 33, "lpgbts": [{"id": 910, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 33, "lpgbts": [{"id": 910, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 33, "lpgbts": [{"id": 910, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 33, "lpgbts": [{"id": 910, "nElinks": 1}, {"id": 911, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 33, "lpgbts": [{"id": 911, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 33, "lpgbts": [{"id": 912, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 33, "lpgbts": [{"id": 912, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 33, "lpgbts": [{"id": 912, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 33, "lpgbts": [{"id": 912, "nElinks": 1}, {"id": 913, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 33, "lpgbts": [{"id": 913, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 33, "lpgbts": [{"id": 914, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 33, "lpgbts": [{"id": 914, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 33, "lpgbts": [{"id": 914, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 33, "lpgbts": [{"id": 914, "nElinks": 1}, {"id": 915, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 33, "lpgbts": [{"id": 915, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 33, "lpgbts": [{"id": 916, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 33, "lpgbts": [{"id": 916, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 33, "lpgbts": [{"id": 916, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 33, "lpgbts": [{"id": 916, "nElinks": 1}, {"id": 917, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 33, "lpgbts": [{"id": 917, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 33, "lpgbts": [{"id": 918, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 33, "lpgbts": [{"id": 918, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 33, "lpgbts": [{"id": 918, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 33, "lpgbts": [{"id": 918, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 33, "lpgbts": [{"id": 919, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 33, "lpgbts": [{"id": 919, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 33, "lpgbts": [{"id": 919, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 33, "lpgbts": [{"id": 920, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 33, "lpgbts": [{"id": 920, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 33, "lpgbts": [{"id": 921, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 33, "lpgbts": [{"id": 921, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 33, "lpgbts": [{"id": 921, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 33, "lpgbts": [{"id": 922, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 33, "lpgbts": [{"id": 922, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 33, "lpgbts": [{"id": 922, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 33, "lpgbts": [{"id": 923, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 33, "lpgbts": [{"id": 923, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 33, "lpgbts": [{"id": 923, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 33, "lpgbts": [{"id": 924, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 33, "lpgbts": [{"id": 924, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 33, "lpgbts": [{"id": 924, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 33, "lpgbts": [{"id": 925, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 33, "lpgbts": [{"id": 925, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 33, "lpgbts": [{"id": 925, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 33, "lpgbts": [{"id": 925, "nElinks": 1}, {"id": 926, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 33, "lpgbts": [{"id": 926, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 33, "lpgbts": [{"id": 927, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 33, "lpgbts": [{"id": 927, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 33, "lpgbts": [{"id": 927, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 33, "lpgbts": [{"id": 927, "nElinks": 1}, {"id": 928, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 9, "layer": 33, "lpgbts": [{"id": 928, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 33, "lpgbts": [{"id": 929, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 33, "lpgbts": [{"id": 929, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 33, "lpgbts": [{"id": 929, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 33, "lpgbts": [{"id": 929, "nElinks": 1}, {"id": 930, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 33, "lpgbts": [{"id": 930, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 33, "lpgbts": [{"id": 930, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 33, "lpgbts": [{"id": 931, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 33, "lpgbts": [{"id": 931, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 33, "lpgbts": [{"id": 931, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 33, "lpgbts": [{"id": 931, "nElinks": 1}, {"id": 932, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 33, "lpgbts": [{"id": 932, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 33, "lpgbts": [{"id": 932, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 33, "lpgbts": [{"id": 933, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 33, "lpgbts": [{"id": 933, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 33, "lpgbts": [{"id": 933, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 33, "lpgbts": [{"id": 933, "nElinks": 1}, {"id": 934, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 33, "lpgbts": [{"id": 934, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 33, "lpgbts": [{"id": 934, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 33, "lpgbts": [{"id": 935, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 33, "lpgbts": [{"id": 935, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 33, "lpgbts": [{"id": 935, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 33, "lpgbts": [{"id": 935, "nElinks": 1}, {"id": 936, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 33, "lpgbts": [{"id": 936, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 33, "lpgbts": [{"id": 936, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 33, "lpgbts": [{"id": 937, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 33, "lpgbts": [{"id": 937, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 33, "lpgbts": [{"id": 937, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 33, "lpgbts": [{"id": 937, "nElinks": 1}, {"id": 938, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 33, "lpgbts": [{"id": 938, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 33, "lpgbts": [{"id": 939, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 33, "lpgbts": [{"id": 939, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 33, "lpgbts": [{"id": 939, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 33, "lpgbts": [{"id": 939, "nElinks": 1}, {"id": 940, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 33, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 33, "lpgbts": [{"id": 941, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 33, "lpgbts": [{"id": 941, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 33, "lpgbts": [{"id": 941, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 33, "lpgbts": [{"id": 941, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 33, "lpgbts": [{"id": 942, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 33, "lpgbts": [{"id": 942, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 33, "lpgbts": [{"id": 942, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 33, "lpgbts": [{"id": 942, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 34, "lpgbts": [{"id": 943, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 34, "lpgbts": [{"id": 943, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 34, "lpgbts": [{"id": 943, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 34, "lpgbts": [{"id": 944, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 34, "lpgbts": [{"id": 944, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 34, "lpgbts": [{"id": 944, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 34, "lpgbts": [{"id": 945, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 34, "lpgbts": [{"id": 945, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 34, "lpgbts": [{"id": 945, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 34, "lpgbts": [{"id": 946, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 34, "lpgbts": [{"id": 946, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 34, "lpgbts": [{"id": 946, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 34, "lpgbts": [{"id": 947, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 34, "lpgbts": [{"id": 947, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 34, "lpgbts": [{"id": 947, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 34, "lpgbts": [{"id": 947, "nElinks": 1}, {"id": 948, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 34, "lpgbts": [{"id": 948, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 34, "lpgbts": [{"id": 949, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 34, "lpgbts": [{"id": 949, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 34, "lpgbts": [{"id": 949, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 34, "lpgbts": [{"id": 949, "nElinks": 1}, {"id": 950, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 10, "layer": 34, "lpgbts": [{"id": 950, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 34, "lpgbts": [{"id": 951, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 34, "lpgbts": [{"id": 951, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 34, "lpgbts": [{"id": 951, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 34, "lpgbts": [{"id": 951, "nElinks": 1}, {"id": 952, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 34, "lpgbts": [{"id": 952, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 34, "lpgbts": [{"id": 952, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 34, "lpgbts": [{"id": 953, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 34, "lpgbts": [{"id": 953, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 34, "lpgbts": [{"id": 953, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 34, "lpgbts": [{"id": 953, "nElinks": 1}, {"id": 954, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 34, "lpgbts": [{"id": 954, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 10, "layer": 34, "lpgbts": [{"id": 954, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 34, "lpgbts": [{"id": 955, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 34, "lpgbts": [{"id": 955, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 34, "lpgbts": [{"id": 955, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 34, "lpgbts": [{"id": 955, "nElinks": 1}, {"id": 956, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 34, "lpgbts": [{"id": 956, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 34, "lpgbts": [{"id": 956, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 34, "lpgbts": [{"id": 957, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 34, "lpgbts": [{"id": 957, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 34, "lpgbts": [{"id": 957, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 34, "lpgbts": [{"id": 957, "nElinks": 1}, {"id": 958, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 34, "lpgbts": [{"id": 958, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 9, "layer": 34, "lpgbts": [{"id": 958, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 34, "lpgbts": [{"id": 959, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 34, "lpgbts": [{"id": 959, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 34, "lpgbts": [{"id": 959, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 34, "lpgbts": [{"id": 959, "nElinks": 1}, {"id": 960, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 34, "lpgbts": [{"id": 960, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 4, "layer": 34, "lpgbts": [{"id": 960, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 34, "lpgbts": [{"id": 961, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 34, "lpgbts": [{"id": 961, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 34, "lpgbts": [{"id": 961, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 34, "lpgbts": [{"id": 961, "nElinks": 1}, {"id": 962, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 34, "lpgbts": [{"id": 963, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 34, "lpgbts": [{"id": 963, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 5, "layer": 34, "lpgbts": [{"id": 963, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 34, "lpgbts": [{"id": 964, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 34, "lpgbts": [{"id": 964, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 6, "layer": 34, "lpgbts": [{"id": 964, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 34, "lpgbts": [{"id": 964, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 34, "lpgbts": [{"id": 965, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 34, "lpgbts": [{"id": 965, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 34, "lpgbts": [{"id": 965, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 34, "lpgbts": [{"id": 966, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 34, "lpgbts": [{"id": 966, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 34, "lpgbts": [{"id": 966, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 34, "lpgbts": [{"id": 967, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 34, "lpgbts": [{"id": 967, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 34, "lpgbts": [{"id": 967, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 34, "lpgbts": [{"id": 968, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 34, "lpgbts": [{"id": 968, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 34, "lpgbts": [{"id": 968, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 34, "lpgbts": [{"id": 969, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 34, "lpgbts": [{"id": 969, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 34, "lpgbts": [{"id": 969, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 34, "lpgbts": [{"id": 970, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 34, "lpgbts": [{"id": 970, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 11, "layer": 34, "lpgbts": [{"id": 970, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 34, "lpgbts": [{"id": 971, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 34, "lpgbts": [{"id": 971, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 34, "lpgbts": [{"id": 971, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 34, "lpgbts": [{"id": 972, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 34, "lpgbts": [{"id": 972, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 34, "lpgbts": [{"id": 972, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 34, "lpgbts": [{"id": 973, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 34, "lpgbts": [{"id": 973, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 34, "lpgbts": [{"id": 973, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 34, "lpgbts": [{"id": 974, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 34, "lpgbts": [{"id": 974, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 34, "lpgbts": [{"id": 974, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 34, "lpgbts": [{"id": 974, "nElinks": 1}, {"id": 975, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 34, "lpgbts": [{"id": 975, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 12, "layer": 34, "lpgbts": [{"id": 975, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 34, "lpgbts": [{"id": 976, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 34, "lpgbts": [{"id": 976, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 11, "layer": 34, "lpgbts": [{"id": 976, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 12, "layer": 34, "lpgbts": [{"id": 976, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 34, "lpgbts": [{"id": 977, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 34, "lpgbts": [{"id": 977, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 11, "layer": 34, "lpgbts": [{"id": 977, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 34, "lpgbts": [{"id": 978, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 34, "lpgbts": [{"id": 978, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 11, "layer": 34, "lpgbts": [{"id": 978, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 12, "layer": 34, "lpgbts": [{"id": 978, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 34, "lpgbts": [{"id": 979, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 34, "lpgbts": [{"id": 979, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 34, "lpgbts": [{"id": 979, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 34, "lpgbts": [{"id": 979, "nElinks": 1}, {"id": 980, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 12, "layer": 34, "lpgbts": [{"id": 980, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 34, "lpgbts": [{"id": 981, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 34, "lpgbts": [{"id": 981, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 34, "lpgbts": [{"id": 981, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 12, "layer": 34, "lpgbts": [{"id": 981, "nElinks": 1}, {"id": 982, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 34, "lpgbts": [{"id": 983, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 34, "lpgbts": [{"id": 983, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 34, "lpgbts": [{"id": 983, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 12, "layer": 34, "lpgbts": [{"id": 983, "nElinks": 1}, {"id": 984, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 13, "layer": 34, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 34, "lpgbts": [{"id": 985, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 34, "lpgbts": [{"id": 985, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 12, "layer": 34, "lpgbts": [{"id": 985, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 34, "lpgbts": [{"id": 985, "nElinks": 1}, {"id": 986, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 12, "layer": 34, "lpgbts": [{"id": 986, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 12, "layer": 34, "lpgbts": [{"id": 986, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 13, "layer": 34, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 0, "layer": 35, "lpgbts": [{"id": 987, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 35, "lpgbts": [{"id": 987, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 35, "lpgbts": [{"id": 987, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 35, "lpgbts": [{"id": 988, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 35, "lpgbts": [{"id": 988, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 35, "lpgbts": [{"id": 988, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 35, "lpgbts": [{"id": 989, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 35, "lpgbts": [{"id": 989, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 35, "lpgbts": [{"id": 989, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 35, "lpgbts": [{"id": 990, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 35, "lpgbts": [{"id": 990, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 35, "lpgbts": [{"id": 990, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 35, "lpgbts": [{"id": 991, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 35, "lpgbts": [{"id": 991, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 35, "lpgbts": [{"id": 991, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 35, "lpgbts": [{"id": 991, "nElinks": 1}, {"id": 992, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 35, "lpgbts": [{"id": 992, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 0, "layer": 35, "lpgbts": [{"id": 992, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 0, "layer": 35, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 35, "lpgbts": [{"id": 993, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 35, "lpgbts": [{"id": 993, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 35, "lpgbts": [{"id": 993, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 35, "lpgbts": [{"id": 993, "nElinks": 1}, {"id": 994, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 35, "lpgbts": [{"id": 994, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 35, "lpgbts": [{"id": 994, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 35, "lpgbts": [{"id": 995, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 35, "lpgbts": [{"id": 995, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 35, "lpgbts": [{"id": 995, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 35, "lpgbts": [{"id": 995, "nElinks": 1}, {"id": 996, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 35, "lpgbts": [{"id": 996, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 1, "layer": 35, "lpgbts": [{"id": 996, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 35, "lpgbts": [{"id": 997, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 35, "lpgbts": [{"id": 997, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 35, "lpgbts": [{"id": 997, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 35, "lpgbts": [{"id": 997, "nElinks": 1}, {"id": 998, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 35, "lpgbts": [{"id": 998, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 9, "layer": 35, "lpgbts": [{"id": 998, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 35, "lpgbts": [{"id": 999, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 35, "lpgbts": [{"id": 999, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 35, "lpgbts": [{"id": 999, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 35, "lpgbts": [{"id": 999, "nElinks": 1}, {"id": 1000, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 35, "lpgbts": [{"id": 1000, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 35, "lpgbts": [{"id": 1000, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 2, "layer": 35, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 35, "lpgbts": [{"id": 1001, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 35, "lpgbts": [{"id": 1001, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 35, "lpgbts": [{"id": 1001, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 35, "lpgbts": [{"id": 1001, "nElinks": 1}, {"id": 1002, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 35, "lpgbts": [{"id": 1002, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 35, "lpgbts": [{"id": 1002, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 35, "lpgbts": [{"id": 1003, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 35, "lpgbts": [{"id": 1003, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 35, "lpgbts": [{"id": 1003, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 35, "lpgbts": [{"id": 1003, "nElinks": 1}, {"id": 1004, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 35, "lpgbts": [{"id": 1004, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 3, "layer": 35, "lpgbts": [{"id": 1004, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 35, "lpgbts": [{"id": 1005, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 35, "lpgbts": [{"id": 1005, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 35, "lpgbts": [{"id": 1005, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 35, "lpgbts": [{"id": 1005, "nElinks": 1}, {"id": 1006, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 35, "lpgbts": [{"id": 1007, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 35, "lpgbts": [{"id": 1007, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 35, "lpgbts": [{"id": 1007, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 4, "layer": 35, "lpgbts": [{"id": 1007, "nElinks": 1}, {"id": 1008, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 35, "lpgbts": [{"id": 1009, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 35, "lpgbts": [{"id": 1009, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 35, "lpgbts": [{"id": 1009, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 2, "layer": 35, "lpgbts": [{"id": 1010, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 35, "lpgbts": [{"id": 1010, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 35, "lpgbts": [{"id": 1010, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 35, "lpgbts": [{"id": 1011, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 35, "lpgbts": [{"id": 1011, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 35, "lpgbts": [{"id": 1011, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 2, "layer": 35, "lpgbts": [{"id": 1012, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 35, "lpgbts": [{"id": 1012, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 35, "lpgbts": [{"id": 1012, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 35, "lpgbts": [{"id": 1013, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 35, "lpgbts": [{"id": 1013, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 35, "lpgbts": [{"id": 1013, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 35, "lpgbts": [{"id": 1014, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 35, "lpgbts": [{"id": 1014, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 35, "lpgbts": [{"id": 1014, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 35, "lpgbts": [{"id": 1014, "nElinks": 1}, {"id": 1015, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 35, "lpgbts": [{"id": 1015, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 10, "layer": 35, "lpgbts": [{"id": 1015, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 35, "lpgbts": [{"id": 1016, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 35, "lpgbts": [{"id": 1016, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 35, "lpgbts": [{"id": 1016, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 35, "lpgbts": [{"id": 1016, "nElinks": 1}, {"id": 1017, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 9, "layer": 35, "lpgbts": [{"id": 1017, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 10, "layer": 35, "lpgbts": [{"id": 1017, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 35, "lpgbts": [{"id": 1018, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 35, "lpgbts": [{"id": 1018, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 35, "lpgbts": [{"id": 1018, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 35, "lpgbts": [{"id": 1019, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 35, "lpgbts": [{"id": 1019, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 35, "lpgbts": [{"id": 1019, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 11, "layer": 35, "lpgbts": [{"id": 1019, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 35, "lpgbts": [{"id": 1020, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 35, "lpgbts": [{"id": 1020, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 35, "lpgbts": [{"id": 1020, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 35, "lpgbts": [{"id": 1021, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 35, "lpgbts": [{"id": 1021, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 35, "lpgbts": [{"id": 1021, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 11, "layer": 35, "lpgbts": [{"id": 1021, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 35, "lpgbts": [{"id": 1022, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 35, "lpgbts": [{"id": 1022, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 35, "lpgbts": [{"id": 1022, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 35, "lpgbts": [{"id": 1022, "nElinks": 1}, {"id": 1023, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 35, "lpgbts": [{"id": 1024, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 35, "lpgbts": [{"id": 1024, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 11, "layer": 35, "lpgbts": [{"id": 1024, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 35, "lpgbts": [{"id": 1025, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 35, "lpgbts": [{"id": 1025, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 35, "lpgbts": [{"id": 1025, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 35, "lpgbts": [{"id": 1025, "nElinks": 1}, {"id": 1026, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 35, "lpgbts": [{"id": 1027, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 35, "lpgbts": [{"id": 1027, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 11, "layer": 35, "lpgbts": [{"id": 1027, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 35, "lpgbts": [{"id": 1028, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 35, "lpgbts": [{"id": 1028, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 35, "lpgbts": [{"id": 1028, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 35, "lpgbts": [{"id": 1028, "nElinks": 1}, {"id": 1029, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 35, "lpgbts": [{"id": 1029, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 35, "lpgbts": [{"id": 1029, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 35, "lpgbts": [{"id": 1030, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 35, "lpgbts": [{"id": 1030, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 35, "lpgbts": [{"id": 1030, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 35, "lpgbts": [{"id": 1030, "nElinks": 1}, {"id": 1031, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 35, "lpgbts": [{"id": 1031, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 35, "lpgbts": [{"id": 1032, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 35, "lpgbts": [{"id": 1032, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 35, "lpgbts": [{"id": 1032, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 35, "lpgbts": [{"id": 1032, "nElinks": 1}, {"id": 1033, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 12, "layer": 35, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 35, "lpgbts": [{"id": 1034, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 35, "lpgbts": [{"id": 1034, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 35, "lpgbts": [{"id": 1034, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 12, "layer": 35, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 35, "lpgbts": [{"id": 1035, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 35, "lpgbts": [{"id": 1035, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 12, "layer": 35, "lpgbts": [{"id": 1035, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 35, "lpgbts": [{"id": 1035, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 12, "layer": 35, "lpgbts": [{"id": 1036, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 36, "lpgbts": [{"id": 1037, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 36, "lpgbts": [{"id": 1037, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 36, "lpgbts": [{"id": 1037, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 36, "lpgbts": [{"id": 1038, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 36, "lpgbts": [{"id": 1038, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 36, "lpgbts": [{"id": 1038, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 36, "lpgbts": [{"id": 1039, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 36, "lpgbts": [{"id": 1039, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 36, "lpgbts": [{"id": 1039, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 36, "lpgbts": [{"id": 1040, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 36, "lpgbts": [{"id": 1040, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 36, "lpgbts": [{"id": 1040, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 36, "lpgbts": [{"id": 1041, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 36, "lpgbts": [{"id": 1041, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 36, "lpgbts": [{"id": 1041, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 36, "lpgbts": [{"id": 1041, "nElinks": 1}, {"id": 1042, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 1, "layer": 36, "lpgbts": [{"id": 1042, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 1, "layer": 36, "lpgbts": [{"id": 1042, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 2, "layer": 36, "lpgbts": [{"id": 1043, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 2, "layer": 36, "lpgbts": [{"id": 1043, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 3, "layer": 36, "lpgbts": [{"id": 1043, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 3, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 36, "lpgbts": [{"id": 1044, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 36, "lpgbts": [{"id": 1044, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 36, "lpgbts": [{"id": 1044, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 36, "lpgbts": [{"id": 1044, "nElinks": 1}, {"id": 1045, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 36, "lpgbts": [{"id": 1045, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 36, "lpgbts": [{"id": 1046, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 36, "lpgbts": [{"id": 1046, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 36, "lpgbts": [{"id": 1046, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 36, "lpgbts": [{"id": 1046, "nElinks": 1}, {"id": 1047, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 10, "layer": 36, "lpgbts": [{"id": 1047, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 11, "layer": 36, "lpgbts": [{"id": 1047, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 10, "layer": 36, "lpgbts": [{"id": 1048, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 10, "layer": 36, "lpgbts": [{"id": 1048, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 11, "layer": 36, "lpgbts": [{"id": 1048, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 11, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 36, "lpgbts": [{"id": 1049, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 36, "lpgbts": [{"id": 1049, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 36, "lpgbts": [{"id": 1049, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 36, "lpgbts": [{"id": 1049, "nElinks": 1}, {"id": 1050, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 36, "lpgbts": [{"id": 1050, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 36, "lpgbts": [{"id": 1051, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 36, "lpgbts": [{"id": 1051, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 36, "lpgbts": [{"id": 1051, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 36, "lpgbts": [{"id": 1051, "nElinks": 1}, {"id": 1052, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 36, "lpgbts": [{"id": 1052, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 3, "layer": 36, "lpgbts": [{"id": 1052, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 36, "lpgbts": [{"id": 1053, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 36, "lpgbts": [{"id": 1053, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 36, "lpgbts": [{"id": 1053, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 36, "lpgbts": [{"id": 1053, "nElinks": 1}, {"id": 1054, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 36, "lpgbts": [{"id": 1054, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 9, "layer": 36, "lpgbts": [{"id": 1054, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 4, "layer": 36, "lpgbts": [{"id": 1055, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 4, "layer": 36, "lpgbts": [{"id": 1055, "nElinks": 1}]},
+        {"isSilicon": true, "u": 13, "v": 5, "layer": 36, "lpgbts": [{"id": 1055, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 9, "layer": 36, "lpgbts": [{"id": 1056, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 9, "layer": 36, "lpgbts": [{"id": 1056, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 10, "layer": 36, "lpgbts": [{"id": 1056, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 36, "lpgbts": [{"id": 1057, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 36, "lpgbts": [{"id": 1057, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 36, "lpgbts": [{"id": 1057, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 36, "lpgbts": [{"id": 1057, "nElinks": 1}, {"id": 1058, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 8, "layer": 36, "lpgbts": [{"id": 1058, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 36, "lpgbts": [{"id": 1059, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 36, "lpgbts": [{"id": 1059, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 36, "lpgbts": [{"id": 1059, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 4, "layer": 36, "lpgbts": [{"id": 1059, "nElinks": 1}, {"id": 1060, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 36, "lpgbts": [{"id": 1061, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 36, "lpgbts": [{"id": 1061, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 36, "lpgbts": [{"id": 1061, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 8, "layer": 36, "lpgbts": [{"id": 1061, "nElinks": 1}, {"id": 1062, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 36, "lpgbts": [{"id": 1063, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 6, "layer": 36, "lpgbts": [{"id": 1063, "nElinks": 2}]},
+        {"isSilicon": true, "u": 13, "v": 6, "layer": 36, "lpgbts": [{"id": 1063, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 7, "layer": 36, "lpgbts": [{"id": 1063, "nElinks": 1}, {"id": 1064, "nElinks": 1}]},
+        {"isSilicon": true, "u": 13, "v": 8, "layer": 36, "lpgbts": [{"id": 1064, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 36, "lpgbts": [{"id": 1065, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 36, "lpgbts": [{"id": 1065, "nElinks": 2}]},
+        {"isSilicon": true, "u": 12, "v": 5, "layer": 36, "lpgbts": [{"id": 1065, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 36, "lpgbts": [{"id": 1066, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 36, "lpgbts": [{"id": 1066, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 36, "lpgbts": [{"id": 1066, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 36, "lpgbts": [{"id": 1066, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 36, "lpgbts": [{"id": 1067, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 36, "lpgbts": [{"id": 1067, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 36, "lpgbts": [{"id": 1067, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 36, "lpgbts": [{"id": 1067, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 36, "lpgbts": [{"id": 1068, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 36, "lpgbts": [{"id": 1068, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 36, "lpgbts": [{"id": 1068, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 36, "lpgbts": [{"id": 1069, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 36, "lpgbts": [{"id": 1069, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 36, "lpgbts": [{"id": 1069, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 36, "lpgbts": [{"id": 1070, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 36, "lpgbts": [{"id": 1070, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 36, "lpgbts": [{"id": 1070, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 36, "lpgbts": [{"id": 1070, "nElinks": 1}, {"id": 1071, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 11, "layer": 36, "lpgbts": [{"id": 1071, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 12, "layer": 36, "lpgbts": [{"id": 1071, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 36, "lpgbts": [{"id": 1072, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 36, "lpgbts": [{"id": 1072, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 36, "lpgbts": [{"id": 1072, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 36, "lpgbts": [{"id": 1072, "nElinks": 1}, {"id": 1073, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 11, "layer": 36, "lpgbts": [{"id": 1073, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 12, "layer": 36, "lpgbts": [{"id": 1073, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 36, "lpgbts": [{"id": 1074, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 36, "lpgbts": [{"id": 1074, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 36, "lpgbts": [{"id": 1074, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 36, "lpgbts": [{"id": 1074, "nElinks": 1}, {"id": 1075, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 11, "layer": 36, "lpgbts": [{"id": 1075, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 12, "layer": 36, "lpgbts": [{"id": 1075, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 13, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 36, "lpgbts": [{"id": 1076, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 36, "lpgbts": [{"id": 1076, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 36, "lpgbts": [{"id": 1076, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 36, "lpgbts": [{"id": 1076, "nElinks": 1}, {"id": 1077, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 11, "layer": 36, "lpgbts": [{"id": 1077, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 12, "layer": 36, "lpgbts": [{"id": 1077, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 13, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 36, "lpgbts": [{"id": 1078, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 36, "lpgbts": [{"id": 1078, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 36, "lpgbts": [{"id": 1078, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 36, "lpgbts": [{"id": 1079, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 36, "lpgbts": [{"id": 1079, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 12, "layer": 36, "lpgbts": [{"id": 1079, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 13, "layer": 36, "lpgbts": [{"id": 1079, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 36, "lpgbts": [{"id": 1080, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 36, "lpgbts": [{"id": 1080, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 36, "lpgbts": [{"id": 1080, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 36, "lpgbts": [{"id": 1081, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 36, "lpgbts": [{"id": 1081, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 12, "layer": 36, "lpgbts": [{"id": 1081, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 13, "layer": 36, "lpgbts": [{"id": 1081, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 36, "lpgbts": [{"id": 1082, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 36, "lpgbts": [{"id": 1082, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 36, "lpgbts": [{"id": 1082, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 36, "lpgbts": [{"id": 1082, "nElinks": 1}, {"id": 1083, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 12, "layer": 36, "lpgbts": [{"id": 1083, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 13, "layer": 36, "lpgbts": [{"id": 1083, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 36, "lpgbts": [{"id": 1084, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 36, "lpgbts": [{"id": 1084, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 36, "lpgbts": [{"id": 1084, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 12, "layer": 36, "lpgbts": [{"id": 1084, "nElinks": 1}, {"id": 1085, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 13, "layer": 36, "lpgbts": [{"id": 1085, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 36, "lpgbts": [{"id": 1086, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 36, "lpgbts": [{"id": 1086, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 12, "layer": 36, "lpgbts": [{"id": 1086, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 13, "layer": 36, "lpgbts": [{"id": 1086, "nElinks": 1}, {"id": 1087, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 14, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 13, "layer": 36, "lpgbts": [{"id": 1087, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 14, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 36, "lpgbts": [{"id": 1088, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 12, "layer": 36, "lpgbts": [{"id": 1088, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 12, "layer": 36, "lpgbts": [{"id": 1088, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 13, "layer": 36, "lpgbts": [{"id": 1088, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 13, "layer": 36, "lpgbts": [{"id": 1089, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 14, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 14, "layer": 36, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 37, "lpgbts": [{"id": 1090, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 37, "lpgbts": [{"id": 1090, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 37, "lpgbts": [{"id": 1090, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 37, "lpgbts": [{"id": 1091, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 37, "lpgbts": [{"id": 1091, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 37, "lpgbts": [{"id": 1091, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 37, "lpgbts": [{"id": 1092, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 37, "lpgbts": [{"id": 1092, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 37, "lpgbts": [{"id": 1092, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 37, "lpgbts": [{"id": 1093, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 37, "lpgbts": [{"id": 1093, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 37, "lpgbts": [{"id": 1093, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 37, "lpgbts": [{"id": 1094, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 37, "lpgbts": [{"id": 1094, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 37, "lpgbts": [{"id": 1094, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 37, "lpgbts": [{"id": 1095, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 37, "lpgbts": [{"id": 1095, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 37, "lpgbts": [{"id": 1095, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 37, "lpgbts": [{"id": 1096, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 37, "lpgbts": [{"id": 1096, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 37, "lpgbts": [{"id": 1096, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 37, "lpgbts": [{"id": 1097, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 37, "lpgbts": [{"id": 1097, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 37, "lpgbts": [{"id": 1097, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 37, "lpgbts": [{"id": 1098, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 37, "lpgbts": [{"id": 1098, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 37, "lpgbts": [{"id": 1098, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 37, "lpgbts": [{"id": 1099, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 37, "lpgbts": [{"id": 1099, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 37, "lpgbts": [{"id": 1099, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 37, "lpgbts": [{"id": 1100, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 37, "lpgbts": [{"id": 1100, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 37, "lpgbts": [{"id": 1100, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 37, "lpgbts": [{"id": 1100, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 37, "lpgbts": [{"id": 1101, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 37, "lpgbts": [{"id": 1101, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 37, "lpgbts": [{"id": 1101, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 37, "lpgbts": [{"id": 1101, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 37, "lpgbts": [{"id": 1102, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 37, "lpgbts": [{"id": 1102, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 37, "lpgbts": [{"id": 1102, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 37, "lpgbts": [{"id": 1102, "nElinks": 1}, {"id": 1103, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 37, "lpgbts": [{"id": 1104, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 37, "lpgbts": [{"id": 1104, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 37, "lpgbts": [{"id": 1104, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 37, "lpgbts": [{"id": 1104, "nElinks": 1}, {"id": 1105, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 37, "lpgbts": [{"id": 1106, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 37, "lpgbts": [{"id": 1106, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 37, "lpgbts": [{"id": 1106, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 37, "lpgbts": [{"id": 1106, "nElinks": 1}, {"id": 1107, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 37, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 37, "lpgbts": [{"id": 1108, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 37, "lpgbts": [{"id": 1108, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 37, "lpgbts": [{"id": 1108, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 37, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 37, "lpgbts": [{"id": 1109, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 37, "lpgbts": [{"id": 1109, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 37, "lpgbts": [{"id": 1109, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 37, "lpgbts": [{"id": 1110, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 37, "lpgbts": [{"id": 1110, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 37, "lpgbts": [{"id": 1110, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 37, "lpgbts": [{"id": 1111, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 37, "lpgbts": [{"id": 1111, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 37, "lpgbts": [{"id": 1111, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 37, "lpgbts": [{"id": 1111, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 37, "lpgbts": [{"id": 1112, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 37, "lpgbts": [{"id": 1112, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 37, "lpgbts": [{"id": 1112, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 37, "lpgbts": [{"id": 1113, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 37, "lpgbts": [{"id": 1113, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 37, "lpgbts": [{"id": 1113, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 37, "lpgbts": [{"id": 1114, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 37, "lpgbts": [{"id": 1114, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 37, "lpgbts": [{"id": 1114, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 37, "lpgbts": [{"id": 1114, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 37, "lpgbts": [{"id": 1115, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 37, "lpgbts": [{"id": 1115, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 37, "lpgbts": [{"id": 1115, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 37, "lpgbts": [{"id": 1115, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 37, "lpgbts": [{"id": 1116, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 37, "lpgbts": [{"id": 1116, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 37, "lpgbts": [{"id": 1116, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 37, "lpgbts": [{"id": 1116, "nElinks": 1}, {"id": 1117, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 37, "lpgbts": [{"id": 1118, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 37, "lpgbts": [{"id": 1118, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 37, "lpgbts": [{"id": 1118, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 37, "lpgbts": [{"id": 1118, "nElinks": 1}, {"id": 1119, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 37, "lpgbts": [{"id": 1120, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 37, "lpgbts": [{"id": 1120, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 37, "lpgbts": [{"id": 1120, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 37, "lpgbts": [{"id": 1120, "nElinks": 1}, {"id": 1121, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 37, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 37, "lpgbts": [{"id": 1122, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 37, "lpgbts": [{"id": 1122, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 37, "lpgbts": [{"id": 1122, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 37, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 37, "lpgbts": [{"id": 1123, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 37, "lpgbts": [{"id": 1123, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 37, "lpgbts": [{"id": 1123, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 37, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 38, "lpgbts": [{"id": 1124, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 38, "lpgbts": [{"id": 1124, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 38, "lpgbts": [{"id": 1124, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 38, "lpgbts": [{"id": 1125, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 38, "lpgbts": [{"id": 1125, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 38, "lpgbts": [{"id": 1125, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 38, "lpgbts": [{"id": 1126, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 38, "lpgbts": [{"id": 1126, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 38, "lpgbts": [{"id": 1126, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 38, "lpgbts": [{"id": 1127, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 38, "lpgbts": [{"id": 1127, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 38, "lpgbts": [{"id": 1127, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 38, "lpgbts": [{"id": 1128, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 38, "lpgbts": [{"id": 1128, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 38, "lpgbts": [{"id": 1128, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 38, "lpgbts": [{"id": 1128, "nElinks": 1}, {"id": 1129, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 38, "lpgbts": [{"id": 1130, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 38, "lpgbts": [{"id": 1130, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 38, "lpgbts": [{"id": 1130, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 38, "lpgbts": [{"id": 1130, "nElinks": 1}, {"id": 1131, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 38, "lpgbts": [{"id": 1132, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 38, "lpgbts": [{"id": 1132, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 38, "lpgbts": [{"id": 1132, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 38, "lpgbts": [{"id": 1132, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 38, "lpgbts": [{"id": 1133, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 38, "lpgbts": [{"id": 1133, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 38, "lpgbts": [{"id": 1133, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 38, "lpgbts": [{"id": 1133, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 38, "lpgbts": [{"id": 1134, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 38, "lpgbts": [{"id": 1134, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 38, "lpgbts": [{"id": 1134, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 38, "lpgbts": [{"id": 1134, "nElinks": 1}, {"id": 1135, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 38, "lpgbts": [{"id": 1135, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 38, "lpgbts": [{"id": 1135, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 38, "lpgbts": [{"id": 1136, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 38, "lpgbts": [{"id": 1136, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 38, "lpgbts": [{"id": 1136, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 38, "lpgbts": [{"id": 1136, "nElinks": 1}, {"id": 1137, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 38, "lpgbts": [{"id": 1137, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 38, "lpgbts": [{"id": 1138, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 38, "lpgbts": [{"id": 1138, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 38, "lpgbts": [{"id": 1138, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 38, "lpgbts": [{"id": 1138, "nElinks": 1}, {"id": 1139, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 38, "lpgbts": [{"id": 1140, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 38, "lpgbts": [{"id": 1140, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 38, "lpgbts": [{"id": 1140, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 38, "lpgbts": [{"id": 1141, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 38, "lpgbts": [{"id": 1141, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 38, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 38, "lpgbts": [{"id": 1142, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 38, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 38, "lpgbts": [{"id": 1143, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 38, "lpgbts": [{"id": 1143, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 38, "lpgbts": [{"id": 1143, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 38, "lpgbts": [{"id": 1144, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 38, "lpgbts": [{"id": 1144, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 38, "lpgbts": [{"id": 1144, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 38, "lpgbts": [{"id": 1145, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 38, "lpgbts": [{"id": 1145, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 38, "lpgbts": [{"id": 1145, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 38, "lpgbts": [{"id": 1146, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 38, "lpgbts": [{"id": 1146, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 38, "lpgbts": [{"id": 1146, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 38, "lpgbts": [{"id": 1147, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 38, "lpgbts": [{"id": 1147, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 38, "lpgbts": [{"id": 1147, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 38, "lpgbts": [{"id": 1147, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 38, "lpgbts": [{"id": 1148, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 38, "lpgbts": [{"id": 1148, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 38, "lpgbts": [{"id": 1148, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 38, "lpgbts": [{"id": 1148, "nElinks": 1}, {"id": 1149, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 38, "lpgbts": [{"id": 1150, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 38, "lpgbts": [{"id": 1150, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 38, "lpgbts": [{"id": 1150, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 38, "lpgbts": [{"id": 1150, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 38, "lpgbts": [{"id": 1151, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 38, "lpgbts": [{"id": 1151, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 38, "lpgbts": [{"id": 1151, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 38, "lpgbts": [{"id": 1151, "nElinks": 1}, {"id": 1152, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 38, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 38, "lpgbts": [{"id": 1153, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 38, "lpgbts": [{"id": 1153, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 38, "lpgbts": [{"id": 1153, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 38, "lpgbts": [{"id": 1153, "nElinks": 1}, {"id": 1154, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 38, "lpgbts": [{"id": 1155, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 38, "lpgbts": [{"id": 1155, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 38, "lpgbts": [{"id": 1155, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 38, "lpgbts": [{"id": 1155, "nElinks": 1}, {"id": 1156, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 38, "lpgbts": [{"id": 1156, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 38, "lpgbts": [{"id": 1157, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 38, "lpgbts": [{"id": 1157, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 38, "lpgbts": [{"id": 1157, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 38, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 38, "lpgbts": [{"id": 1158, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 38, "lpgbts": [{"id": 1158, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 38, "lpgbts": [{"id": 1158, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 38, "lpgbts": [{"id": 1158, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 38, "lpgbts": [{"id": 1159, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 38, "lpgbts": [{"id": 1159, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 39, "lpgbts": [{"id": 1160, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 39, "lpgbts": [{"id": 1160, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 39, "lpgbts": [{"id": 1160, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 39, "lpgbts": [{"id": 1161, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 39, "lpgbts": [{"id": 1161, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 39, "lpgbts": [{"id": 1161, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 39, "lpgbts": [{"id": 1161, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 39, "lpgbts": [{"id": 1162, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 39, "lpgbts": [{"id": 1162, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 39, "lpgbts": [{"id": 1162, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 39, "lpgbts": [{"id": 1163, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 39, "lpgbts": [{"id": 1163, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 39, "lpgbts": [{"id": 1163, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 0, "layer": 39, "lpgbts": [{"id": 1163, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 39, "lpgbts": [{"id": 1164, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 39, "lpgbts": [{"id": 1164, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 39, "lpgbts": [{"id": 1164, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 39, "lpgbts": [{"id": 1165, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 39, "lpgbts": [{"id": 1165, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 39, "lpgbts": [{"id": 1165, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 39, "lpgbts": [{"id": 1166, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 39, "lpgbts": [{"id": 1166, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 39, "lpgbts": [{"id": 1166, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 39, "lpgbts": [{"id": 1166, "nElinks": 1}, {"id": 1167, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 39, "lpgbts": [{"id": 1168, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 39, "lpgbts": [{"id": 1168, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 39, "lpgbts": [{"id": 1168, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 39, "lpgbts": [{"id": 1168, "nElinks": 1}, {"id": 1169, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 39, "lpgbts": [{"id": 1170, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 39, "lpgbts": [{"id": 1170, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 39, "lpgbts": [{"id": 1170, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 39, "lpgbts": [{"id": 1170, "nElinks": 1}, {"id": 1171, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 39, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 39, "lpgbts": [{"id": 1172, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 39, "lpgbts": [{"id": 1172, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 39, "lpgbts": [{"id": 1172, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 39, "lpgbts": [{"id": 1172, "nElinks": 1}, {"id": 1173, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 39, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 39, "lpgbts": [{"id": 1174, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 39, "lpgbts": [{"id": 1174, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 39, "lpgbts": [{"id": 1174, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 39, "lpgbts": [{"id": 1174, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 39, "lpgbts": [{"id": 1175, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 39, "lpgbts": [{"id": 1175, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 39, "lpgbts": [{"id": 1175, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 39, "lpgbts": [{"id": 1176, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 39, "lpgbts": [{"id": 1176, "nElinks": 1}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 39, "lpgbts": [{"id": 1176, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 1, "layer": 39, "lpgbts": [{"id": 1177, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 39, "lpgbts": [{"id": 1177, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 39, "lpgbts": [{"id": 1177, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 2, "layer": 39, "lpgbts": [{"id": 1178, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 39, "lpgbts": [{"id": 1178, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 39, "lpgbts": [{"id": 1178, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 39, "lpgbts": [{"id": 1179, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 39, "lpgbts": [{"id": 1179, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 39, "lpgbts": [{"id": 1179, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 39, "lpgbts": [{"id": 1180, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 39, "lpgbts": [{"id": 1180, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 39, "lpgbts": [{"id": 1180, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 39, "lpgbts": [{"id": 1181, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 39, "lpgbts": [{"id": 1181, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 39, "lpgbts": [{"id": 1181, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 39, "lpgbts": [{"id": 1182, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 39, "lpgbts": [{"id": 1182, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 39, "lpgbts": [{"id": 1182, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 39, "lpgbts": [{"id": 1182, "nElinks": 1}, {"id": 1183, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 39, "lpgbts": [{"id": 1184, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 39, "lpgbts": [{"id": 1184, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 39, "lpgbts": [{"id": 1184, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 8, "layer": 39, "lpgbts": [{"id": 1184, "nElinks": 1}, {"id": 1185, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 39, "lpgbts": [{"id": 1186, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 39, "lpgbts": [{"id": 1186, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 39, "lpgbts": [{"id": 1186, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 39, "lpgbts": [{"id": 1186, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 39, "lpgbts": [{"id": 1187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 39, "lpgbts": [{"id": 1187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 39, "lpgbts": [{"id": 1187, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 39, "lpgbts": [{"id": 1187, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 39, "lpgbts": [{"id": 1188, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 39, "lpgbts": [{"id": 1188, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 39, "lpgbts": [{"id": 1188, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 39, "lpgbts": [{"id": 1188, "nElinks": 1}, {"id": 1189, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 39, "lpgbts": [{"id": 1190, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 39, "lpgbts": [{"id": 1190, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 39, "lpgbts": [{"id": 1190, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 39, "lpgbts": [{"id": 1190, "nElinks": 1}, {"id": 1191, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 39, "lpgbts": [{"id": 1192, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 39, "lpgbts": [{"id": 1192, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 39, "lpgbts": [{"id": 1192, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 39, "lpgbts": [{"id": 1192, "nElinks": 1}, {"id": 1193, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 39, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 39, "lpgbts": [{"id": 1194, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 39, "lpgbts": [{"id": 1194, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 39, "lpgbts": [{"id": 1194, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 39, "lpgbts": [{"id": 1194, "nElinks": 1}, {"id": 1195, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 39, "lpgbts": [{"id": 1195, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 39, "lpgbts": [{"id": 1195, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 39, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 39, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 1, "layer": 40, "lpgbts": [{"id": 1196, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 40, "lpgbts": [{"id": 1196, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 40, "lpgbts": [{"id": 1196, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 40, "lpgbts": [{"id": 1197, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 40, "lpgbts": [{"id": 1197, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 40, "lpgbts": [{"id": 1197, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 40, "lpgbts": [{"id": 1198, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 40, "lpgbts": [{"id": 1198, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 40, "lpgbts": [{"id": 1198, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 9, "layer": 40, "lpgbts": [{"id": 1198, "nElinks": 1}, {"id": 1199, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 40, "lpgbts": [{"id": 1200, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 40, "lpgbts": [{"id": 1200, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 40, "lpgbts": [{"id": 1200, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 1, "layer": 40, "lpgbts": [{"id": 1200, "nElinks": 1}, {"id": 1201, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 40, "lpgbts": [{"id": 1202, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 40, "lpgbts": [{"id": 1202, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 40, "lpgbts": [{"id": 1202, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 40, "lpgbts": [{"id": 1203, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 40, "lpgbts": [{"id": 1203, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 40, "lpgbts": [{"id": 1203, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 40, "lpgbts": [{"id": 1204, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 40, "lpgbts": [{"id": 1204, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 40, "lpgbts": [{"id": 1204, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 40, "lpgbts": [{"id": 1205, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 40, "lpgbts": [{"id": 1205, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 40, "lpgbts": [{"id": 1205, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 9, "layer": 40, "lpgbts": [{"id": 1205, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 40, "lpgbts": [{"id": 1206, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 40, "lpgbts": [{"id": 1206, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 40, "lpgbts": [{"id": 1206, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 2, "layer": 40, "lpgbts": [{"id": 1206, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 40, "lpgbts": [{"id": 1207, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 40, "lpgbts": [{"id": 1207, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 40, "lpgbts": [{"id": 1207, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 8, "layer": 40, "lpgbts": [{"id": 1207, "nElinks": 1}, {"id": 1208, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 40, "lpgbts": [{"id": 1209, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 40, "lpgbts": [{"id": 1209, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 40, "lpgbts": [{"id": 1209, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 3, "layer": 40, "lpgbts": [{"id": 1209, "nElinks": 1}, {"id": 1210, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 40, "lpgbts": [{"id": 1211, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 40, "lpgbts": [{"id": 1211, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 40, "lpgbts": [{"id": 1211, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 7, "layer": 40, "lpgbts": [{"id": 1211, "nElinks": 1}, {"id": 1212, "nElinks": 1}]},
+        {"isSilicon": true, "u": 11, "v": 7, "layer": 40, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 40, "lpgbts": [{"id": 1213, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 40, "lpgbts": [{"id": 1213, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 4, "layer": 40, "lpgbts": [{"id": 1213, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 40, "lpgbts": [{"id": 1214, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 40, "lpgbts": [{"id": 1214, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 5, "layer": 40, "lpgbts": []},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 40, "lpgbts": [{"id": 1214, "nElinks": 2}]},
+        {"isSilicon": true, "u": 11, "v": 6, "layer": 40, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 40, "lpgbts": [{"id": 1215, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 40, "lpgbts": [{"id": 1215, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 40, "lpgbts": [{"id": 1215, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 40, "lpgbts": [{"id": 1216, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 40, "lpgbts": [{"id": 1216, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 40, "lpgbts": [{"id": 1216, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 10, "layer": 40, "lpgbts": [{"id": 1216, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 40, "lpgbts": [{"id": 1217, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 40, "lpgbts": [{"id": 1217, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 40, "lpgbts": [{"id": 1217, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 40, "lpgbts": [{"id": 1218, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 40, "lpgbts": [{"id": 1218, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 40, "lpgbts": [{"id": 1218, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 10, "layer": 40, "lpgbts": [{"id": 1218, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 40, "lpgbts": [{"id": 1219, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 40, "lpgbts": [{"id": 1219, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 40, "lpgbts": [{"id": 1219, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 40, "lpgbts": [{"id": 1220, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 40, "lpgbts": [{"id": 1220, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 40, "lpgbts": [{"id": 1220, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 40, "lpgbts": [{"id": 1221, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 40, "lpgbts": [{"id": 1221, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 40, "lpgbts": [{"id": 1221, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 10, "layer": 40, "lpgbts": [{"id": 1221, "nElinks": 1}, {"id": 1222, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 40, "lpgbts": [{"id": 1223, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 40, "lpgbts": [{"id": 1223, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 40, "lpgbts": [{"id": 1223, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 40, "lpgbts": [{"id": 1223, "nElinks": 1}, {"id": 1224, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 11, "layer": 40, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 40, "lpgbts": [{"id": 1225, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 40, "lpgbts": [{"id": 1225, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 40, "lpgbts": [{"id": 1225, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 10, "layer": 40, "lpgbts": [{"id": 1225, "nElinks": 1}, {"id": 1226, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 40, "lpgbts": [{"id": 1227, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 40, "lpgbts": [{"id": 1227, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 40, "lpgbts": [{"id": 1227, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 40, "lpgbts": [{"id": 1227, "nElinks": 1}, {"id": 1228, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 11, "layer": 40, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 40, "lpgbts": [{"id": 1229, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 40, "lpgbts": [{"id": 1229, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 40, "lpgbts": [{"id": 1229, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 11, "layer": 40, "lpgbts": [{"id": 1229, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 40, "lpgbts": [{"id": 1230, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 40, "lpgbts": [{"id": 1230, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 11, "layer": 40, "lpgbts": [{"id": 1230, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 40, "lpgbts": [{"id": 1230, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 11, "layer": 40, "lpgbts": [{"id": 1231, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 11, "layer": 40, "lpgbts": [{"id": 1231, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 41, "lpgbts": [{"id": 1232, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 41, "lpgbts": [{"id": 1232, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 41, "lpgbts": [{"id": 1232, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 41, "lpgbts": [{"id": 1232, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 41, "lpgbts": [{"id": 1233, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 0, "layer": 41, "lpgbts": [{"id": 1233, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 41, "lpgbts": [{"id": 1234, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 41, "lpgbts": [{"id": 1234, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 41, "lpgbts": [{"id": 1234, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 41, "lpgbts": [{"id": 1234, "nElinks": 1}, {"id": 1235, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 41, "lpgbts": [{"id": 1235, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 41, "lpgbts": [{"id": 1236, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 41, "lpgbts": [{"id": 1236, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 41, "lpgbts": [{"id": 1236, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 41, "lpgbts": [{"id": 1236, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 41, "lpgbts": [{"id": 1237, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 41, "lpgbts": [{"id": 1237, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 41, "lpgbts": [{"id": 1238, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 41, "lpgbts": [{"id": 1238, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 41, "lpgbts": [{"id": 1238, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 41, "lpgbts": [{"id": 1238, "nElinks": 1}, {"id": 1239, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 41, "lpgbts": [{"id": 1239, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 41, "lpgbts": [{"id": 1240, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 41, "lpgbts": [{"id": 1240, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 41, "lpgbts": [{"id": 1240, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 41, "lpgbts": [{"id": 1240, "nElinks": 1}, {"id": 1241, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 41, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 41, "lpgbts": [{"id": 1242, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 41, "lpgbts": [{"id": 1242, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 41, "lpgbts": [{"id": 1242, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 41, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 41, "lpgbts": [{"id": 1243, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 41, "lpgbts": [{"id": 1243, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 41, "lpgbts": [{"id": 1243, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 41, "lpgbts": [{"id": 1244, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 41, "lpgbts": [{"id": 1244, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 41, "lpgbts": [{"id": 1244, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 41, "lpgbts": [{"id": 1245, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 41, "lpgbts": [{"id": 1245, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 41, "lpgbts": [{"id": 1245, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 41, "lpgbts": [{"id": 1245, "nElinks": 1}, {"id": 1246, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 41, "lpgbts": [{"id": 1246, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 41, "lpgbts": [{"id": 1247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 41, "lpgbts": [{"id": 1247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 41, "lpgbts": [{"id": 1247, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 41, "lpgbts": [{"id": 1247, "nElinks": 1}, {"id": 1248, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 7, "layer": 41, "lpgbts": [{"id": 1248, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 41, "lpgbts": [{"id": 1249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 41, "lpgbts": [{"id": 1249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 41, "lpgbts": [{"id": 1249, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 41, "lpgbts": [{"id": 1249, "nElinks": 1}, {"id": 1250, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 41, "lpgbts": [{"id": 1250, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 41, "lpgbts": [{"id": 1250, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 41, "lpgbts": [{"id": 1251, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 41, "lpgbts": [{"id": 1251, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 41, "lpgbts": [{"id": 1251, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 41, "lpgbts": [{"id": 1251, "nElinks": 1}, {"id": 1252, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 41, "lpgbts": [{"id": 1252, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 41, "lpgbts": [{"id": 1252, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 41, "lpgbts": [{"id": 1253, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 41, "lpgbts": [{"id": 1253, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 41, "lpgbts": [{"id": 1253, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 41, "lpgbts": [{"id": 1253, "nElinks": 1}, {"id": 1254, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 41, "lpgbts": [{"id": 1254, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 41, "lpgbts": [{"id": 1255, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 41, "lpgbts": [{"id": 1255, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 41, "lpgbts": [{"id": 1255, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 41, "lpgbts": [{"id": 1255, "nElinks": 1}, {"id": 1256, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 41, "lpgbts": [{"id": 1257, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 41, "lpgbts": [{"id": 1257, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 41, "lpgbts": [{"id": 1257, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 41, "lpgbts": [{"id": 1257, "nElinks": 1}, {"id": 1258, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 41, "lpgbts": [{"id": 1258, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 41, "lpgbts": [{"id": 1258, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 41, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 41, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 42, "lpgbts": [{"id": 1259, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 42, "lpgbts": [{"id": 1259, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 42, "lpgbts": [{"id": 1259, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 42, "lpgbts": [{"id": 1259, "nElinks": 1}, {"id": 1260, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 1, "layer": 42, "lpgbts": [{"id": 1260, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 42, "lpgbts": [{"id": 1261, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 42, "lpgbts": [{"id": 1261, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 42, "lpgbts": [{"id": 1261, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 42, "lpgbts": [{"id": 1261, "nElinks": 1}, {"id": 1262, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 8, "layer": 42, "lpgbts": [{"id": 1262, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 42, "lpgbts": [{"id": 1263, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 42, "lpgbts": [{"id": 1263, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 42, "lpgbts": [{"id": 1263, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 42, "lpgbts": [{"id": 1263, "nElinks": 1}, {"id": 1264, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 42, "lpgbts": [{"id": 1264, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 2, "layer": 42, "lpgbts": [{"id": 1264, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 42, "lpgbts": [{"id": 1265, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 42, "lpgbts": [{"id": 1265, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 42, "lpgbts": [{"id": 1265, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 42, "lpgbts": [{"id": 1265, "nElinks": 1}, {"id": 1266, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 42, "lpgbts": [{"id": 1266, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 8, "layer": 42, "lpgbts": [{"id": 1266, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 42, "lpgbts": [{"id": 1267, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 42, "lpgbts": [{"id": 1267, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 42, "lpgbts": [{"id": 1267, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 42, "lpgbts": [{"id": 1267, "nElinks": 1}, {"id": 1268, "nElinks": 1}]},
+        {"isSilicon": true, "u": 9, "v": 3, "layer": 42, "lpgbts": [{"id": 1268, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 42, "lpgbts": [{"id": 1269, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 42, "lpgbts": [{"id": 1269, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 42, "lpgbts": [{"id": 1269, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 7, "layer": 42, "lpgbts": [{"id": 1269, "nElinks": 1}, {"id": 1270, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 42, "lpgbts": [{"id": 1271, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 42, "lpgbts": [{"id": 1271, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 4, "layer": 42, "lpgbts": [{"id": 1271, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 42, "lpgbts": [{"id": 1272, "nElinks": 2}]},
+        {"isSilicon": true, "u": 9, "v": 5, "layer": 42, "lpgbts": [{"id": 1272, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 5, "layer": 42, "lpgbts": []},
+        {"isSilicon": true, "u": 9, "v": 6, "layer": 42, "lpgbts": [{"id": 1272, "nElinks": 2}]},
+        {"isSilicon": true, "u": 10, "v": 6, "layer": 42, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 42, "lpgbts": [{"id": 1273, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 42, "lpgbts": [{"id": 1273, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 42, "lpgbts": [{"id": 1273, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 42, "lpgbts": [{"id": 1273, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 42, "lpgbts": [{"id": 1274, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 9, "layer": 42, "lpgbts": [{"id": 1274, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 42, "lpgbts": [{"id": 1275, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 42, "lpgbts": [{"id": 1275, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 42, "lpgbts": [{"id": 1275, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 42, "lpgbts": [{"id": 1275, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 42, "lpgbts": [{"id": 1276, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 9, "layer": 42, "lpgbts": [{"id": 1276, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 42, "lpgbts": [{"id": 1277, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 42, "lpgbts": [{"id": 1277, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 42, "lpgbts": [{"id": 1277, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 42, "lpgbts": [{"id": 1277, "nElinks": 1}, {"id": 1278, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 9, "layer": 42, "lpgbts": [{"id": 1278, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 42, "lpgbts": [{"id": 1279, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 42, "lpgbts": [{"id": 1279, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 42, "lpgbts": [{"id": 1279, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 42, "lpgbts": [{"id": 1279, "nElinks": 1}, {"id": 1280, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 9, "layer": 42, "lpgbts": [{"id": 1280, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 42, "lpgbts": [{"id": 1281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 42, "lpgbts": [{"id": 1281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 42, "lpgbts": [{"id": 1281, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 42, "lpgbts": [{"id": 1281, "nElinks": 1}, {"id": 1282, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 10, "layer": 42, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 42, "lpgbts": [{"id": 1283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 42, "lpgbts": [{"id": 1283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 42, "lpgbts": [{"id": 1283, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 10, "layer": 42, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 42, "lpgbts": [{"id": 1284, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 42, "lpgbts": [{"id": 1284, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 10, "layer": 42, "lpgbts": [{"id": 1284, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 42, "lpgbts": [{"id": 1284, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 10, "layer": 42, "lpgbts": [{"id": 1285, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 10, "layer": 42, "lpgbts": [{"id": 1285, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 43, "lpgbts": [{"id": 1286, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 43, "lpgbts": [{"id": 1286, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 43, "lpgbts": [{"id": 1286, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 43, "lpgbts": [{"id": 1286, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 43, "lpgbts": [{"id": 1287, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 43, "lpgbts": [{"id": 1288, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 43, "lpgbts": [{"id": 1288, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 43, "lpgbts": [{"id": 1288, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 43, "lpgbts": [{"id": 1288, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 43, "lpgbts": [{"id": 1289, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 43, "lpgbts": [{"id": 1290, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 43, "lpgbts": [{"id": 1290, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 43, "lpgbts": [{"id": 1290, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 43, "lpgbts": [{"id": 1290, "nElinks": 1}, {"id": 1291, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 43, "lpgbts": [{"id": 1292, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 43, "lpgbts": [{"id": 1292, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 43, "lpgbts": [{"id": 1292, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 43, "lpgbts": [{"id": 1292, "nElinks": 1}, {"id": 1293, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 43, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 43, "lpgbts": [{"id": 1294, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 43, "lpgbts": [{"id": 1294, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 43, "lpgbts": [{"id": 1294, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 43, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 43, "lpgbts": [{"id": 1295, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 43, "lpgbts": [{"id": 1295, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 43, "lpgbts": []},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 43, "lpgbts": [{"id": 1295, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 43, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 43, "lpgbts": [{"id": 1296, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 43, "lpgbts": [{"id": 1296, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 43, "lpgbts": [{"id": 1296, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 43, "lpgbts": [{"id": 1296, "nElinks": 1}, {"id": 1297, "nElinks": 1}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 43, "lpgbts": [{"id": 1298, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 43, "lpgbts": [{"id": 1298, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 43, "lpgbts": [{"id": 1298, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 43, "lpgbts": [{"id": 1298, "nElinks": 1}, {"id": 1299, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 43, "lpgbts": [{"id": 1300, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 43, "lpgbts": [{"id": 1300, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 43, "lpgbts": [{"id": 1300, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 43, "lpgbts": [{"id": 1300, "nElinks": 1}, {"id": 1301, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 43, "lpgbts": [{"id": 1301, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 43, "lpgbts": [{"id": 1302, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 43, "lpgbts": [{"id": 1302, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 43, "lpgbts": [{"id": 1302, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 43, "lpgbts": [{"id": 1302, "nElinks": 1}, {"id": 1303, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 43, "lpgbts": [{"id": 1303, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 43, "lpgbts": [{"id": 1304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 43, "lpgbts": [{"id": 1304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 43, "lpgbts": [{"id": 1304, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 43, "lpgbts": [{"id": 1304, "nElinks": 1}, {"id": 1305, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 43, "lpgbts": [{"id": 1306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 43, "lpgbts": [{"id": 1306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 43, "lpgbts": [{"id": 1306, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 43, "lpgbts": [{"id": 1306, "nElinks": 1}, {"id": 1307, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 43, "lpgbts": [{"id": 1307, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 43, "lpgbts": [{"id": 1307, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 44, "lpgbts": [{"id": 1308, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 44, "lpgbts": [{"id": 1308, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 44, "lpgbts": [{"id": 1308, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 44, "lpgbts": [{"id": 1308, "nElinks": 1}, {"id": 1309, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 44, "lpgbts": [{"id": 1310, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 44, "lpgbts": [{"id": 1310, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 44, "lpgbts": [{"id": 1310, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 44, "lpgbts": [{"id": 1310, "nElinks": 1}, {"id": 1311, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 44, "lpgbts": [{"id": 1312, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 44, "lpgbts": [{"id": 1312, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 44, "lpgbts": [{"id": 1312, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 44, "lpgbts": [{"id": 1312, "nElinks": 1}, {"id": 1313, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 44, "lpgbts": [{"id": 1313, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 44, "lpgbts": [{"id": 1314, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 44, "lpgbts": [{"id": 1314, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 44, "lpgbts": [{"id": 1314, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 44, "lpgbts": [{"id": 1314, "nElinks": 1}, {"id": 1315, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 44, "lpgbts": [{"id": 1315, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 44, "lpgbts": [{"id": 1316, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 44, "lpgbts": [{"id": 1316, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 44, "lpgbts": [{"id": 1316, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 44, "lpgbts": [{"id": 1316, "nElinks": 1}, {"id": 1317, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 44, "lpgbts": [{"id": 1318, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 44, "lpgbts": [{"id": 1318, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 44, "lpgbts": [{"id": 1318, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 44, "lpgbts": [{"id": 1319, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 44, "lpgbts": [{"id": 1319, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 44, "lpgbts": [{"id": 1319, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 44, "lpgbts": [{"id": 1320, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 44, "lpgbts": [{"id": 1320, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 44, "lpgbts": [{"id": 1320, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 44, "lpgbts": [{"id": 1320, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 44, "lpgbts": [{"id": 1321, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 44, "lpgbts": [{"id": 1322, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 44, "lpgbts": [{"id": 1322, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 44, "lpgbts": [{"id": 1322, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 44, "lpgbts": [{"id": 1322, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 44, "lpgbts": [{"id": 1323, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 44, "lpgbts": [{"id": 1324, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 44, "lpgbts": [{"id": 1324, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 44, "lpgbts": [{"id": 1324, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 44, "lpgbts": [{"id": 1324, "nElinks": 1}, {"id": 1325, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 44, "lpgbts": [{"id": 1326, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 44, "lpgbts": [{"id": 1326, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 44, "lpgbts": [{"id": 1326, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 44, "lpgbts": [{"id": 1326, "nElinks": 1}, {"id": 1327, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 44, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 44, "lpgbts": [{"id": 1328, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 44, "lpgbts": [{"id": 1328, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 44, "lpgbts": [{"id": 1328, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 44, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 44, "lpgbts": [{"id": 1329, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 44, "lpgbts": [{"id": 1329, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 44, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 44, "lpgbts": [{"id": 1329, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 44, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 45, "lpgbts": [{"id": 1330, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 45, "lpgbts": [{"id": 1330, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 45, "lpgbts": [{"id": 1330, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 45, "lpgbts": [{"id": 1330, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 0, "layer": 45, "lpgbts": [{"id": 1331, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 45, "lpgbts": [{"id": 1332, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 45, "lpgbts": [{"id": 1332, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 45, "lpgbts": [{"id": 1332, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 45, "lpgbts": [{"id": 1332, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 45, "lpgbts": [{"id": 1333, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 45, "lpgbts": [{"id": 1334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 45, "lpgbts": [{"id": 1334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 45, "lpgbts": [{"id": 1334, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 45, "lpgbts": [{"id": 1334, "nElinks": 1}, {"id": 1335, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 45, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 45, "lpgbts": [{"id": 1336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 45, "lpgbts": [{"id": 1336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 45, "lpgbts": [{"id": 1336, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 45, "lpgbts": [{"id": 1336, "nElinks": 1}, {"id": 1337, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 45, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 45, "lpgbts": [{"id": 1338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 45, "lpgbts": [{"id": 1338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 45, "lpgbts": [{"id": 1338, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 45, "lpgbts": [{"id": 1338, "nElinks": 1}, {"id": 1339, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 45, "lpgbts": [{"id": 1339, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 45, "lpgbts": [{"id": 1339, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 45, "lpgbts": []},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 45, "lpgbts": []},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 45, "lpgbts": [{"id": 1340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 45, "lpgbts": [{"id": 1340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 45, "lpgbts": [{"id": 1340, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 6, "layer": 45, "lpgbts": [{"id": 1340, "nElinks": 1}, {"id": 1341, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 45, "lpgbts": [{"id": 1342, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 45, "lpgbts": [{"id": 1342, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 45, "lpgbts": [{"id": 1342, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 45, "lpgbts": [{"id": 1342, "nElinks": 1}, {"id": 1343, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 45, "lpgbts": [{"id": 1344, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 45, "lpgbts": [{"id": 1344, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 45, "lpgbts": [{"id": 1344, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 45, "lpgbts": [{"id": 1344, "nElinks": 1}, {"id": 1345, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 45, "lpgbts": [{"id": 1345, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 45, "lpgbts": [{"id": 1346, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 45, "lpgbts": [{"id": 1346, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 45, "lpgbts": [{"id": 1346, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 45, "lpgbts": [{"id": 1346, "nElinks": 1}, {"id": 1347, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 45, "lpgbts": [{"id": 1347, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 45, "lpgbts": [{"id": 1348, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 45, "lpgbts": [{"id": 1348, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 45, "lpgbts": [{"id": 1348, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 45, "lpgbts": [{"id": 1348, "nElinks": 1}, {"id": 1349, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 45, "lpgbts": [{"id": 1350, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 45, "lpgbts": [{"id": 1350, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 45, "lpgbts": [{"id": 1350, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 45, "lpgbts": [{"id": 1350, "nElinks": 1}, {"id": 1351, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 45, "lpgbts": [{"id": 1351, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 45, "lpgbts": [{"id": 1351, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 46, "lpgbts": [{"id": 1352, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 46, "lpgbts": [{"id": 1352, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 46, "lpgbts": [{"id": 1352, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 1, "layer": 46, "lpgbts": [{"id": 1352, "nElinks": 1}, {"id": 1353, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 46, "lpgbts": [{"id": 1354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 46, "lpgbts": [{"id": 1354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 46, "lpgbts": [{"id": 1354, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 7, "layer": 46, "lpgbts": [{"id": 1354, "nElinks": 1}, {"id": 1355, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 46, "lpgbts": [{"id": 1356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 46, "lpgbts": [{"id": 1356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 46, "lpgbts": [{"id": 1356, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 46, "lpgbts": [{"id": 1356, "nElinks": 1}, {"id": 1357, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 2, "layer": 46, "lpgbts": [{"id": 1357, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 46, "lpgbts": [{"id": 1358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 46, "lpgbts": [{"id": 1358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 46, "lpgbts": [{"id": 1358, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 46, "lpgbts": [{"id": 1358, "nElinks": 1}, {"id": 1359, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 7, "layer": 46, "lpgbts": [{"id": 1359, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 46, "lpgbts": [{"id": 1360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 46, "lpgbts": [{"id": 1360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 46, "lpgbts": [{"id": 1360, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 6, "layer": 46, "lpgbts": [{"id": 1360, "nElinks": 1}, {"id": 1361, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 46, "lpgbts": [{"id": 1362, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 46, "lpgbts": [{"id": 1362, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 3, "layer": 46, "lpgbts": [{"id": 1362, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 46, "lpgbts": [{"id": 1362, "nElinks": 1}, {"id": 1363, "nElinks": 1}]},
+        {"isSilicon": true, "u": 8, "v": 4, "layer": 46, "lpgbts": [{"id": 1363, "nElinks": 2}]},
+        {"isSilicon": true, "u": 8, "v": 5, "layer": 46, "lpgbts": [{"id": 1363, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 46, "lpgbts": [{"id": 1364, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 46, "lpgbts": [{"id": 1364, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 46, "lpgbts": [{"id": 1364, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 46, "lpgbts": [{"id": 1364, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 8, "layer": 46, "lpgbts": [{"id": 1365, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 46, "lpgbts": [{"id": 1366, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 46, "lpgbts": [{"id": 1366, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 46, "lpgbts": [{"id": 1366, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 8, "layer": 46, "lpgbts": [{"id": 1366, "nElinks": 1}, {"id": 1367, "nElinks": 1}]},
+        {"isSilicon": true, "u": 6, "v": 9, "layer": 46, "lpgbts": []},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 46, "lpgbts": [{"id": 1368, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 46, "lpgbts": [{"id": 1368, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 46, "lpgbts": [{"id": 1368, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 46, "lpgbts": [{"id": 1368, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 8, "layer": 46, "lpgbts": [{"id": 1369, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 46, "lpgbts": [{"id": 1370, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 46, "lpgbts": [{"id": 1370, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 46, "lpgbts": [{"id": 1370, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 8, "layer": 46, "lpgbts": [{"id": 1370, "nElinks": 1}, {"id": 1371, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 46, "lpgbts": [{"id": 1372, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 46, "lpgbts": [{"id": 1372, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 46, "lpgbts": [{"id": 1372, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 46, "lpgbts": [{"id": 1372, "nElinks": 1}, {"id": 1373, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 46, "lpgbts": [{"id": 1373, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 46, "lpgbts": [{"id": 1373, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 9, "layer": 46, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 9, "layer": 46, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 9, "layer": 46, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 47, "lpgbts": [{"id": 1374, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 47, "lpgbts": [{"id": 1374, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 47, "lpgbts": [{"id": 1374, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 47, "lpgbts": [{"id": 1374, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 47, "lpgbts": [{"id": 1375, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 47, "lpgbts": [{"id": 1375, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 47, "lpgbts": [{"id": 1375, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 47, "lpgbts": [{"id": 1375, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 47, "lpgbts": [{"id": 1376, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 47, "lpgbts": [{"id": 1376, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 47, "lpgbts": [{"id": 1376, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 47, "lpgbts": [{"id": 1377, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 47, "lpgbts": [{"id": 1377, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 47, "lpgbts": [{"id": 1377, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 47, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 47, "lpgbts": [{"id": 1378, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 47, "lpgbts": [{"id": 1378, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 47, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 47, "lpgbts": [{"id": 1378, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 47, "lpgbts": []},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 47, "lpgbts": [{"id": 1379, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 47, "lpgbts": [{"id": 1379, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 47, "lpgbts": [{"id": 1379, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 47, "lpgbts": [{"id": 1379, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 47, "lpgbts": [{"id": 1380, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 47, "lpgbts": [{"id": 1380, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 47, "lpgbts": [{"id": 1380, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 47, "lpgbts": [{"id": 1381, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 47, "lpgbts": [{"id": 1381, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 47, "lpgbts": [{"id": 1381, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 47, "lpgbts": [{"id": 1382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 47, "lpgbts": [{"id": 1382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 47, "lpgbts": [{"id": 1382, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 47, "lpgbts": [{"id": 1382, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 47, "lpgbts": [{"id": 1383, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 47, "lpgbts": [{"id": 1383, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 47, "lpgbts": [{"id": 1383, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 47, "lpgbts": [{"id": 1383, "nElinks": 1}, {"id": 1384, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 47, "lpgbts": [{"id": 1384, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 47, "lpgbts": [{"id": 1384, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 48, "lpgbts": [{"id": 1385, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 48, "lpgbts": [{"id": 1385, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 48, "lpgbts": [{"id": 1385, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 48, "lpgbts": [{"id": 1386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 48, "lpgbts": [{"id": 1386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 48, "lpgbts": [{"id": 1386, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 48, "lpgbts": [{"id": 1387, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 48, "lpgbts": [{"id": 1387, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 48, "lpgbts": [{"id": 1387, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 48, "lpgbts": [{"id": 1387, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 48, "lpgbts": [{"id": 1388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 48, "lpgbts": [{"id": 1388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 48, "lpgbts": [{"id": 1388, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 48, "lpgbts": [{"id": 1388, "nElinks": 1}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 48, "lpgbts": [{"id": 1389, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 48, "lpgbts": [{"id": 1389, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 48, "lpgbts": [{"id": 1389, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 48, "lpgbts": [{"id": 1389, "nElinks": 1}, {"id": 1390, "nElinks": 1}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 48, "lpgbts": [{"id": 1390, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 48, "lpgbts": [{"id": 1390, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 48, "lpgbts": [{"id": 1391, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 48, "lpgbts": [{"id": 1391, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 48, "lpgbts": [{"id": 1391, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 48, "lpgbts": [{"id": 1391, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 48, "lpgbts": [{"id": 1392, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 48, "lpgbts": [{"id": 1392, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 48, "lpgbts": [{"id": 1392, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 48, "lpgbts": [{"id": 1392, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 48, "lpgbts": [{"id": 1393, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 48, "lpgbts": [{"id": 1393, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 48, "lpgbts": [{"id": 1393, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 48, "lpgbts": [{"id": 1394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 48, "lpgbts": [{"id": 1394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 48, "lpgbts": [{"id": 1394, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 48, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 48, "lpgbts": [{"id": 1395, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 48, "lpgbts": [{"id": 1395, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 48, "lpgbts": [{"id": 1395, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 48, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 48, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 0, "layer": 49, "lpgbts": [{"id": 1396, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 0, "layer": 49, "lpgbts": [{"id": 1396, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 0, "layer": 49, "lpgbts": [{"id": 1396, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 0, "layer": 49, "lpgbts": [{"id": 1396, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 2, "layer": 49, "lpgbts": [{"id": 1397, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 49, "lpgbts": [{"id": 1397, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 49, "lpgbts": [{"id": 1397, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 49, "lpgbts": [{"id": 1397, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 49, "lpgbts": [{"id": 1398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 49, "lpgbts": [{"id": 1398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 49, "lpgbts": [{"id": 1398, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 49, "lpgbts": [{"id": 1399, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 49, "lpgbts": [{"id": 1399, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 49, "lpgbts": [{"id": 1399, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 49, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 49, "lpgbts": [{"id": 1400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 49, "lpgbts": [{"id": 1400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 49, "lpgbts": []},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 49, "lpgbts": [{"id": 1400, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 49, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 3, "layer": 49, "lpgbts": [{"id": 1401, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 49, "lpgbts": [{"id": 1401, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 49, "lpgbts": [{"id": 1401, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 3, "layer": 49, "lpgbts": [{"id": 1402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 4, "layer": 49, "lpgbts": [{"id": 1402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 0, "v": 5, "layer": 49, "lpgbts": [{"id": 1402, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 3, "layer": 49, "lpgbts": [{"id": 1403, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 49, "lpgbts": [{"id": 1403, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 49, "lpgbts": [{"id": 1403, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 49, "lpgbts": [{"id": 1403, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 3, "layer": 49, "lpgbts": [{"id": 1404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 49, "lpgbts": [{"id": 1404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 49, "lpgbts": [{"id": 1404, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 49, "lpgbts": [{"id": 1404, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 4, "layer": 49, "lpgbts": [{"id": 1405, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 49, "lpgbts": [{"id": 1405, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 49, "lpgbts": [{"id": 1405, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 49, "lpgbts": [{"id": 1405, "nElinks": 1}, {"id": 1406, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 49, "lpgbts": [{"id": 1406, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 49, "lpgbts": [{"id": 1406, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 1, "layer": 50, "lpgbts": [{"id": 1407, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 1, "layer": 50, "lpgbts": [{"id": 1407, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 1, "layer": 50, "lpgbts": [{"id": 1407, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 2, "layer": 50, "lpgbts": [{"id": 1408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 2, "layer": 50, "lpgbts": [{"id": 1408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 2, "layer": 50, "lpgbts": [{"id": 1408, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 2, "layer": 50, "lpgbts": [{"id": 1408, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 3, "layer": 50, "lpgbts": [{"id": 1409, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 4, "layer": 50, "lpgbts": [{"id": 1409, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 5, "layer": 50, "lpgbts": [{"id": 1409, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 6, "layer": 50, "lpgbts": [{"id": 1409, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 4, "layer": 50, "lpgbts": [{"id": 1410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 5, "layer": 50, "lpgbts": [{"id": 1410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 6, "layer": 50, "lpgbts": [{"id": 1410, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 4, "layer": 50, "lpgbts": [{"id": 1411, "nElinks": 1}]},
+        {"isSilicon": true, "u": 1, "v": 5, "layer": 50, "lpgbts": [{"id": 1411, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 6, "layer": 50, "lpgbts": [{"id": 1411, "nElinks": 2}]},
+        {"isSilicon": true, "u": 1, "v": 7, "layer": 50, "lpgbts": [{"id": 1411, "nElinks": 1}]},
+        {"isSilicon": true, "u": 2, "v": 5, "layer": 50, "lpgbts": [{"id": 1412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 6, "layer": 50, "lpgbts": [{"id": 1412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 2, "v": 7, "layer": 50, "lpgbts": [{"id": 1412, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 8, "layer": 50, "lpgbts": []},
+        {"isSilicon": true, "u": 3, "v": 4, "layer": 50, "lpgbts": [{"id": 1413, "nElinks": 1}]},
+        {"isSilicon": true, "u": 4, "v": 5, "layer": 50, "lpgbts": [{"id": 1413, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 6, "layer": 50, "lpgbts": [{"id": 1413, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 7, "layer": 50, "lpgbts": [{"id": 1413, "nElinks": 1}]},
+        {"isSilicon": true, "u": 3, "v": 5, "layer": 50, "lpgbts": [{"id": 1414, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 6, "layer": 50, "lpgbts": [{"id": 1414, "nElinks": 2}]},
+        {"isSilicon": true, "u": 3, "v": 7, "layer": 50, "lpgbts": [{"id": 1414, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 8, "layer": 50, "lpgbts": []},
+        {"isSilicon": true, "u": 4, "v": 6, "layer": 50, "lpgbts": [{"id": 1415, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 7, "layer": 50, "lpgbts": [{"id": 1415, "nElinks": 2}]},
+        {"isSilicon": true, "u": 4, "v": 7, "layer": 50, "lpgbts": [{"id": 1415, "nElinks": 2}]},
+        {"isSilicon": true, "u": 5, "v": 8, "layer": 50, "lpgbts": []},
+        {"isSilicon": true, "u": 5, "v": 3, "layer": 50, "lpgbts": [{"id": 1416, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 3, "layer": 50, "lpgbts": [{"id": 1416, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 3, "layer": 50, "lpgbts": [{"id": 1416, "nElinks": 2}]},
+        {"isSilicon": true, "u": 6, "v": 4, "layer": 50, "lpgbts": [{"id": 1417, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 4, "layer": 50, "lpgbts": [{"id": 1417, "nElinks": 2}]},
+        {"isSilicon": true, "u": 7, "v": 5, "layer": 50, "lpgbts": [{"id": 1417, "nElinks": 2}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 37, "lpgbts": [{"id": 1418, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 37, "lpgbts": [{"id": 1418, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 37, "lpgbts": [{"id": 1419, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 37, "lpgbts": [{"id": 1419, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 37, "lpgbts": [{"id": 1420, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 37, "lpgbts": [{"id": 1420, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 37, "lpgbts": [{"id": 1421, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 37, "lpgbts": [{"id": 1421, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 37, "lpgbts": [{"id": 1422, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 37, "lpgbts": [{"id": 1422, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 37, "lpgbts": [{"id": 1423, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 37, "lpgbts": [{"id": 1423, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 37, "lpgbts": [{"id": 1424, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 37, "lpgbts": [{"id": 1424, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 37, "lpgbts": [{"id": 1425, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 37, "lpgbts": [{"id": 1425, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 37, "lpgbts": [{"id": 1426, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 37, "lpgbts": [{"id": 1426, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 37, "lpgbts": [{"id": 1427, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 37, "lpgbts": [{"id": 1427, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 37, "lpgbts": [{"id": 1428, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 37, "lpgbts": [{"id": 1428, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 37, "lpgbts": [{"id": 1429, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 37, "lpgbts": [{"id": 1429, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 38, "lpgbts": [{"id": 1430, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 38, "lpgbts": [{"id": 1430, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 38, "lpgbts": [{"id": 1431, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 38, "lpgbts": [{"id": 1431, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 38, "lpgbts": [{"id": 1432, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 38, "lpgbts": [{"id": 1432, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 38, "lpgbts": [{"id": 1433, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 38, "lpgbts": [{"id": 1433, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 38, "lpgbts": [{"id": 1434, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 38, "lpgbts": [{"id": 1434, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 38, "lpgbts": [{"id": 1435, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 38, "lpgbts": [{"id": 1435, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 38, "lpgbts": [{"id": 1436, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 38, "lpgbts": [{"id": 1436, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 38, "lpgbts": [{"id": 1437, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 38, "lpgbts": [{"id": 1437, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 38, "lpgbts": [{"id": 1438, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 38, "lpgbts": [{"id": 1438, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 38, "lpgbts": [{"id": 1439, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 38, "lpgbts": [{"id": 1439, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 38, "lpgbts": [{"id": 1440, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 38, "lpgbts": [{"id": 1440, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 38, "lpgbts": [{"id": 1441, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 38, "lpgbts": [{"id": 1441, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 39, "lpgbts": [{"id": 1442, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 39, "lpgbts": [{"id": 1442, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 39, "lpgbts": [{"id": 1443, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 39, "lpgbts": [{"id": 1443, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 39, "lpgbts": [{"id": 1444, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 39, "lpgbts": [{"id": 1444, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 39, "lpgbts": [{"id": 1445, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 39, "lpgbts": [{"id": 1445, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 39, "lpgbts": [{"id": 1446, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 39, "lpgbts": [{"id": 1446, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 39, "lpgbts": [{"id": 1447, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 39, "lpgbts": [{"id": 1447, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 39, "lpgbts": [{"id": 1448, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 39, "lpgbts": [{"id": 1448, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 39, "lpgbts": [{"id": 1449, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 39, "lpgbts": [{"id": 1449, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 39, "lpgbts": [{"id": 1450, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 39, "lpgbts": [{"id": 1450, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 39, "lpgbts": [{"id": 1451, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 39, "lpgbts": [{"id": 1451, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 39, "lpgbts": [{"id": 1452, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 39, "lpgbts": [{"id": 1452, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 39, "lpgbts": [{"id": 1453, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 39, "lpgbts": [{"id": 1453, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 40, "lpgbts": [{"id": 1454, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 40, "lpgbts": [{"id": 1454, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 40, "lpgbts": [{"id": 1455, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 40, "lpgbts": [{"id": 1455, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 40, "lpgbts": [{"id": 1456, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 40, "lpgbts": [{"id": 1456, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 40, "lpgbts": [{"id": 1457, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 40, "lpgbts": [{"id": 1457, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 40, "lpgbts": [{"id": 1458, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 40, "lpgbts": [{"id": 1458, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 40, "lpgbts": [{"id": 1459, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 40, "lpgbts": [{"id": 1459, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 40, "lpgbts": [{"id": 1460, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 40, "lpgbts": [{"id": 1460, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 40, "lpgbts": [{"id": 1461, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 40, "lpgbts": [{"id": 1461, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 40, "lpgbts": [{"id": 1462, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 40, "lpgbts": [{"id": 1462, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 40, "lpgbts": [{"id": 1463, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 40, "lpgbts": [{"id": 1463, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 40, "lpgbts": [{"id": 1464, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 40, "lpgbts": [{"id": 1464, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 40, "lpgbts": [{"id": 1465, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 40, "lpgbts": [{"id": 1465, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 41, "lpgbts": [{"id": 1466, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 41, "lpgbts": [{"id": 1466, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 41, "lpgbts": [{"id": 1467, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 41, "lpgbts": [{"id": 1467, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 41, "lpgbts": [{"id": 1468, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 41, "lpgbts": [{"id": 1468, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 41, "lpgbts": [{"id": 1469, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 41, "lpgbts": [{"id": 1469, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 41, "lpgbts": [{"id": 1470, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 41, "lpgbts": [{"id": 1470, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 41, "lpgbts": [{"id": 1471, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 41, "lpgbts": [{"id": 1471, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 41, "lpgbts": [{"id": 1472, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 41, "lpgbts": [{"id": 1472, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 41, "lpgbts": [{"id": 1473, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 41, "lpgbts": [{"id": 1473, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 41, "lpgbts": [{"id": 1474, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 41, "lpgbts": [{"id": 1474, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 41, "lpgbts": [{"id": 1475, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 41, "lpgbts": [{"id": 1475, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 41, "lpgbts": [{"id": 1476, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 41, "lpgbts": [{"id": 1476, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 41, "lpgbts": [{"id": 1477, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 41, "lpgbts": [{"id": 1477, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 42, "lpgbts": [{"id": 1478, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 42, "lpgbts": [{"id": 1478, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 42, "lpgbts": [{"id": 1479, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 42, "lpgbts": [{"id": 1479, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 42, "lpgbts": [{"id": 1480, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 42, "lpgbts": [{"id": 1480, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 42, "lpgbts": [{"id": 1481, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 42, "lpgbts": [{"id": 1481, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 42, "lpgbts": [{"id": 1482, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 42, "lpgbts": [{"id": 1482, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 42, "lpgbts": [{"id": 1483, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 42, "lpgbts": [{"id": 1483, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 42, "lpgbts": [{"id": 1484, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 42, "lpgbts": [{"id": 1484, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 42, "lpgbts": [{"id": 1485, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 42, "lpgbts": [{"id": 1485, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 42, "lpgbts": [{"id": 1486, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 42, "lpgbts": [{"id": 1486, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 42, "lpgbts": [{"id": 1487, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 42, "lpgbts": [{"id": 1487, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 42, "lpgbts": [{"id": 1488, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 42, "lpgbts": [{"id": 1488, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 42, "lpgbts": [{"id": 1489, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 42, "lpgbts": [{"id": 1489, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 43, "lpgbts": [{"id": 1490, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 43, "lpgbts": [{"id": 1490, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 43, "lpgbts": [{"id": 1491, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 43, "lpgbts": [{"id": 1491, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 43, "lpgbts": [{"id": 1492, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 43, "lpgbts": [{"id": 1492, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 43, "lpgbts": [{"id": 1493, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 43, "lpgbts": [{"id": 1493, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 43, "lpgbts": [{"id": 1494, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 43, "lpgbts": [{"id": 1494, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 43, "lpgbts": [{"id": 1495, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 43, "lpgbts": [{"id": 1495, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 43, "lpgbts": [{"id": 1496, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 43, "lpgbts": [{"id": 1496, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 43, "lpgbts": [{"id": 1497, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 43, "lpgbts": [{"id": 1497, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 43, "lpgbts": [{"id": 1498, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 43, "lpgbts": [{"id": 1498, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 43, "lpgbts": [{"id": 1499, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 43, "lpgbts": [{"id": 1499, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 43, "lpgbts": [{"id": 1500, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 43, "lpgbts": [{"id": 1500, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 43, "lpgbts": [{"id": 1501, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 43, "lpgbts": [{"id": 1501, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 44, "lpgbts": [{"id": 1502, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 44, "lpgbts": [{"id": 1502, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 44, "lpgbts": [{"id": 1503, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 44, "lpgbts": [{"id": 1503, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 44, "lpgbts": [{"id": 1504, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 44, "lpgbts": [{"id": 1504, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 44, "lpgbts": [{"id": 1505, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 44, "lpgbts": [{"id": 1505, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 44, "lpgbts": [{"id": 1506, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 44, "lpgbts": [{"id": 1506, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 44, "lpgbts": [{"id": 1507, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 44, "lpgbts": [{"id": 1507, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 44, "lpgbts": [{"id": 1508, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 44, "lpgbts": [{"id": 1508, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 44, "lpgbts": [{"id": 1509, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 44, "lpgbts": [{"id": 1509, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 44, "lpgbts": [{"id": 1510, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 44, "lpgbts": [{"id": 1510, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 44, "lpgbts": [{"id": 1511, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 44, "lpgbts": [{"id": 1511, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 44, "lpgbts": [{"id": 1512, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 44, "lpgbts": [{"id": 1512, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 44, "lpgbts": [{"id": 1513, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 44, "lpgbts": [{"id": 1513, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 45, "lpgbts": [{"id": 1514, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 45, "lpgbts": [{"id": 1514, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 45, "lpgbts": [{"id": 1515, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 45, "lpgbts": [{"id": 1515, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 45, "lpgbts": [{"id": 1516, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 45, "lpgbts": [{"id": 1516, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 45, "lpgbts": [{"id": 1517, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 45, "lpgbts": [{"id": 1517, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 45, "lpgbts": [{"id": 1518, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 45, "lpgbts": [{"id": 1518, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 45, "lpgbts": [{"id": 1519, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 45, "lpgbts": [{"id": 1519, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 45, "lpgbts": [{"id": 1520, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 45, "lpgbts": [{"id": 1520, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 45, "lpgbts": [{"id": 1521, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 45, "lpgbts": [{"id": 1521, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 45, "lpgbts": [{"id": 1522, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 45, "lpgbts": [{"id": 1522, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 45, "lpgbts": [{"id": 1523, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 45, "lpgbts": [{"id": 1523, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 45, "lpgbts": [{"id": 1524, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 45, "lpgbts": [{"id": 1524, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 45, "lpgbts": [{"id": 1525, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 45, "lpgbts": [{"id": 1525, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 46, "lpgbts": [{"id": 1526, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 46, "lpgbts": [{"id": 1526, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 46, "lpgbts": [{"id": 1527, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 46, "lpgbts": [{"id": 1527, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 46, "lpgbts": [{"id": 1528, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 46, "lpgbts": [{"id": 1528, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 46, "lpgbts": [{"id": 1529, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 46, "lpgbts": [{"id": 1529, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 46, "lpgbts": [{"id": 1530, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 46, "lpgbts": [{"id": 1530, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 46, "lpgbts": [{"id": 1531, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 46, "lpgbts": [{"id": 1531, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 46, "lpgbts": [{"id": 1532, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 46, "lpgbts": [{"id": 1532, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 46, "lpgbts": [{"id": 1533, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 46, "lpgbts": [{"id": 1533, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 46, "lpgbts": [{"id": 1534, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 46, "lpgbts": [{"id": 1534, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 46, "lpgbts": [{"id": 1535, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 46, "lpgbts": [{"id": 1535, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 46, "lpgbts": [{"id": 1536, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 46, "lpgbts": [{"id": 1536, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 46, "lpgbts": [{"id": 1537, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 46, "lpgbts": [{"id": 1537, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 47, "lpgbts": [{"id": 1538, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 47, "lpgbts": [{"id": 1538, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 47, "lpgbts": [{"id": 1539, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 47, "lpgbts": [{"id": 1539, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 47, "lpgbts": [{"id": 1540, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 47, "lpgbts": [{"id": 1540, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 47, "lpgbts": [{"id": 1541, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 47, "lpgbts": [{"id": 1541, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 47, "lpgbts": [{"id": 1542, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 47, "lpgbts": [{"id": 1542, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 47, "lpgbts": [{"id": 1543, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 47, "lpgbts": [{"id": 1543, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 47, "lpgbts": [{"id": 1544, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 47, "lpgbts": [{"id": 1544, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 47, "lpgbts": [{"id": 1545, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 47, "lpgbts": [{"id": 1545, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 47, "lpgbts": [{"id": 1546, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 47, "lpgbts": [{"id": 1546, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 47, "lpgbts": [{"id": 1547, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 47, "lpgbts": [{"id": 1547, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 47, "lpgbts": [{"id": 1548, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 47, "lpgbts": [{"id": 1548, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 47, "lpgbts": [{"id": 1549, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 47, "lpgbts": [{"id": 1549, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 48, "lpgbts": [{"id": 1550, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 48, "lpgbts": [{"id": 1550, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 48, "lpgbts": [{"id": 1551, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 48, "lpgbts": [{"id": 1551, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 48, "lpgbts": [{"id": 1552, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 48, "lpgbts": [{"id": 1552, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 48, "lpgbts": [{"id": 1553, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 48, "lpgbts": [{"id": 1553, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 48, "lpgbts": [{"id": 1554, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 48, "lpgbts": [{"id": 1554, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 48, "lpgbts": [{"id": 1555, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 48, "lpgbts": [{"id": 1555, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 48, "lpgbts": [{"id": 1556, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 48, "lpgbts": [{"id": 1556, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 48, "lpgbts": [{"id": 1557, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 48, "lpgbts": [{"id": 1557, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 48, "lpgbts": [{"id": 1558, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 48, "lpgbts": [{"id": 1558, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 48, "lpgbts": [{"id": 1559, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 48, "lpgbts": [{"id": 1559, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 48, "lpgbts": [{"id": 1560, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 48, "lpgbts": [{"id": 1560, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 48, "lpgbts": [{"id": 1561, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 48, "lpgbts": [{"id": 1561, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 49, "lpgbts": [{"id": 1562, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 49, "lpgbts": [{"id": 1562, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 49, "lpgbts": [{"id": 1563, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 49, "lpgbts": [{"id": 1563, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 49, "lpgbts": [{"id": 1564, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 49, "lpgbts": [{"id": 1564, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 49, "lpgbts": [{"id": 1565, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 49, "lpgbts": [{"id": 1565, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 49, "lpgbts": [{"id": 1566, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 49, "lpgbts": [{"id": 1566, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 49, "lpgbts": [{"id": 1567, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 49, "lpgbts": [{"id": 1567, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 49, "lpgbts": [{"id": 1568, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 49, "lpgbts": [{"id": 1568, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 49, "lpgbts": [{"id": 1569, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 49, "lpgbts": [{"id": 1569, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 49, "lpgbts": [{"id": 1570, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 49, "lpgbts": [{"id": 1570, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 49, "lpgbts": [{"id": 1571, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 49, "lpgbts": [{"id": 1571, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 49, "lpgbts": [{"id": 1572, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 49, "lpgbts": [{"id": 1572, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 49, "lpgbts": [{"id": 1573, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 49, "lpgbts": [{"id": 1573, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 0, "layer": 50, "lpgbts": [{"id": 1574, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 0, "layer": 50, "lpgbts": [{"id": 1574, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 1, "layer": 50, "lpgbts": [{"id": 1575, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 1, "layer": 50, "lpgbts": [{"id": 1575, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 2, "layer": 50, "lpgbts": [{"id": 1576, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 2, "layer": 50, "lpgbts": [{"id": 1576, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 3, "layer": 50, "lpgbts": [{"id": 1577, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 3, "layer": 50, "lpgbts": [{"id": 1577, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 4, "layer": 50, "lpgbts": [{"id": 1578, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 4, "layer": 50, "lpgbts": [{"id": 1578, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 5, "layer": 50, "lpgbts": [{"id": 1579, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 5, "layer": 50, "lpgbts": [{"id": 1579, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 6, "layer": 50, "lpgbts": [{"id": 1580, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 6, "layer": 50, "lpgbts": [{"id": 1580, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 7, "layer": 50, "lpgbts": [{"id": 1581, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 7, "layer": 50, "lpgbts": [{"id": 1581, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 8, "layer": 50, "lpgbts": [{"id": 1582, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 8, "layer": 50, "lpgbts": [{"id": 1582, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 9, "layer": 50, "lpgbts": [{"id": 1583, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 9, "layer": 50, "lpgbts": [{"id": 1583, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 10, "layer": 50, "lpgbts": [{"id": 1584, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 10, "layer": 50, "lpgbts": [{"id": 1584, "nElinks": 3}]},
+        {"isSilicon": false, "u": 0, "v": 11, "layer": 50, "lpgbts": [{"id": 1585, "nElinks": 4}]},
+        {"isSilicon": false, "u": 1, "v": 11, "layer": 50, "lpgbts": [{"id": 1585, "nElinks": 3}]},
+        {"isSilicon": true, "layer": 1, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 1, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 3, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 7, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 9, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 2, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 3, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 9, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 4, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 5, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 9, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 6, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 7, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 9, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 8, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 9, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 1, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 5, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 10, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 11, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 10, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 12, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 13, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 14, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 15, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 16, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 17, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 18, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 19, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 20, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 21, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 22, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 23, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 24, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 25, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 26, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 6, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 27, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 6, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 11, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 28, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 0, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 1, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 1, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 4, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 7, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 9, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 10, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 10, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 11, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 29, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 1, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 2, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 3, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 6, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 9, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 10, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 11, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 11, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 12, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 12, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 30, "u": 12, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 0, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 0, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 1, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 3, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 8, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 11, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 12, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 31, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 2, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 2, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 5, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 6, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 6, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 7, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 8, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 10, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 11, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 11, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 12, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 12, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 32, "u": 12, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 0, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 0, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 1, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 5, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 6, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 11, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 11, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 12, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 12, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 33, "u": 12, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 1, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 2, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 4, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 6, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 7, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 9, "v": 13, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 10, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 11, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 11, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 11, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 12, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 13, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 13, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 34, "u": 13, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 0, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 1, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 3, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 6, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 9, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 11, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 12, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 12, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 12, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 12, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 12, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 35, "u": 13, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 2, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 4, "v": 14, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 7, "v": 14, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 10, "v": 14, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 12, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 12, "v": 12, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 13, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 14, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 14, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 14, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 36, "u": 14, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 0, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 1, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 2, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 3, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 7, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 37, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 1, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 2, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 3, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 11, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 38, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 0, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 1, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 2, "v": 0, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 3, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 7, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 39, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 1, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 2, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 2, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 3, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 9, "v": 11, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 10, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 10, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 11, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 40, "u": 11, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 0, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 0, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 2, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 3, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 6, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 7, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 8, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 9, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 41, "u": 9, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 2, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 2, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 3, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 8, "v": 10, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 9, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 9, "v": 9, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 10, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 10, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 10, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 42, "u": 10, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 0, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 0, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 3, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 4, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 5, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 43, "u": 7, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 2, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 3, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 8, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 8, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 9, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 9, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 44, "u": 9, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 0, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 0, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 3, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 4, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 5, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 45, "u": 7, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 2, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 3, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 8, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 8, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 9, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 9, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 46, "u": 9, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 0, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 0, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 3, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 4, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 6, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 7, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 47, "u": 7, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 2, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 2, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 3, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 6, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 7, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 7, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 8, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 48, "u": 8, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 0, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 0, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 2, "v": 2, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 3, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 4, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 6, "v": 6, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 7, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 49, "u": 7, "v": 5, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 2, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 2, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 3, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 3, "v": 3, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 6, "v": 8, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 7, "v": 1, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 7, "v": 7, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 8, "v": 4, "lpgbts": []},
+        {"isSilicon": true, "layer": 50, "u": 8, "v": 5, "lpgbts": []}
+    ]
+}

--- a/L1Trigger/L1THGCal/interface/HGCalBackendCommon.h
+++ b/L1Trigger/L1THGCal/interface/HGCalBackendCommon.h
@@ -1,0 +1,6 @@
+#ifndef L1Trigger_L1THGCal_HGCalBackendCommon_H
+#define L1Trigger_L1THGCal_HGCalBackendCommon_H 1
+
+enum HGCalClassIdentifier { ModuleDetId, BackendDetId };
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalBackendDetId.h
+++ b/L1Trigger/L1THGCal/interface/HGCalBackendDetId.h
@@ -1,0 +1,76 @@
+#ifndef L1Trigger_L1THGCal_HGCalBackendDetId_H
+#define L1Trigger_L1THGCal_HGCalBackendDetId_H 1
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "L1Trigger/L1THGCal/interface/HGCalBackendCommon.h"
+
+/* \brief description of the bit assigment
+   [0:10]  ID of the lpGBT or Stage 1 FPGA in sector 0 
+   [11:12] sector (0,1,2 counter-clockwise from u-axis)
+   [13:15] Type (0 lpGBT
+                 1 Stage 1 FPGA
+                 2 Stage 1 link
+                 3 Stage 2 FPGA)
+   [16:16] z-side (0 for +z; 1 for -z)
+   [19:23] reserved for future use
+   [24:24] Class identifier (0 for HGCalModuleDetID, 1 for HGCalBackendDetID)
+   [25:27] Subdetector Type (HGCTrigger)
+   [28:31] Detector type (Forward)
+*/
+
+class HGCalBackendDetId : public DetId {
+public:
+  /** Create a null backend id*/
+  HGCalBackendDetId();
+  /** Create backend id from raw id (0=invalid id) */
+  HGCalBackendDetId(uint32_t rawid);
+  /** Constructor from zplus, type, sector, label */
+  HGCalBackendDetId(int zp, int type, int sector, int label);
+  /** Constructor from a generic det id */
+  HGCalBackendDetId(const DetId& id);
+  /** Assignment from a generic det id */
+  HGCalBackendDetId& operator=(const DetId& id);
+
+  /// get the class
+  int classId() const { return (id_ >> kHGCalClassIdentifierOffset) & kHGCalClassIdentifierMask; }
+
+  /// get the type
+  int type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
+
+  /// get the z-side of the backend object (1/-1)
+  int zside() const { return ((id_ >> kHGCalZsideOffset) & kHGCalZsideMask ? -1 : 1); }
+
+  /// get the sector #
+  int sector() const { return (id_ >> kHGCalSectorOffset) & kHGCalSectorMask; }
+
+  /// get the value
+  int label() const { return (id_ >> kHGCalLabelOffset) & kHGCalLabelMask; }
+
+  bool isLpGBT() const { return (type() == BackendType::LpGBT); }
+  bool isStage1FPGA() const { return (type() == BackendType::Stage1FPGA); }
+  bool isStage1Link() const { return (type() == BackendType::Stage1Link); }
+  bool isStage2FPGA() const { return (type() == BackendType::Stage2FPGA); }
+  bool isForward() const { return true; }
+  bool isHGCalModuleDetId() const { return (classId() == HGCalClassIdentifier::ModuleDetId); }
+  bool isHGCalBackendDetId() const { return (classId() == HGCalClassIdentifier::BackendDetId); }
+
+  static const HGCalBackendDetId Undefined;
+
+  static const int kHGCalLabelOffset = 0;
+  static const int kHGCalLabelMask = 0x7FF;
+  static const int kHGCalSectorOffset = 11;
+  static const int kHGCalSectorMask = 0x3;
+  static const int kHGCalTypeOffset = 13;
+  static const int kHGCalTypeMask = 0x7;
+  static const int kHGCalZsideOffset = 16;
+  static const int kHGCalZsideMask = 0x1;
+  static const int kHGCalClassIdentifierOffset = 24;
+  static const int kHGCalClassIdentifierMask = 0x1;
+
+  enum BackendType { LpGBT, Stage1FPGA, Stage1Link, Stage2FPGA };
+};
+
+std::ostream& operator<<(std::ostream&, const HGCalBackendDetId& id);
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalModuleDetId.h
+++ b/L1Trigger/L1THGCal/interface/HGCalModuleDetId.h
@@ -1,0 +1,106 @@
+#ifndef L1Trigger_L1THGCal_HGCalModuleDetId_H
+#define L1Trigger_L1THGCal_HGCalModuleDetId_H 1
+
+#include "L1Trigger/L1THGCal/interface/HGCalBackendCommon.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+
+/* \brief description of the bit assigment
+   [0:3]  u-coordinate of the silicon module (u-axis points along -x axis)
+          or eta-coordinate of the scintillator module
+   [4:7]  v-coordinate of the silicon module (v-axis points 60-degree wrt x-axis)
+          or phi-coordinate of the scintillator module
+   [8:9] sector (0,1,2 counter-clockwise from u-axis)
+
+   [10:13] reserved for future use
+
+   [14:18] layer number 
+   [19:20] Type (0 fine divisions of wafer with 120 mum thick silicon
+                 1 coarse divisions of wafer with 200 mum thick silicon
+                 2 coarse divisions of wafer with 300 mum thick silicon
+                 0 fine divisions of scintillators
+                 1 coarse divisions of scintillators)
+
+   [21:21] z-side (0 for +z; 1 for -z)
+   [22:23] Trigger Subdetector Type(HGCEE/HGCHEF/HGCHEB/HFNose) 
+   [24:24] Class identifier (0 for HGCalModuleDetID, 1 for HGCalBackendDetID)
+   [25:27] Subdetector Type (HGCTrigger)
+   [28:31] Detector type (Forward)
+*/
+
+class HGCalModuleDetId : public DetId {
+public:
+  /** Create a null module id*/
+  HGCalModuleDetId();
+  /** Create module id from raw id (0=invalid id) */
+  HGCalModuleDetId(uint32_t rawid);
+  /** Constructor from subdetector, zplus, type, layer, sector, module numbers */
+  HGCalModuleDetId(HGCalTriggerSubdetector subdet, int zp, int type, int layer, int sector, int moduleU, int moduleV);
+  /** Constructor from a generic det id */
+  HGCalModuleDetId(const DetId& id);
+  /** Assignment from a generic det id */
+  HGCalModuleDetId& operator=(const DetId& id);
+
+  /// get the trigger sub-detector
+  int triggerSubdetId() const { return (id_ >> kHGCalTriggerSubdetOffset) & kHGCalTriggerSubdetMask; }
+
+  /// get the class
+  int classId() const { return (id_ >> kHGCalClassIdentifierOffset) & kHGCalClassIdentifierMask; }
+
+  /// get the type
+  int type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
+
+  /// get the z-side of the module (1/-1)
+  int zside() const { return ((id_ >> kHGCalZsideOffset) & kHGCalZsideMask ? -1 : 1); }
+
+  /// get the layer #
+  int layer() const { return (id_ >> kHGCalLayerOffset) & kHGCalLayerMask; }
+
+  /// get the sector #
+  int sector() const { return (id_ >> kHGCalSectorOffset) & kHGCalSectorMask; }
+
+  /// get the module U
+  int moduleU() const { return (id_ >> kHGCalModuleUOffset) & kHGCalModuleUMask; }
+
+  /// get the module V
+  int moduleV() const { return (id_ >> kHGCalModuleVOffset) & kHGCalModuleVMask; }
+
+  /// get the scintillator panel eta
+  int eta() const { return moduleU(); }
+
+  /// get the scintillator panel phi
+  int phi() const { return moduleV(); }
+
+  /// consistency check : no bits left => no overhead
+  bool isHFNose() const { return (triggerSubdetId() == HFNoseTrigger); }
+  bool isEE() const { return (triggerSubdetId() == HGCalEETrigger); }
+  bool isHSilicon() const { return (triggerSubdetId() == HGCalHSiTrigger); }
+  bool isHScintillator() const { return (triggerSubdetId() == HGCalHScTrigger); }
+  bool isForward() const { return true; }
+  bool isHGCTrigger() const { return true; }
+  bool isHGCalModuleDetId() const { return (classId() == HGCalClassIdentifier::ModuleDetId); }
+  bool isHGCalBackendDetId() const { return (classId() == HGCalClassIdentifier::BackendDetId); }
+
+  static const HGCalModuleDetId Undefined;
+
+  static const int kHGCalModuleUOffset = 0;
+  static const int kHGCalModuleUMask = 0xF;
+  static const int kHGCalModuleVOffset = 4;
+  static const int kHGCalModuleVMask = 0xF;
+  static const int kHGCalSectorOffset = 8;
+  static const int kHGCalSectorMask = 0x3;
+  static const int kHGCalLayerOffset = 14;
+  static const int kHGCalLayerMask = 0x1F;
+  static const int kHGCalTypeOffset = 19;
+  static const int kHGCalTypeMask = 0x3;
+  static const int kHGCalZsideOffset = 24;
+  static const int kHGCalZsideMask = 0x1;
+  static const int kHGCalTriggerSubdetOffset = 22;
+  static const int kHGCalTriggerSubdetMask = 0x3;
+  static const int kHGCalClassIdentifierOffset = 24;
+  static const int kHGCalClassIdentifierMask = 0x1;
+};
+
+std::ostream& operator<<(std::ostream&, const HGCalModuleDetId& id);
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -85,6 +85,19 @@ public:
   virtual geom_set getCellsFromModule(const unsigned cell_det_id) const = 0;
   virtual geom_set getTriggerCellsFromModule(const unsigned trigger_cell_det_id) const = 0;
 
+  virtual geom_set getStage1FpgasFromStage2Fpga(const unsigned stage2_id) const = 0;
+  virtual geom_set getStage2FpgasFromStage1Fpga(const unsigned stage1_id) const = 0;
+
+  virtual geom_set getStage1LinksFromStage2Fpga(const unsigned) const = 0;
+  virtual unsigned getStage1FpgaFromStage1Link(const unsigned) const = 0;
+  virtual unsigned getStage2FpgaFromStage1Link(const unsigned) const = 0;
+  virtual geom_set getStage1LinksFromStage1Fpga(const unsigned) const = 0;
+  virtual geom_set getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
+  virtual unsigned getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const = 0;
+  virtual geom_set getModulesFromLpgbt(const unsigned lpgbt_id) const = 0;
+  virtual geom_set getLpgbtsFromModule(const unsigned module_id) const = 0;
+  virtual unsigned getStage1FpgaFromModule(const unsigned module_id) const = 0;
+
   virtual geom_ordered_set getOrderedCellsFromModule(const unsigned cell_det_id) const = 0;
   virtual geom_ordered_set getOrderedTriggerCellsFromModule(const unsigned trigger_cell_det_id) const = 0;
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -32,6 +32,19 @@ public:
 
   geom_set getNeighborsFromTriggerCell(const unsigned) const final;
 
+  geom_set getStage1FpgasFromStage2Fpga(const unsigned) const final;
+  geom_set getStage2FpgasFromStage1Fpga(const unsigned) const final;
+
+  geom_set getStage1LinksFromStage2Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
+  unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
+  geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
+  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
+  geom_set getModulesFromLpgbt(const unsigned) const final;
+  geom_set getLpgbtsFromModule(const unsigned) const final;
+  unsigned getStage1FpgaFromModule(const unsigned module_id) const final;
+
   unsigned getLinksInModule(const unsigned module_id) const final;
   unsigned getModuleSize(const unsigned module_id) const final;
 
@@ -783,6 +796,65 @@ unsigned HGCalTriggerGeometryHexLayerBasedImp1::layerWithOffset(unsigned id) con
       break;
   };
   return layer;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getStage1FpgasFromStage2Fpga(
+    const unsigned) const {
+  geom_set stage1_ids;
+  return stage1_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getStage2FpgasFromStage1Fpga(
+    const unsigned) const {
+  geom_set stage2_ids;
+  return stage2_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getStage1LinksFromStage2Fpga(
+    const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+unsigned HGCalTriggerGeometryHexLayerBasedImp1::getStage1FpgaFromStage1Link(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+unsigned HGCalTriggerGeometryHexLayerBasedImp1::getStage2FpgaFromStage1Link(const unsigned) const {
+  unsigned stage2_id = 0;
+  return stage2_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getStage1LinksFromStage1Fpga(
+    const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getLpgbtsFromStage1Fpga(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryHexLayerBasedImp1::getStage1FpgaFromLpgbt(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getModulesFromLpgbt(const unsigned) const {
+  geom_set modules;
+  return modules;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryHexLayerBasedImp1::getLpgbtsFromModule(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryHexLayerBasedImp1::getStage1FpgaFromModule(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
 }
 
 DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory,

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
@@ -33,6 +33,19 @@ public:
 
   geom_set getNeighborsFromTriggerCell(const unsigned) const final;
 
+  geom_set getStage1FpgasFromStage2Fpga(const unsigned) const final;
+  geom_set getStage2FpgasFromStage1Fpga(const unsigned) const final;
+
+  geom_set getStage1LinksFromStage2Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
+  unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
+  geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
+  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
+  geom_set getModulesFromLpgbt(const unsigned) const final;
+  geom_set getLpgbtsFromModule(const unsigned) const final;
+  unsigned getStage1FpgaFromModule(const unsigned module_id) const final;
+
   unsigned getLinksInModule(const unsigned module_id) const final;
   unsigned getModuleSize(const unsigned module_id) const final;
 
@@ -1026,6 +1039,61 @@ unsigned HGCalTriggerGeometryV9Imp1::layerWithOffset(unsigned id) const {
       break;
   };
   return layer;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getStage1FpgasFromStage2Fpga(const unsigned) const {
+  geom_set stage1_ids;
+  return stage1_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getStage2FpgasFromStage1Fpga(const unsigned) const {
+  geom_set stage2_ids;
+  return stage2_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getLpgbtsFromStage1Fpga(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getStage1LinksFromStage2Fpga(const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp1::getStage1FpgaFromStage1Link(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+unsigned HGCalTriggerGeometryV9Imp1::getStage2FpgaFromStage1Link(const unsigned) const {
+  unsigned stage2_id = 0;
+  return stage2_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getStage1LinksFromStage1Fpga(const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp1::getStage1FpgaFromLpgbt(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getModulesFromLpgbt(const unsigned) const {
+  geom_set modules;
+  return modules;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp1::getLpgbtsFromModule(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp1::getStage1FpgaFromModule(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
 }
 
 DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, HGCalTriggerGeometryV9Imp1, "HGCalTriggerGeometryV9Imp1");

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -37,6 +37,19 @@ public:
 
   geom_set getNeighborsFromTriggerCell(const unsigned) const final;
 
+  geom_set getStage1FpgasFromStage2Fpga(const unsigned) const final;
+  geom_set getStage2FpgasFromStage1Fpga(const unsigned) const final;
+
+  geom_set getStage1LinksFromStage2Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
+  unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
+  geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
+  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
+  geom_set getModulesFromLpgbt(const unsigned) const final;
+  geom_set getLpgbtsFromModule(const unsigned) const final;
+  unsigned getStage1FpgaFromModule(const unsigned module_id) const final;
+
   unsigned getLinksInModule(const unsigned module_id) const final;
   unsigned getModuleSize(const unsigned module_id) const final;
 
@@ -825,6 +838,61 @@ unsigned HGCalTriggerGeometryV9Imp2::layerWithOffset(unsigned id) const {
     }
   }
   return layer;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1FpgasFromStage2Fpga(const unsigned) const {
+  geom_set stage1_ids;
+  return stage1_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage2FpgasFromStage1Fpga(const unsigned) const {
+  geom_set stage2_ids;
+  return stage2_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1LinksFromStage2Fpga(const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp2::getStage1FpgaFromStage1Link(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+unsigned HGCalTriggerGeometryV9Imp2::getStage2FpgaFromStage1Link(const unsigned) const {
+  unsigned stage2_id = 0;
+  return stage2_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1LinksFromStage1Fpga(const unsigned) const {
+  geom_set stage1link_ids;
+  return stage1link_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp2::getStage1FpgaFromLpgbt(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getModulesFromLpgbt(const unsigned) const {
+  geom_set modules;
+  return modules;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getLpgbtsFromModule(const unsigned) const {
+  geom_set lpgbt_ids;
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp2::getStage1FpgaFromModule(const unsigned) const {
+  unsigned stage1_id = 0;
+  return stage1_id;
 }
 
 DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, HGCalTriggerGeometryV9Imp2, "HGCalTriggerGeometryV9Imp2");

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -1,0 +1,1088 @@
+#include "Geometry/HGCalCommonData/interface/HGCalGeomRotation.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalModuleDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalBackendDetId.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h"
+
+#include <fstream>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+class HGCalTriggerGeometryV9Imp3 : public HGCalTriggerGeometryBase {
+public:
+  HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf);
+
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
+  void reset() final;
+
+  unsigned getTriggerCellFromCell(const unsigned) const final;
+  unsigned getModuleFromCell(const unsigned) const final;
+  unsigned getModuleFromTriggerCell(const unsigned) const final;
+
+  geom_set getCellsFromTriggerCell(const unsigned) const final;
+  geom_set getCellsFromModule(const unsigned) const final;
+  geom_set getTriggerCellsFromModule(const unsigned) const final;
+
+  geom_ordered_set getOrderedCellsFromModule(const unsigned) const final;
+  geom_ordered_set getOrderedTriggerCellsFromModule(const unsigned) const final;
+
+  geom_set getNeighborsFromTriggerCell(const unsigned) const final;
+
+  geom_set getStage1FpgasFromStage2Fpga(const unsigned) const final;
+  geom_set getStage2FpgasFromStage1Fpga(const unsigned) const final;
+
+  geom_set getStage1LinksFromStage2Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
+  unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
+  geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
+  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
+  geom_set getModulesFromLpgbt(const unsigned) const final;
+  geom_set getLpgbtsFromModule(const unsigned) const final;
+  unsigned getStage1FpgaFromModule(const unsigned module_id) const final;
+
+  unsigned getLinksInModule(const unsigned module_id) const final;
+  unsigned getModuleSize(const unsigned module_id) const final;
+
+  GlobalPoint getTriggerCellPosition(const unsigned) const final;
+  GlobalPoint getModulePosition(const unsigned) const final;
+
+  bool validCell(const unsigned) const final;
+  bool validTriggerCell(const unsigned) const final;
+  bool disconnectedModule(const unsigned) const final;
+  unsigned lastTriggerLayer() const final { return last_trigger_layer_; }
+  unsigned triggerLayer(const unsigned) const final;
+
+private:
+  // HSc trigger cell grouping
+  unsigned hSc_triggercell_size_ = 2;
+  unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
+  unsigned hSc_wafers_per_module_ = 3;
+
+  edm::FileInPath jsonMappingFile_;
+
+  // rotation class
+  HGCalGeomRotation geom_rotation_120_ = {HGCalGeomRotation::SectorType::Sector120Degrees};
+
+  // module related maps
+  std::unordered_map<unsigned, unsigned> links_per_module_;
+
+  std::unordered_multimap<unsigned, unsigned> stage2_to_stage1links_;
+  std::unordered_map<unsigned, unsigned> stage1link_to_stage2_;
+  std::unordered_map<unsigned, unsigned> stage1link_to_stage1_;
+  std::unordered_multimap<unsigned, unsigned> stage1_to_stage1links_;
+  std::unordered_multimap<unsigned, unsigned> stage1_to_lpgbts_;
+  std::unordered_map<unsigned, unsigned> lpgbt_to_stage1_;
+  std::unordered_multimap<unsigned, unsigned> lpgbt_to_modules_;
+  std::unordered_multimap<unsigned, unsigned> module_to_lpgbts_;
+  std::unordered_map<unsigned, unsigned> module_to_stage1_;
+
+  // Disconnected modules and layers
+  std::unordered_set<unsigned> disconnected_layers_;
+  std::vector<unsigned> trigger_layers_;
+  std::vector<unsigned> trigger_nose_layers_;
+  unsigned last_trigger_layer_ = 0;
+
+  //Scintillator layout
+  unsigned hSc_num_panels_per_sector_ = 8;
+
+  // layer offsets
+  unsigned heOffset_ = 0;
+  unsigned noseLayers_ = 0;
+  unsigned totalLayers_ = 0;
+
+  void fillMaps();
+  bool validCellId(unsigned det, unsigned cell_id) const;
+  bool validTriggerCellFromCells(const unsigned) const;
+
+  int detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const;
+  void layerWithoutOffsetAndSubdetId(unsigned& layer, int& subdetId, bool isSilicon) const;
+  unsigned packLayerSubdetWaferId(unsigned layer, int subdet, int waferU, int waferV) const;
+  void unpackLayerSubdetWaferId(unsigned wafer, unsigned& layer, int& subdet, int& waferU, int& waferV) const;
+  HGCalGeomRotation::WaferCentring getWaferCentring(unsigned layer, int subdet) const;
+  void etaphiMappingFromSector0(int& ieta, int& iphi, unsigned sector) const;
+  unsigned etaphiMappingToSector0(int& ieta, int& iphi) const;
+  unsigned layerWithOffset(unsigned) const;
+  unsigned getNextSector(const unsigned sector) const;
+  unsigned getPreviousSector(const unsigned sector) const;
+};
+
+HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf)
+    : HGCalTriggerGeometryBase(conf),
+      hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
+      hSc_module_size_(conf.getParameter<unsigned>("ScintillatorModuleSize")),
+      jsonMappingFile_(conf.getParameter<edm::FileInPath>("JsonMappingFile")) {
+  const unsigned ntc_per_wafer = 48;
+  hSc_wafers_per_module_ = std::round(hSc_module_size_ * hSc_module_size_ / float(ntc_per_wafer));
+  if (ntc_per_wafer * hSc_wafers_per_module_ < hSc_module_size_ * hSc_module_size_) {
+    hSc_wafers_per_module_++;
+  }
+  std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedLayers");
+  std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_layers_, disconnected_layers_.end()));
+}
+
+void HGCalTriggerGeometryV9Imp3::reset() {
+  stage2_to_stage1links_.clear();
+  stage1link_to_stage2_.clear();
+  stage1link_to_stage1_.clear();
+  stage1_to_stage1links_.clear();
+  stage1_to_lpgbts_.clear();
+  lpgbt_to_stage1_.clear();
+  lpgbt_to_modules_.clear();
+  module_to_lpgbts_.clear();
+  module_to_stage1_.clear();
+}
+
+void HGCalTriggerGeometryV9Imp3::initialize(const CaloGeometry* calo_geometry) {
+  throw cms::Exception("BadGeometry")
+      << "HGCalTriggerGeometryV9Imp3 geometry cannot be initialized with the V7/V8 HGCAL geometry";
+}
+
+void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                            const HGCalGeometry* hgc_hsi_geometry,
+                                            const HGCalGeometry* hgc_hsc_geometry) {
+  setEEGeometry(hgc_ee_geometry);
+  setHSiGeometry(hgc_hsi_geometry);
+  setHScGeometry(hgc_hsc_geometry);
+  heOffset_ = eeTopology().dddConstants().layers(true);
+  totalLayers_ = heOffset_ + hsiTopology().dddConstants().layers(true);
+  trigger_layers_.resize(totalLayers_ + 1);
+  trigger_layers_[0] = 0;  // layer number 0 doesn't exist
+  unsigned trigger_layer = 1;
+  for (unsigned layer = 1; layer < trigger_layers_.size(); layer++) {
+    if (disconnected_layers_.find(layer) == disconnected_layers_.end()) {
+      // Increase trigger layer number if the layer is not disconnected
+      trigger_layers_[layer] = trigger_layer;
+      trigger_layer++;
+    } else {
+      trigger_layers_[layer] = 0;
+    }
+  }
+  last_trigger_layer_ = trigger_layer - 1;
+  fillMaps();
+}
+
+void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                            const HGCalGeometry* hgc_hsi_geometry,
+                                            const HGCalGeometry* hgc_hsc_geometry,
+                                            const HGCalGeometry* hgc_nose_geometry) {
+  setEEGeometry(hgc_ee_geometry);
+  setHSiGeometry(hgc_hsi_geometry);
+  setHScGeometry(hgc_hsc_geometry);
+  setNoseGeometry(hgc_nose_geometry);
+
+  heOffset_ = eeTopology().dddConstants().layers(true);
+  totalLayers_ = heOffset_ + hsiTopology().dddConstants().layers(true);
+
+  trigger_layers_.resize(totalLayers_ + 1);
+  trigger_layers_[0] = 0;  // layer number 0 doesn't exist
+  unsigned trigger_layer = 1;
+  for (unsigned layer = 1; layer < trigger_layers_.size(); layer++) {
+    if (disconnected_layers_.find(layer) == disconnected_layers_.end()) {
+      // Increase trigger layer number if the layer is not disconnected
+      trigger_layers_[layer] = trigger_layer;
+      trigger_layer++;
+    } else {
+      trigger_layers_[layer] = 0;
+    }
+  }
+  last_trigger_layer_ = trigger_layer - 1;
+  fillMaps();
+
+  noseLayers_ = noseTopology().dddConstants().layers(true);
+
+  trigger_nose_layers_.resize(noseLayers_ + 1);
+  trigger_nose_layers_[0] = 0;  // layer number 0 doesn't exist
+  unsigned trigger_nose_layer = 1;
+  for (unsigned layer = 1; layer < trigger_nose_layers_.size(); layer++) {
+    trigger_nose_layers_[layer] = trigger_nose_layer;
+    trigger_nose_layer++;
+  }
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getTriggerCellFromCell(const unsigned cell_id) const {
+  unsigned det = DetId(cell_id).det();
+  unsigned trigger_cell_id = 0;
+  // Scintillator
+  if (det == DetId::HGCalHSc) {
+    // Very rough mapping from cells to TC
+    HGCScintillatorDetId cell_sc_id(cell_id);
+    int ieta = ((cell_sc_id.ietaAbs() - 1) / hSc_triggercell_size_ + 1) * cell_sc_id.zside();
+    int iphi = (cell_sc_id.iphi() - 1) / hSc_triggercell_size_ + 1;
+    trigger_cell_id = HGCScintillatorDetId(cell_sc_id.type(), cell_sc_id.layer(), ieta, iphi);
+  }
+  // HFNose
+  else if (det == DetId::Forward && DetId(cell_id).subdetId() == ForwardSubdetector::HFNose) {
+    HFNoseDetId cell_nose_id(cell_id);
+    trigger_cell_id = HFNoseTriggerDetId(HGCalTriggerSubdetector::HFNoseTrigger,
+                                         cell_nose_id.zside(),
+                                         cell_nose_id.type(),
+                                         cell_nose_id.layer(),
+                                         cell_nose_id.waferU(),
+                                         cell_nose_id.waferV(),
+                                         cell_nose_id.triggerCellU(),
+                                         cell_nose_id.triggerCellV());
+  }
+  // Silicon
+  else if (det == DetId::HGCalEE || det == DetId::HGCalHSi) {
+    HGCSiliconDetId cell_si_id(cell_id);
+    trigger_cell_id = HGCalTriggerDetId(
+        det == DetId::HGCalEE ? HGCalTriggerSubdetector::HGCalEETrigger : HGCalTriggerSubdetector::HGCalHSiTrigger,
+        cell_si_id.zside(),
+        cell_si_id.type(),
+        cell_si_id.layer(),
+        cell_si_id.waferU(),
+        cell_si_id.waferV(),
+        cell_si_id.triggerCellU(),
+        cell_si_id.triggerCellV());
+  }
+  return trigger_cell_id;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getModuleFromCell(const unsigned cell_id) const {
+  return getModuleFromTriggerCell(getTriggerCellFromCell(cell_id));
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned trigger_cell_id) const {
+  unsigned det = DetId(trigger_cell_id).det();
+  int zside = 0;
+  unsigned tc_type = 1;
+  unsigned layer = 0;
+  unsigned module_id = 0;
+
+  // Scintillator
+  if (det == DetId::HGCalHSc) {
+    HGCScintillatorDetId trigger_cell_sc_id(trigger_cell_id);
+    tc_type = trigger_cell_sc_id.type();
+    layer = trigger_cell_sc_id.layer();
+    zside = trigger_cell_sc_id.zside();
+    int ietamin = hscTopology().dddConstants().getREtaRange(layer).first;
+    int ietamin_tc = ((ietamin - 1) / hSc_triggercell_size_ + 1);
+    int ieta = ((trigger_cell_sc_id.ietaAbs() - ietamin_tc) / hSc_module_size_ + 1);
+    int iphi = (trigger_cell_sc_id.iphi() - 1) / hSc_module_size_ + 1;
+    unsigned sector = etaphiMappingToSector0(ieta, iphi);
+    module_id = HGCalModuleDetId(HGCalTriggerSubdetector::HGCalHScTrigger, zside, tc_type, layer, sector, ieta, iphi);
+  }
+  // HFNose
+  else if (det == DetId::HGCalTrigger and
+           HGCalTriggerDetId(trigger_cell_id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    HFNoseTriggerDetId trigger_cell_trig_id(trigger_cell_id);
+    tc_type = trigger_cell_trig_id.type();
+    layer = trigger_cell_trig_id.layer();
+    zside = trigger_cell_trig_id.zside();
+    int waferu = trigger_cell_trig_id.waferU();
+    int waferv = trigger_cell_trig_id.waferV();
+    unsigned sector = geom_rotation_120_.uvMappingToSector0(
+        getWaferCentring(layer, HGCalTriggerSubdetector::HFNoseTrigger), waferu, waferv);
+    module_id = HGCalModuleDetId(HGCalTriggerSubdetector::HFNoseTrigger, zside, tc_type, layer, sector, waferu, waferv);
+  }
+  // Silicon
+  else {
+    HGCalTriggerDetId trigger_cell_trig_id(trigger_cell_id);
+    unsigned subdet = trigger_cell_trig_id.subdet();
+    tc_type = trigger_cell_trig_id.type();
+    layer = trigger_cell_trig_id.layer();
+    zside = trigger_cell_trig_id.zside();
+    int waferu = trigger_cell_trig_id.waferU();
+    int waferv = trigger_cell_trig_id.waferV();
+    unsigned sector = geom_rotation_120_.uvMappingToSector0(getWaferCentring(layer, subdet), waferu, waferv);
+    module_id = HGCalModuleDetId(HGCalTriggerSubdetector(subdet), zside, tc_type, layer, sector, waferu, waferv);
+  }
+  return module_id;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromTriggerCell(
+    const unsigned trigger_cell_id) const {
+  DetId trigger_cell_det_id(trigger_cell_id);
+  unsigned det = trigger_cell_det_id.det();
+  geom_set cell_det_ids;
+  // Scintillator
+  if (det == DetId::HGCalHSc) {
+    HGCScintillatorDetId trigger_cell_sc_id(trigger_cell_id);
+    int ieta0 = (trigger_cell_sc_id.ietaAbs() - 1) * hSc_triggercell_size_ + 1;
+    int iphi0 = (trigger_cell_sc_id.iphi() - 1) * hSc_triggercell_size_ + 1;
+    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_triggercell_size_; ietaAbs++) {
+      int ieta = ietaAbs * trigger_cell_sc_id.zside();
+      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_triggercell_size_; iphi++) {
+        unsigned cell_id = HGCScintillatorDetId(trigger_cell_sc_id.type(), trigger_cell_sc_id.layer(), ieta, iphi);
+        if (validCellId(DetId::HGCalHSc, cell_id))
+          cell_det_ids.emplace(cell_id);
+      }
+    }
+  }
+  // HFNose
+  else if (det == DetId::HGCalTrigger and
+           HGCalTriggerDetId(trigger_cell_id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    HFNoseTriggerDetId trigger_cell_nose_id(trigger_cell_id);
+    int layer = trigger_cell_nose_id.layer();
+    int zside = trigger_cell_nose_id.zside();
+    int type = trigger_cell_nose_id.type();
+    int waferu = trigger_cell_nose_id.waferU();
+    int waferv = trigger_cell_nose_id.waferV();
+    std::vector<int> cellus = trigger_cell_nose_id.cellU();
+    std::vector<int> cellvs = trigger_cell_nose_id.cellV();
+    for (unsigned ic = 0; ic < cellus.size(); ic++) {
+      HFNoseDetId cell_det_id(zside, type, layer, waferu, waferv, cellus[ic], cellvs[ic]);
+      cell_det_ids.emplace(cell_det_id);
+    }
+  }
+  // Silicon
+  else {
+    HGCalTriggerDetId trigger_cell_trig_id(trigger_cell_id);
+    unsigned subdet = trigger_cell_trig_id.subdet();
+    if (subdet == HGCalTriggerSubdetector::HGCalEETrigger || subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+      DetId::Detector cell_det = (subdet == HGCalTriggerSubdetector::HGCalEETrigger ? DetId::HGCalEE : DetId::HGCalHSi);
+      int layer = trigger_cell_trig_id.layer();
+      int zside = trigger_cell_trig_id.zside();
+      int type = trigger_cell_trig_id.type();
+      int waferu = trigger_cell_trig_id.waferU();
+      int waferv = trigger_cell_trig_id.waferV();
+      std::vector<int> cellus = trigger_cell_trig_id.cellU();
+      std::vector<int> cellvs = trigger_cell_trig_id.cellV();
+      for (unsigned ic = 0; ic < cellus.size(); ic++) {
+        HGCSiliconDetId cell_det_id(cell_det, zside, type, layer, waferu, waferv, cellus[ic], cellvs[ic]);
+        cell_det_ids.emplace(cell_det_id);
+      }
+    }
+  }
+  return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromModule(const unsigned module_id) const {
+  geom_set cell_det_ids;
+  geom_set trigger_cells = getTriggerCellsFromModule(module_id);
+
+  for (auto trigger_cell_id : trigger_cells) {
+    geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+    cell_det_ids.insert(cells.begin(), cells.end());
+  }
+  return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrderedCellsFromModule(
+    const unsigned module_id) const {
+  geom_ordered_set cell_det_ids;
+  geom_ordered_set trigger_cells = getOrderedTriggerCellsFromModule(module_id);
+  for (auto trigger_cell_id : trigger_cells) {
+    geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+    cell_det_ids.insert(cells.begin(), cells.end());
+  }
+  return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getTriggerCellsFromModule(
+    const unsigned module_id) const {
+  HGCalModuleDetId hgc_module_id(module_id);
+  unsigned subdet = hgc_module_id.triggerSubdetId();
+
+  geom_set trigger_cell_det_ids;
+  // Scintillator
+  if (subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
+    int ietamin = hscTopology().dddConstants().getREtaRange(hgc_module_id.layer()).first;
+    int ietamin_tc = ((ietamin - 1) / hSc_triggercell_size_ + 1);
+    int ieta0 = (hgc_module_id.eta() - 1) * hSc_module_size_ + ietamin_tc;
+    int iphi0 = hgc_module_id.phi();
+    etaphiMappingFromSector0(ieta0, iphi0, hgc_module_id.sector());
+    iphi0 = (iphi0 - 1) * hSc_module_size_ + 1;
+    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_module_size_; ietaAbs++) {
+      int ieta = ietaAbs * hgc_module_id.zside();
+      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_module_size_; iphi++) {
+        unsigned trigger_cell_id = HGCScintillatorDetId(hgc_module_id.type(), hgc_module_id.layer(), ieta, iphi);
+        if (validTriggerCellFromCells(trigger_cell_id))
+          trigger_cell_det_ids.emplace(trigger_cell_id);
+      }
+    }
+  }
+  // HFNose
+  else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+    HFNoseDetId module_nose_id(module_id);
+    HFNoseDetIdToModule hfn;
+    std::vector<HFNoseTriggerDetId> ids = hfn.getTriggerDetIds(module_nose_id);
+    for (auto const& idx : ids) {
+      if (validTriggerCellFromCells(idx.rawId()))
+        trigger_cell_det_ids.emplace(idx);
+    }
+  }
+  // Silicon
+  else {
+    HGCSiliconDetIdToROC tc2roc;
+    int moduleU = hgc_module_id.moduleU();
+    int moduleV = hgc_module_id.moduleV();
+    unsigned layer = hgc_module_id.layer();
+
+    //Rotate to sector
+    geom_rotation_120_.uvMappingFromSector0(getWaferCentring(layer, subdet), moduleU, moduleV, hgc_module_id.sector());
+
+    DetId::Detector det = (subdet == HGCalTriggerSubdetector::HGCalEETrigger ? DetId::HGCalEE : DetId::HGCalHSi);
+
+    unsigned wafer_type = detIdWaferType(det, layer, moduleU, moduleV);
+    int nroc = (wafer_type == HGCSiliconDetId::HGCalFine ? 6 : 3);
+    // Loop on ROCs in wafer
+    for (int roc = 1; roc <= nroc; roc++) {
+      // loop on TCs in ROC
+      auto tc_uvs = tc2roc.getTriggerId(roc, wafer_type);
+      for (const auto& tc_uv : tc_uvs) {
+        HGCalTriggerDetId trigger_cell_id(
+            subdet, hgc_module_id.zside(), wafer_type, layer, moduleU, moduleV, tc_uv.first, tc_uv.second);
+        if (validTriggerCellFromCells(trigger_cell_id.rawId()))
+          trigger_cell_det_ids.emplace(trigger_cell_id);
+      }
+    }
+  }
+
+  return trigger_cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrderedTriggerCellsFromModule(
+    const unsigned module_id) const {
+  HGCalModuleDetId hgc_module_id(module_id);
+  unsigned subdet = hgc_module_id.triggerSubdetId();
+
+  geom_ordered_set trigger_cell_det_ids;
+
+  // Scintillator
+  if (subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
+    int ieta0 = hgc_module_id.eta() * hSc_module_size_;
+    int iphi0 = (hgc_module_id.phi() * (hgc_module_id.sector() + 1)) * hSc_module_size_;
+
+    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_module_size_; ietaAbs++) {
+      int ieta = ietaAbs * hgc_module_id.zside();
+      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_module_size_; iphi++) {
+        unsigned trigger_cell_id = HGCScintillatorDetId(hgc_module_id.type(), hgc_module_id.layer(), ieta, iphi);
+        if (validTriggerCellFromCells(trigger_cell_id))
+          trigger_cell_det_ids.emplace(trigger_cell_id);
+      }
+    }
+  }
+
+  // HFNose
+  else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+    HFNoseDetId module_nose_id(module_id);
+    HFNoseDetIdToModule hfn;
+    std::vector<HFNoseTriggerDetId> ids = hfn.getTriggerDetIds(module_nose_id);
+    for (auto const& idx : ids) {
+      if (validTriggerCellFromCells(idx.rawId()))
+        trigger_cell_det_ids.emplace(idx);
+    }
+  }
+  // Silicon
+  else {
+    HGCSiliconDetIdToROC tc2roc;
+    int moduleU = hgc_module_id.moduleU();
+    int moduleV = hgc_module_id.moduleU();
+    unsigned layer = hgc_module_id.layer();
+
+    //Rotate to sector
+    geom_rotation_120_.uvMappingFromSector0(getWaferCentring(layer, subdet), moduleU, moduleV, hgc_module_id.sector());
+
+    DetId::Detector det = (subdet == HGCalTriggerSubdetector::HGCalEETrigger ? DetId::HGCalEE : DetId::HGCalHSi);
+
+    unsigned wafer_type = detIdWaferType(det, layer, moduleU, moduleV);
+    int nroc = (wafer_type == HGCSiliconDetId::HGCalFine ? 6 : 3);
+    // Loop on ROCs in wafer
+    for (int roc = 1; roc <= nroc; roc++) {
+      // loop on TCs in ROC
+      auto tc_uvs = tc2roc.getTriggerId(roc, wafer_type);
+      for (const auto& tc_uv : tc_uvs) {
+        HGCalTriggerDetId trigger_cell_id(
+            subdet, hgc_module_id.zside(), wafer_type, layer, moduleU, moduleV, tc_uv.first, tc_uv.second);
+        if (validTriggerCellFromCells(trigger_cell_id.rawId()))
+          trigger_cell_det_ids.emplace(trigger_cell_id);
+      }
+    }
+  }
+
+  return trigger_cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getNeighborsFromTriggerCell(
+    const unsigned trigger_cell_id) const {
+  throw cms::Exception("FeatureNotImplemented") << "Neighbor search is not implemented in HGCalTriggerGeometryV9Imp3";
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getLinksInModule(const unsigned module_id) const {
+  HGCalModuleDetId module_det_id(module_id);
+  unsigned subdet = module_det_id.triggerSubdetId();
+
+  unsigned links = 0;
+  // HF Nose
+  if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+    links = 1;
+  }
+  // TO ADD HFNOSE : getLinksInModule
+  // Silicon and Scintillator
+  else {
+    int packed_module =
+        packLayerSubdetWaferId(module_det_id.layer(), subdet, module_det_id.moduleU(), module_det_id.moduleV());
+    links = links_per_module_.at(packed_module);
+  }
+  return links;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getModuleSize(const unsigned module_id) const {
+  unsigned nWafers = 1;
+  return nWafers;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getNextSector(const unsigned sector) const {
+  unsigned next_sector = 0;
+  if (sector < 2) {
+    next_sector = sector + 1;
+  }
+  return next_sector;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getPreviousSector(const unsigned sector) const {
+  unsigned previous_sector = 2;
+  if (sector > 0) {
+    previous_sector = sector - 1;
+  }
+  return previous_sector;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1FpgasFromStage2Fpga(
+    const unsigned stage2_id) const {
+  geom_set stage1_ids;
+  HGCalBackendDetId id(stage2_id);
+
+  geom_set stage1_links = getStage1LinksFromStage2Fpga(stage2_id);
+  for (const auto& stage1_link : stage1_links) {
+    stage1_ids.emplace(getStage1FpgaFromStage1Link(stage1_link));
+  }
+
+  return stage1_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage2FpgasFromStage1Fpga(
+    const unsigned stage1_id) const {
+  geom_set stage2_ids;
+  HGCalBackendDetId id(stage1_id);
+
+  geom_set stage1_links = getStage1LinksFromStage1Fpga(stage1_id);
+  for (const auto& stage1_link : stage1_links) {
+    stage2_ids.emplace(getStage2FpgaFromStage1Link(stage1_link));
+  }
+
+  return stage2_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFromStage2Fpga(
+    const unsigned stage2_id) const {
+  geom_set stage1link_ids;
+  HGCalBackendDetId id(stage2_id);
+
+  auto stage2_itrs = stage2_to_stage1links_.equal_range(id.label());
+  for (auto stage2_itr = stage2_itrs.first; stage2_itr != stage2_itrs.second; stage2_itr++) {
+    if (stage2_itr->second == true) {  //link and stage2 FPGA are the same sector
+      stage1link_ids.emplace(
+          HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::Stage1Link, id.sector(), stage2_itr->second));
+    } else {  //link is from the next sector (anti-clockwise)
+      stage1link_ids.emplace(HGCalBackendDetId(
+          id.zside(), HGCalBackendDetId::BackendType::Stage1Link, getNextSector(id.sector()), stage2_itr->second));
+    }
+  }
+
+  return stage1link_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromStage1Link(const unsigned link_id) const {
+  HGCalBackendDetId id(link_id);
+  unsigned stage1_label = stage1link_to_stage1_.at(id.label());
+
+  return HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getStage2FpgaFromStage1Link(const unsigned link_id) const {
+  HGCalBackendDetId id(link_id);
+  bool same_sector = stage1link_to_stage2_.at(id.label());
+  unsigned sector = id.sector();
+
+  if (!same_sector) {
+    sector = getPreviousSector(sector);
+  }
+
+  return HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::Stage2FPGA, sector, 0);
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFromStage1Fpga(
+    const unsigned stage1_id) const {
+  geom_set stage1link_ids;
+
+  auto stage1_itrs = stage1_to_stage1links_.equal_range(stage1_id);
+  for (auto stage1_itr = stage1_itrs.first; stage1_itr != stage1_itrs.second; stage1_itr++) {
+    stage1link_ids.emplace(stage1_itr->second);
+  }
+
+  return stage1link_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const unsigned stage1_id) const {
+  geom_set lpgbt_ids;
+  HGCalBackendDetId id(stage1_id);
+
+  auto stage1_itrs = stage1_to_lpgbts_.equal_range(id.label());
+  for (auto stage1_itr = stage1_itrs.first; stage1_itr != stage1_itrs.second; stage1_itr++) {
+    lpgbt_ids.emplace(
+        HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr->second));
+  }
+
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const {
+  HGCalBackendDetId id(lpgbt_id);
+  unsigned stage1_label = lpgbt_to_stage1_.at(id.label());
+
+  return HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromLpgbt(const unsigned lpgbt_id) const {
+  geom_set modules;
+  HGCalBackendDetId id(lpgbt_id);
+
+  auto lpgbt_itrs = lpgbt_to_modules_.equal_range(id.label());
+  for (auto lpgbt_itr = lpgbt_itrs.first; lpgbt_itr != lpgbt_itrs.second; lpgbt_itr++) {
+    unsigned layer = 0;
+    int moduleU = 0;
+    int moduleV = 0;
+    int subdet = 0;
+    unpackLayerSubdetWaferId(lpgbt_itr->second, layer, subdet, moduleU, moduleV);
+    unsigned det = 0;
+    switch (subdet) {
+      case HGCalTriggerSubdetector::HGCalEETrigger:
+        det = DetId::HGCalEE;
+        break;
+      case HGCalTriggerSubdetector::HGCalHSiTrigger:
+        det = DetId::HGCalHSi;
+        break;
+      case HGCalTriggerSubdetector::HGCalHScTrigger:
+        det = DetId::HGCalHSc;
+        break;
+      default:
+        det = DetId::HGCalEE;
+        break;
+    }
+
+    int type = detIdWaferType(det, layer, moduleU, moduleV);
+    modules.emplace(
+        HGCalModuleDetId(HGCalTriggerSubdetector(subdet), id.zside(), type, layer, id.sector(), moduleU, moduleV));
+  }
+
+  return modules;
+}
+
+HGCalTriggerGeometryV9Imp3::geom_set HGCalTriggerGeometryV9Imp3::getLpgbtsFromModule(const unsigned module_id) const {
+  geom_set lpgbt_ids;
+  HGCalModuleDetId id(module_id);
+
+  auto module_itrs = module_to_lpgbts_.equal_range(
+      packLayerSubdetWaferId(id.layer(), id.triggerSubdetId(), id.moduleU(), id.moduleV()));
+  for (auto module_itr = module_itrs.first; module_itr != module_itrs.second; module_itr++) {
+    lpgbt_ids.emplace(
+        HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::LpGBT, id.sector(), module_itr->second));
+  }
+
+  return lpgbt_ids;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromModule(const unsigned module_id) const {
+  HGCalModuleDetId id(module_id);
+
+  unsigned stage1_label =
+      module_to_stage1_.at(packLayerSubdetWaferId(id.layer(), id.triggerSubdetId(), id.moduleU(), id.moduleV()));
+
+  return HGCalBackendDetId(id.zside(), HGCalBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
+}
+
+GlobalPoint HGCalTriggerGeometryV9Imp3::getTriggerCellPosition(const unsigned trigger_cell_det_id) const {
+  unsigned det = DetId(trigger_cell_det_id).det();
+
+  // Position: barycenter of the trigger cell.
+  Basic3DVector<float> triggerCellVector(0., 0., 0.);
+  const auto cell_ids = getCellsFromTriggerCell(trigger_cell_det_id);
+  // Scintillator
+  if (det == DetId::HGCalHSc) {
+    for (const auto& cell : cell_ids) {
+      triggerCellVector += hscGeometry()->getPosition(cell).basicVector();
+    }
+  }
+  // HFNose
+  else if (det == DetId::HGCalTrigger and
+           HGCalTriggerDetId(trigger_cell_det_id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    for (const auto& cell : cell_ids) {
+      HFNoseDetId cellDetId(cell);
+      triggerCellVector += noseGeometry()->getPosition(cellDetId).basicVector();
+    }
+  }
+  // Silicon
+  else {
+    for (const auto& cell : cell_ids) {
+      HGCSiliconDetId cellDetId(cell);
+      triggerCellVector += (cellDetId.det() == DetId::HGCalEE ? eeGeometry()->getPosition(cellDetId)
+                                                              : hsiGeometry()->getPosition(cellDetId))
+                               .basicVector();
+    }
+  }
+  return GlobalPoint(triggerCellVector / cell_ids.size());
+}
+
+GlobalPoint HGCalTriggerGeometryV9Imp3::getModulePosition(const unsigned module_det_id) const {
+  unsigned subdet = HGCalModuleDetId(module_det_id).triggerSubdetId();
+  // Position: barycenter of the module.
+  Basic3DVector<float> moduleVector(0., 0., 0.);
+  const auto cell_ids = getCellsFromModule(module_det_id);
+  // Scintillator
+  if (subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
+    for (const auto& cell : cell_ids) {
+      moduleVector += hscGeometry()->getPosition(cell).basicVector();
+    }
+  }
+  // HFNose
+  else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+    for (const auto& cell : cell_ids) {
+      HFNoseDetId cellDetId(cell);
+      moduleVector += noseGeometry()->getPosition(cellDetId).basicVector();
+    }
+  }  // Silicon
+  else {
+    for (const auto& cell : cell_ids) {
+      HGCSiliconDetId cellDetId(cell);
+      moduleVector += (cellDetId.det() == DetId::HGCalEE ? eeGeometry()->getPosition(cellDetId)
+                                                         : hsiGeometry()->getPosition(cellDetId))
+                          .basicVector();
+    }
+  }
+
+  return GlobalPoint(moduleVector / cell_ids.size());
+}
+
+void HGCalTriggerGeometryV9Imp3::fillMaps() {
+  // read json mapping file
+  json mapping_config;
+  std::ifstream json_input_file(jsonMappingFile_.fullPath());
+  if (!json_input_file.is_open()) {
+    throw cms::Exception("MissingDataFile") << "Cannot open HGCalTriggerGeometry L1TMapping file\n";
+  }
+  json_input_file >> mapping_config;
+
+  try {
+    //Stage 2 to Stage 1 links mapping
+    for (unsigned stage2_id = 0; stage2_id < mapping_config.at("Stage2").size(); stage2_id++) {
+      for (auto& link : mapping_config.at("Stage2").at(stage2_id).at("Stage1Links")) {
+        stage2_to_stage1links_.emplace(stage2_id, link.at("SameSector"));
+      }
+    }
+  } catch (const json::exception& e) {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "The mapping input json file does not have the expected structure for the Stage2 block";
+  }
+
+  try {
+    for (unsigned link_id = 0; link_id < mapping_config.at("Stage1Links").size(); link_id++) {
+      //Stage 1 links to Stage 1 FPGAs mapping
+      stage1link_to_stage1_.emplace(link_id, mapping_config.at("Stage1Links").at(link_id).at("Stage1"));
+
+      //Stage 1 links to Stage 2 mapping
+      stage1link_to_stage2_.emplace(link_id, mapping_config.at("Stage1Links").at(link_id).at("Stage2SameSector"));
+    }
+  } catch (const json::exception& e) {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "The mapping input json file does not have the expected structure for the Stage1Links block";
+  }
+
+  try {
+    for (unsigned stage1_id = 0; stage1_id < mapping_config.at("Stage1").size(); stage1_id++) {
+      //Stage 1 to Stage 1 links mapping
+      for (auto& link_id : mapping_config.at("Stage1").at(stage1_id).at("Stage1Links")) {
+        stage1_to_stage1links_.emplace(stage1_id, link_id);
+      }
+
+      //Stage 1 to lpgbt mapping
+      for (auto& lpgbt_id : mapping_config.at("Stage1").at(stage1_id).at("lpgbts")) {
+        stage1_to_lpgbts_.emplace(stage1_id, lpgbt_id);
+      }
+    }
+
+  } catch (const json::exception& e) {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "The mapping input json file does not have the expected structure for the Stage1 block";
+  }
+
+  try {
+    for (unsigned lpgbt_id = 0; lpgbt_id < mapping_config.at("lpgbt").size(); lpgbt_id++) {
+      //lpgbt to Stage 1 mapping
+      unsigned stage1_id = mapping_config.at("lpgbt").at(lpgbt_id).at("Stage1");
+      lpgbt_to_stage1_.emplace(lpgbt_id, stage1_id);
+
+      //lpgbt to module mapping
+      for (auto& modules : mapping_config.at("lpgbt").at(lpgbt_id).at("Modules")) {
+        unsigned layer = modules.at("layer");
+        int subdetId = 0;
+        bool isSilicon = modules.at("isSilicon");
+        layerWithoutOffsetAndSubdetId(layer, subdetId, isSilicon);
+        unsigned packed_value = packLayerSubdetWaferId(layer, subdetId, modules.at("u"), modules.at("v"));
+        lpgbt_to_modules_.emplace(lpgbt_id, packed_value);
+
+        //fill subsiduary module to stage 1 mapping
+        auto result = module_to_stage1_.emplace(packed_value, stage1_id);
+        if (result.second == false &&
+            stage1_id != result.first->second) {  //check that the stage1_id is the same as in the existing map
+          edm::LogError("HGCalTriggerGeometryV9Imp3") << "One module is connected to two separate Stage1 FPGAs";
+        }
+      }
+    }
+
+  } catch (const json::exception& e) {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "The mapping input json file does not have the expected structure for the lpGBT block";
+  }
+
+  try {
+    //module to lpgbt mapping
+    for (unsigned module = 0; module < mapping_config.at("Module").size(); module++) {
+      unsigned num_elinks = 0;  //Sum number of e-links in each module over lpGBTs
+      unsigned layer = mapping_config.at("Module").at(module).at("layer");
+      unsigned moduleU = mapping_config.at("Module").at(module).at("u");
+      unsigned moduleV = mapping_config.at("Module").at(module).at("v");
+      bool isSilicon = mapping_config.at("Module").at(module).at("isSilicon");
+      int subdetId = 0;
+      layerWithoutOffsetAndSubdetId(layer, subdetId, isSilicon);
+
+      for (auto& lpgbt : mapping_config.at("Module").at(module).at("lpgbts")) {
+        module_to_lpgbts_.emplace(packLayerSubdetWaferId(layer, subdetId, moduleU, moduleV), lpgbt.at("id"));
+        num_elinks += unsigned(lpgbt.at("nElinks"));
+      }
+      int packed_module = packLayerSubdetWaferId(layer, subdetId, moduleU, moduleV);
+      links_per_module_.emplace(packed_module, num_elinks);
+    }
+  } catch (const json::exception& e) {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "The mapping input json file does not have the expected structure for the Module block";
+  }
+
+  json_input_file.close();
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::packLayerSubdetWaferId(unsigned layer, int subdet, int waferU, int waferV) const {
+  unsigned packed_value = 0;
+
+  packed_value |= ((waferU & HGCalModuleDetId::kHGCalModuleUMask) << HGCalModuleDetId::kHGCalModuleUOffset);
+  packed_value |= ((waferV & HGCalModuleDetId::kHGCalModuleVMask) << HGCalModuleDetId::kHGCalModuleVOffset);
+  packed_value |= ((subdet & HGCalModuleDetId::kHGCalTriggerSubdetMask) << HGCalModuleDetId::kHGCalTriggerSubdetOffset);
+  packed_value |= ((layer & HGCalModuleDetId::kHGCalLayerMask) << HGCalModuleDetId::kHGCalLayerOffset);
+  return packed_value;
+}
+
+void HGCalTriggerGeometryV9Imp3::unpackLayerSubdetWaferId(
+    unsigned wafer, unsigned& layer, int& subdet, int& waferU, int& waferV) const {
+  waferU = (wafer >> HGCalModuleDetId::kHGCalModuleUOffset) & HGCalModuleDetId::kHGCalModuleUMask;
+  waferV = (wafer >> HGCalModuleDetId::kHGCalModuleVOffset) & HGCalModuleDetId::kHGCalModuleVMask;
+  subdet = (wafer >> HGCalModuleDetId::kHGCalTriggerSubdetOffset) & HGCalModuleDetId::kHGCalTriggerSubdetMask;
+  layer = (wafer >> HGCalModuleDetId::kHGCalLayerOffset) & HGCalModuleDetId::kHGCalLayerMask;
+}
+
+void HGCalTriggerGeometryV9Imp3::etaphiMappingFromSector0(int& ieta, int& iphi, unsigned sector) const {
+  if (sector == 0) {
+    return;
+  }
+  iphi = iphi + (sector * hSc_num_panels_per_sector_);
+}
+
+HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(unsigned layer, int subdet) const {
+  if (subdet == HGCalTriggerSubdetector::HGCalEETrigger) {  // CE-E
+    return HGCalGeomRotation::WaferCentring::WaferCentred;
+  } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+    if ((layer % 2) == 1) {  // CE-H Odd
+      return HGCalGeomRotation::WaferCentring::CornerCentredY;
+    } else {  // CE-H Even
+      return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
+    }
+  } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {  //HFNose
+    return HGCalGeomRotation::WaferCentring::WaferCentred;
+  } else {
+    edm::LogError("HGCalTriggerGeometryV9Imp3")
+        << "HGCalTriggerGeometryV9Imp3: trigger sub-detector expected to be silicon";
+    return HGCalGeomRotation::WaferCentring::WaferCentred;
+  }
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::etaphiMappingToSector0(int& ieta, int& iphi) const {
+  unsigned sector = 0;
+
+  if (unsigned(std::abs(iphi)) > 2 * hSc_num_panels_per_sector_)
+    sector = 2;
+  else if (unsigned(std::abs(iphi)) > hSc_num_panels_per_sector_)
+    sector = 1;
+  else
+    sector = 0;
+
+  iphi = iphi - (sector * hSc_num_panels_per_sector_);
+
+  return sector;
+}
+
+bool HGCalTriggerGeometryV9Imp3::validTriggerCell(const unsigned trigger_cell_id) const {
+  return validTriggerCellFromCells(trigger_cell_id);
+}
+
+bool HGCalTriggerGeometryV9Imp3::disconnectedModule(const unsigned module_id) const {
+  bool disconnected = false;
+  HGCalModuleDetId id(module_id);
+  if (module_to_stage1_.find(packLayerSubdetWaferId(id.layer(), id.triggerSubdetId(), id.moduleU(), id.moduleV())) ==
+      module_to_stage1_.end()) {
+    disconnected = true;
+  }
+  if (disconnected_layers_.find(layerWithOffset(module_id)) != disconnected_layers_.end()) {
+    disconnected = true;
+  }
+  return disconnected;
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::triggerLayer(const unsigned id) const {
+  unsigned layer = layerWithOffset(id);
+
+  if (DetId(id).det() == DetId::HGCalTrigger and
+      HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    if (layer >= trigger_nose_layers_.size())
+      return 0;
+    return trigger_nose_layers_[layer];
+  }
+  if (layer >= trigger_layers_.size())
+    return 0;
+  return trigger_layers_[layer];
+}
+
+bool HGCalTriggerGeometryV9Imp3::validCell(unsigned cell_id) const {
+  bool is_valid = false;
+  unsigned det = DetId(cell_id).det();
+  switch (det) {
+    case DetId::HGCalEE:
+      is_valid = eeTopology().valid(cell_id);
+      break;
+    case DetId::HGCalHSi:
+      is_valid = hsiTopology().valid(cell_id);
+      break;
+    case DetId::HGCalHSc:
+      is_valid = hscTopology().valid(cell_id);
+      break;
+    case DetId::Forward:
+      is_valid = noseTopology().valid(cell_id);
+      break;
+    default:
+      is_valid = false;
+      break;
+  }
+  return is_valid;
+}
+
+bool HGCalTriggerGeometryV9Imp3::validTriggerCellFromCells(const unsigned trigger_cell_id) const {
+  // Check the validity of a trigger cell with the
+  // validity of the cells. One valid cell in the
+  // trigger cell is enough to make the trigger cell
+  // valid.
+  const geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+  bool is_valid = false;
+  for (const auto cell_id : cells) {
+    unsigned det = DetId(cell_id).det();
+    is_valid |= validCellId(det, cell_id);
+    if (is_valid)
+      break;
+  }
+  return is_valid;
+}
+
+bool HGCalTriggerGeometryV9Imp3::validCellId(unsigned subdet, unsigned cell_id) const {
+  bool is_valid = false;
+  switch (subdet) {
+    case DetId::HGCalEE:
+      is_valid = eeTopology().valid(cell_id);
+      break;
+    case DetId::HGCalHSi:
+      is_valid = hsiTopology().valid(cell_id);
+      break;
+    case DetId::HGCalHSc:
+      is_valid = hscTopology().valid(cell_id);
+      break;
+    case DetId::Forward:
+      is_valid = noseTopology().valid(cell_id);
+      break;
+    default:
+      is_valid = false;
+      break;
+  }
+  return is_valid;
+}
+
+int HGCalTriggerGeometryV9Imp3::detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const {
+  int wafer_type = 0;
+  switch (det) {
+    case DetId::HGCalEE:
+      wafer_type = eeTopology().dddConstants().getTypeHex(layer, waferU, waferV);
+      break;
+    case DetId::HGCalHSi:
+      wafer_type = hsiTopology().dddConstants().getTypeHex(layer, waferU, waferV);
+      break;
+    case DetId::HGCalHSc:
+      wafer_type = hscTopology().dddConstants().getTypeTrap(layer);
+      break;
+    default:
+      break;
+  };
+  return wafer_type;
+}
+
+void HGCalTriggerGeometryV9Imp3::layerWithoutOffsetAndSubdetId(unsigned& layer, int& subdetId, bool isSilicon) const {
+  if (!isSilicon) {
+    layer = layer - heOffset_;
+    subdetId = HGCalTriggerSubdetector::HGCalHScTrigger;
+  } else {
+    if (layer > heOffset_) {
+      subdetId = HGCalTriggerSubdetector::HGCalHSiTrigger;
+      layer = layer - heOffset_;
+    } else {
+      subdetId = HGCalTriggerSubdetector::HGCalEETrigger;
+    }
+  }
+}
+
+unsigned HGCalTriggerGeometryV9Imp3::layerWithOffset(unsigned id) const {
+  unsigned det = DetId(id).det();
+  unsigned layer = 0;
+
+  if (det == DetId::HGCalTrigger) {
+    unsigned subdet = HGCalTriggerDetId(id).subdet();
+    if (subdet == HGCalTriggerSubdetector::HGCalEETrigger) {
+      layer = HGCalTriggerDetId(id).layer();
+    } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+      layer = heOffset_ + HGCalTriggerDetId(id).layer();
+    } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+      layer = HFNoseTriggerDetId(id).layer();
+    }
+  } else if (det == DetId::HGCalHSc) {
+    layer = heOffset_ + HGCScintillatorDetId(id).layer();
+  } else if (det == DetId::Forward) {
+    unsigned subdet = HGCalModuleDetId(id).triggerSubdetId();
+    if (subdet == HGCalTriggerSubdetector::HGCalEETrigger) {
+      layer = HGCalModuleDetId(id).layer();
+    } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger ||
+               subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
+      layer = heOffset_ + HGCalDetId(id).layer();
+    } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {
+      layer = HGCalModuleDetId(id).layer();
+    }
+  }
+  return layer;
+}
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, HGCalTriggerGeometryV9Imp3, "HGCalTriggerGeometryV9Imp3");

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -1,20 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
 
-def custom_geometry_decentralized_V11(process, links='signaldriven'):
+def custom_geometry_decentralized_V11(process, links='signaldriven',implementation=1):
     if links=='signaldriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_signaldriven_0.txt'
     elif links=='pudriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_march20_0.txt'
     else:
         raise RuntimeError('Unknown links mapping "{}". Options are "signaldriven" or "pudriven".'.format(links))
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
+    if implementation==1:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
+    elif implementation==2:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp3')
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorModuleSize = cms.uint32(6)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_V11_decentralized_march20_2.txt")
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TLinksMapping = cms.FileInPath(links_mapping)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorLinksPerModule = cms.uint32(2)
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_v1.json")
     return process
 
 

--- a/L1Trigger/L1THGCal/src/HGCalBackendDetId.cc
+++ b/L1Trigger/L1THGCal/src/HGCalBackendDetId.cc
@@ -1,0 +1,42 @@
+#include "L1Trigger/L1THGCal/interface/HGCalBackendDetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <iostream>
+
+HGCalBackendDetId::HGCalBackendDetId() : DetId() {}
+
+HGCalBackendDetId::HGCalBackendDetId(uint32_t rawid) : DetId(rawid) {}
+
+HGCalBackendDetId::HGCalBackendDetId(int zp, int type, int sector, int label) : DetId(Forward, HGCTrigger) {
+  int classid = HGCalClassIdentifier::ModuleDetId;
+  int zside = (zp < 0) ? 1 : 0;
+  id_ |= (((label & kHGCalLabelMask) << kHGCalLabelOffset) | ((sector & kHGCalSectorMask) << kHGCalSectorOffset) |
+          ((zside & kHGCalZsideMask) << kHGCalZsideOffset) | ((type & kHGCalTypeMask) << kHGCalTypeOffset) |
+          ((classid & kHGCalClassIdentifierMask) << kHGCalClassIdentifierOffset));
+}
+
+HGCalBackendDetId::HGCalBackendDetId(const DetId& gen) {
+  if (!gen.null()) {
+    if (gen.det() != Forward) {
+      throw cms::Exception("Invalid DetId")
+          << "Cannot initialize HGCalBackendDetId from " << std::hex << gen.rawId() << std::dec;
+    }
+  }
+  id_ = gen.rawId();
+}
+
+HGCalBackendDetId& HGCalBackendDetId::operator=(const DetId& gen) {
+  if (!gen.null()) {
+    if (gen.det() != Forward) {
+      throw cms::Exception("Invalid DetId")
+          << "Cannot assign HGCalBackendDetId from " << std::hex << gen.rawId() << std::dec;
+    }
+  }
+  id_ = gen.rawId();
+  return (*this);
+}
+
+std::ostream& operator<<(std::ostream& s, const HGCalBackendDetId& id) {
+  return s << "HGCalBackendDetId::lpGBT:Stage1 FPGA:Stage2 FPGA= " << id.isLpGBT() << ":" << id.isStage1FPGA() << ":"
+           << id.isStage1Link() << ":" << id.isStage2FPGA() << " z= " << id.zside() << " sector= " << id.sector()
+           << " id= " << id.label();
+}

--- a/L1Trigger/L1THGCal/src/HGCalModuleDetId.cc
+++ b/L1Trigger/L1THGCal/src/HGCalModuleDetId.cc
@@ -1,0 +1,48 @@
+#include "L1Trigger/L1THGCal/interface/HGCalModuleDetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <iostream>
+
+HGCalModuleDetId::HGCalModuleDetId() : DetId() {}
+
+HGCalModuleDetId::HGCalModuleDetId(uint32_t rawid) : DetId(rawid) {}
+
+HGCalModuleDetId::HGCalModuleDetId(
+    HGCalTriggerSubdetector subdet, int zp, int type, int layer, int sector, int moduleU, int moduleV)
+    : DetId(Forward, HGCTrigger) {
+  int classid = HGCalClassIdentifier::ModuleDetId;
+  int zside = (zp < 0) ? 1 : 0;
+
+  id_ |=
+      (((moduleU & kHGCalModuleUMask) << kHGCalModuleUOffset) | ((moduleV & kHGCalModuleVMask) << kHGCalModuleVOffset) |
+       ((sector & kHGCalSectorMask) << kHGCalSectorOffset) | ((layer & kHGCalLayerMask) << kHGCalLayerOffset) |
+       ((zside & kHGCalZsideMask) << kHGCalZsideOffset) | ((type & kHGCalTypeMask) << kHGCalTypeOffset) |
+       ((subdet & kHGCalTriggerSubdetMask) << kHGCalTriggerSubdetOffset) |
+       ((classid & kHGCalClassIdentifierMask) << kHGCalClassIdentifierOffset));
+}
+
+HGCalModuleDetId::HGCalModuleDetId(const DetId& gen) {
+  if (!gen.null()) {
+    if (gen.det() != Forward) {
+      throw cms::Exception("Invalid DetId")
+          << "Cannot initialize HGCalModuleDetId from " << std::hex << gen.rawId() << std::dec;
+    }
+  }
+  id_ = gen.rawId();
+}
+
+HGCalModuleDetId& HGCalModuleDetId::operator=(const DetId& gen) {
+  if (!gen.null()) {
+    if (gen.det() != Forward) {
+      throw cms::Exception("Invalid DetId")
+          << "Cannot assign HGCalModuleDetId from " << std::hex << gen.rawId() << std::dec;
+    }
+  }
+  id_ = gen.rawId();
+  return (*this);
+}
+
+std::ostream& operator<<(std::ostream& s, const HGCalModuleDetId& id) {
+  return s << "HGCalModuleDetId::HFNose:EE:HSil:HScin= " << id.isHFNose() << ":" << id.isEE() << ":" << id.isHSilicon()
+           << ":" << id.isHScintillator() << " type= " << id.type() << " z= " << id.zside() << " layer= " << id.layer()
+           << " sector= " << id.sector() << " module(u,v)= (" << id.moduleU() << "," << id.moduleV() << ")";
+}

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -6,6 +6,7 @@
 #include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "L1Trigger/L1THGCal//interface/HGCalModuleDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
@@ -110,10 +111,13 @@ unsigned HGCalTriggerTools::layers(DetId::Detector type) const {
 
 unsigned HGCalTriggerTools::layer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
-  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose) {
+  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose &&
+      id.subdetId() != ForwardSubdetector::HGCTrigger) {
     layer = HGCalDetId(id).layer();
   } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
     layer = HFNoseDetId(id).layer();
+  } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    layer = HGCalModuleDetId(id).layer();
   } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
     layer = HcalDetId(id).depth();
   } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
@@ -151,10 +155,13 @@ unsigned HGCalTriggerTools::layerWithOffset(const DetId& id) const {
 bool HGCalTriggerTools::isEm(const DetId& id) const {
   bool em = false;
 
-  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose) {
+  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose &&
+      id.subdetId() != ForwardSubdetector::HGCTrigger) {
     em = (id.subdetId() == HGCEE);
   } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
     em = HFNoseDetId(id).isEE();
+  } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    em = HGCalModuleDetId(id).isEE();
   } else if (id.det() == DetId::HGCalEE) {
     em = true;
   } else if (id.det() == DetId::HGCalTrigger &&
@@ -180,8 +187,10 @@ bool HGCalTriggerTools::isNose(const DetId& id) const {
 
 bool HGCalTriggerTools::isSilicon(const DetId& id) const {
   bool silicon = false;
-  if (id.det() == DetId::Forward) {
+  if (id.det() == DetId::Forward && id.subdetId() != HGCTrigger) {
     silicon = (id.subdetId() != HGCHEB);
+  } else if (id.det() == DetId::Forward && id.subdetId() == HGCTrigger) {
+    silicon = (HGCalModuleDetId(id).triggerSubdetId() != HGCalHScTrigger);
   } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
     silicon = true;
   } else if (id.det() == DetId::HGCalTrigger &&
@@ -209,10 +218,13 @@ HGCalTriggerTools::SubDetectorType HGCalTriggerTools::getSubDetectorType(const D
 
 int HGCalTriggerTools::zside(const DetId& id) const {
   int zside = 0;
-  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose) {
+  if (id.det() == DetId::Forward && id.subdetId() != ForwardSubdetector::HFNose &&
+      id.subdetId() != ForwardSubdetector::HGCTrigger) {
     zside = HGCalDetId(id).zside();
   } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
     zside = HFNoseDetId(id).zside();
+  } else if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    zside = HGCalModuleDetId(id).zside();
   } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
     zside = HcalDetId(id).zside();
   } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="L1Trigger/L1THGCal"/>
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
-<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTester.cc,HGCalTriggerGeomTesterV9.cc,HGCalTriggerGeomTesterV9Imp2.cc">
+<use name="DataFormats/L1Trigger"/>
+<use name="SimDataFormats/CaloTest"/>
+<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTester.cc,HGCalTriggerGeomTesterV9.cc,HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -1,0 +1,1309 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "TTree.h"
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalModuleDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalBackendDetId.h"
+
+#include <cstdlib>
+
+namespace {
+  template <typename T>
+  struct array_deleter {
+    void operator()(T* arr) { delete[] arr; }
+  };
+}  // namespace
+
+class HGCalTriggerGeomTesterV9Imp3 : public edm::stream::EDAnalyzer<> {
+public:
+  explicit HGCalTriggerGeomTesterV9Imp3(const edm::ParameterSet&);
+  ~HGCalTriggerGeomTesterV9Imp3();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
+  void fillTriggerGeometry();
+  bool checkMappingConsistency();
+  void setTreeModuleSize(const size_t n);
+  void setTreeModuleCellSize(const size_t n);
+  void setTreeTriggerCellSize(const size_t n);
+  void setTreeCellCornerSize(const size_t n);
+  void setTreeTriggerCellNeighborSize(const size_t n);
+
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  edm::Service<TFileService> fs_;
+  bool no_trigger_;
+  bool no_neighbors_;
+  TTree* treeModules_;
+  TTree* treeTriggerCells_;
+  TTree* treeCells_;
+  TTree* treeCellsBH_;
+  TTree* treeCellsNose_;
+  TTree* treeModuleErrors_;
+  // tree variables
+  int moduleId_ = 0;
+  int moduleSide_ = 0;
+  int moduleSubdet_ = 0;
+  int moduleLayer_ = 0;
+  int moduleIEta_ = 0;
+  int moduleIPhi_ = 0;
+  int module_ = 0;
+  float moduleX_ = 0;
+  float moduleY_ = 0;
+  float moduleZ_ = 0;
+  int moduleTC_N_ = 0;
+  int moduleLinks_ = 0;
+  std::shared_ptr<int> moduleTC_id_;
+  std::shared_ptr<int> moduleTC_zside_;
+  std::shared_ptr<int> moduleTC_subdet_;
+  std::shared_ptr<int> moduleTC_layer_;
+  std::shared_ptr<int> moduleTC_waferU_;
+  std::shared_ptr<int> moduleTC_waferV_;
+  std::shared_ptr<int> moduleTC_cellU_;
+  std::shared_ptr<int> moduleTC_cellV_;
+  std::shared_ptr<int> moduleTC_ieta_;
+  std::shared_ptr<int> moduleTC_iphi_;
+  std::shared_ptr<float> moduleTC_x_;
+  std::shared_ptr<float> moduleTC_y_;
+  std::shared_ptr<float> moduleTC_z_;
+  int moduleCell_N_ = 0;
+  std::shared_ptr<int> moduleCell_id_;
+  std::shared_ptr<int> moduleCell_zside_;
+  std::shared_ptr<int> moduleCell_subdet_;
+  std::shared_ptr<int> moduleCell_layer_;
+  std::shared_ptr<int> moduleCell_waferU_;
+  std::shared_ptr<int> moduleCell_waferV_;
+  std::shared_ptr<int> moduleCell_cellU_;
+  std::shared_ptr<int> moduleCell_cellV_;
+  std::shared_ptr<float> moduleCell_x_;
+  std::shared_ptr<float> moduleCell_y_;
+  std::shared_ptr<float> moduleCell_z_;
+  int triggerCellId_ = 0;
+  int triggerCellSide_ = 0;
+  int triggerCellSubdet_ = 0;
+  int triggerCellLayer_ = 0;
+  int triggerCellWaferU_ = 0;
+  int triggerCellWaferV_ = 0;
+  int triggerCellU_ = 0;
+  int triggerCellV_ = 0;
+  int triggerCellIEta_ = 0;
+  int triggerCellIPhi_ = 0;
+  float triggerCellX_ = 0;
+  float triggerCellY_ = 0;
+  float triggerCellZ_ = 0;
+  int triggerCellNeighbor_N_ = 0;
+  std::shared_ptr<int> triggerCellNeighbor_id_;
+  std::shared_ptr<int> triggerCellNeighbor_zside_;
+  std::shared_ptr<int> triggerCellNeighbor_subdet_;
+  std::shared_ptr<int> triggerCellNeighbor_layer_;
+  std::shared_ptr<int> triggerCellNeighbor_waferU_;
+  std::shared_ptr<int> triggerCellNeighbor_waferV_;
+  std::shared_ptr<int> triggerCellNeighbor_cellU_;
+  std::shared_ptr<int> triggerCellNeighbor_cellV_;
+  std::shared_ptr<int> triggerCellNeighbor_cellIEta_;
+  std::shared_ptr<int> triggerCellNeighbor_cellIPhi_;
+  std::shared_ptr<float> triggerCellNeighbor_distance_;
+  int triggerCellCell_N_ = 0;
+  std::shared_ptr<int> triggerCellCell_id_;
+  std::shared_ptr<int> triggerCellCell_zside_;
+  std::shared_ptr<int> triggerCellCell_subdet_;
+  std::shared_ptr<int> triggerCellCell_layer_;
+  std::shared_ptr<int> triggerCellCell_waferU_;
+  std::shared_ptr<int> triggerCellCell_waferV_;
+  std::shared_ptr<int> triggerCellCell_cellU_;
+  std::shared_ptr<int> triggerCellCell_cellV_;
+  std::shared_ptr<int> triggerCellCell_ieta_;
+  std::shared_ptr<int> triggerCellCell_iphi_;
+  std::shared_ptr<float> triggerCellCell_x_;
+  std::shared_ptr<float> triggerCellCell_y_;
+  std::shared_ptr<float> triggerCellCell_z_;
+  int cellId_ = 0;
+  int cellSide_ = 0;
+  int cellSubdet_ = 0;
+  int cellLayer_ = 0;
+  int cellWaferU_ = 0;
+  int cellWaferV_ = 0;
+  int cellWaferType_ = 0;
+  int cellWaferRow_ = 0;
+  int cellWaferColumn_ = 0;
+  int cellU_ = 0;
+  int cellV_ = 0;
+  float cellX_ = 0;
+  float cellY_ = 0;
+  float cellZ_ = 0;
+  int cellCornersN_ = 0;
+  std::shared_ptr<float> cellCornersX_;
+  std::shared_ptr<float> cellCornersY_;
+  std::shared_ptr<float> cellCornersZ_;
+  int cellBHId_ = 0;
+  int cellBHType_ = 0;
+  int cellBHSide_ = 0;
+  int cellBHSubdet_ = 0;
+  int cellBHLayer_ = 0;
+  int cellBHIEta_ = 0;
+  int cellBHIPhi_ = 0;
+  float cellBHEta_ = 0;
+  float cellBHPhi_ = 0;
+  float cellBHX_ = 0;
+  float cellBHY_ = 0;
+  float cellBHZ_ = 0;
+  float cellBHX1_ = 0;
+  float cellBHY1_ = 0;
+  float cellBHX2_ = 0;
+  float cellBHY2_ = 0;
+  float cellBHX3_ = 0;
+  float cellBHY3_ = 0;
+  float cellBHX4_ = 0;
+  float cellBHY4_ = 0;
+  //
+  int moduleErrorSubdet_ = 0;
+  int moduleErrorLayer_ = 0;
+  int moduleErrorWaferU_ = 0;
+  int moduleErrorWaferV_ = 0;
+
+private:
+  typedef std::unordered_map<uint32_t, std::unordered_set<uint32_t>> trigger_map_set;
+};
+
+/*****************************************************************/
+HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterSet& conf)
+    : no_trigger_(false),
+      no_neighbors_(true)
+/*****************************************************************/
+{
+  // initialize output trees
+  treeModules_ = fs_->make<TTree>("TreeModules", "Tree of all HGC modules");
+  treeModules_->Branch("id", &moduleId_, "id/I");
+  treeModules_->Branch("zside", &moduleSide_, "zside/I");
+  treeModules_->Branch("subdet", &moduleSubdet_, "subdet/I");
+  treeModules_->Branch("layer", &moduleLayer_, "layer/I");
+  treeModules_->Branch("ieta", &moduleIEta_, "ieta/I");
+  treeModules_->Branch("iphi", &moduleIPhi_, "iphi/I");
+  treeModules_->Branch("module", &module_, "module/I");
+  treeModules_->Branch("links", &moduleLinks_, "links/I");
+  treeModules_->Branch("x", &moduleX_, "x/F");
+  treeModules_->Branch("y", &moduleY_, "y/F");
+  treeModules_->Branch("z", &moduleZ_, "z/F");
+  treeModules_->Branch("tc_n", &moduleTC_N_, "tc_n/I");
+  moduleTC_id_.reset(new int[1], array_deleter<int>());
+  moduleTC_zside_.reset(new int[1], array_deleter<int>());
+  moduleTC_subdet_.reset(new int[1], array_deleter<int>());
+  moduleTC_layer_.reset(new int[1], array_deleter<int>());
+  moduleTC_waferU_.reset(new int[1], array_deleter<int>());
+  moduleTC_waferV_.reset(new int[1], array_deleter<int>());
+  moduleTC_cellU_.reset(new int[1], array_deleter<int>());
+  moduleTC_cellV_.reset(new int[1], array_deleter<int>());
+  moduleTC_x_.reset(new float[1], array_deleter<float>());
+  moduleTC_y_.reset(new float[1], array_deleter<float>());
+  moduleTC_z_.reset(new float[1], array_deleter<float>());
+  treeModules_->Branch("tc_id", moduleTC_id_.get(), "tc_id[tc_n]/I");
+  treeModules_->Branch("tc_zside", moduleTC_zside_.get(), "tc_zside[tc_n]/I");
+  treeModules_->Branch("tc_subdet", moduleTC_subdet_.get(), "tc_subdet[tc_n]/I");
+  treeModules_->Branch("tc_layer", moduleTC_layer_.get(), "tc_layer[tc_n]/I");
+  treeModules_->Branch("tc_waferu", moduleTC_waferU_.get(), "tc_waferu[tc_n]/I");
+  treeModules_->Branch("tc_waferv", moduleTC_waferV_.get(), "tc_waferv[tc_n]/I");
+  treeModules_->Branch("tc_cellu", moduleTC_cellU_.get(), "tc_cellu[tc_n]/I");
+  treeModules_->Branch("tc_cellv", moduleTC_cellV_.get(), "tc_cellv[tc_n]/I");
+  treeModules_->Branch("tc_ieta", moduleTC_ieta_.get(), "tc_ieta[tc_n]/I");
+  treeModules_->Branch("tc_iphi", moduleTC_iphi_.get(), "tc_iphi[tc_n]/I");
+  treeModules_->Branch("tc_x", moduleTC_x_.get(), "tc_x[tc_n]/F");
+  treeModules_->Branch("tc_y", moduleTC_y_.get(), "tc_y[tc_n]/F");
+  treeModules_->Branch("tc_z", moduleTC_z_.get(), "tc_z[tc_n]/F");
+  treeModules_->Branch("c_n", &moduleCell_N_, "c_n/I");
+  moduleCell_id_.reset(new int[1], array_deleter<int>());
+  moduleCell_zside_.reset(new int[1], array_deleter<int>());
+  moduleCell_subdet_.reset(new int[1], array_deleter<int>());
+  moduleCell_layer_.reset(new int[1], array_deleter<int>());
+  moduleCell_waferU_.reset(new int[1], array_deleter<int>());
+  moduleCell_waferV_.reset(new int[1], array_deleter<int>());
+  moduleCell_cellU_.reset(new int[1], array_deleter<int>());
+  moduleCell_cellV_.reset(new int[1], array_deleter<int>());
+  moduleCell_x_.reset(new float[1], array_deleter<float>());
+  moduleCell_y_.reset(new float[1], array_deleter<float>());
+  moduleCell_z_.reset(new float[1], array_deleter<float>());
+  treeModules_->Branch("c_id", moduleCell_id_.get(), "c_id[c_n]/I");
+  treeModules_->Branch("c_zside", moduleCell_zside_.get(), "c_zside[c_n]/I");
+  treeModules_->Branch("c_subdet", moduleCell_subdet_.get(), "c_subdet[c_n]/I");
+  treeModules_->Branch("c_layer", moduleCell_layer_.get(), "c_layer[c_n]/I");
+  treeModules_->Branch("c_waferu", moduleCell_waferU_.get(), "c_waferu[c_n]/I");
+  treeModules_->Branch("c_waferv", moduleCell_waferV_.get(), "c_waferv[c_n]/I");
+  treeModules_->Branch("c_cellu", moduleCell_cellU_.get(), "c_cellu[c_n]/I");
+  treeModules_->Branch("c_cellv", moduleCell_cellV_.get(), "c_cellv[c_n]/I");
+  treeModules_->Branch("c_x", moduleCell_x_.get(), "c_x[c_n]/F");
+  treeModules_->Branch("c_y", moduleCell_y_.get(), "c_y[c_n]/F");
+  treeModules_->Branch("c_z", moduleCell_z_.get(), "c_z[c_n]/F");
+  //
+  treeTriggerCells_ = fs_->make<TTree>("TreeTriggerCells", "Tree of all HGC trigger cells");
+  treeTriggerCells_->Branch("id", &triggerCellId_, "id/I");
+  treeTriggerCells_->Branch("zside", &triggerCellSide_, "zside/I");
+  treeTriggerCells_->Branch("subdet", &triggerCellSubdet_, "subdet/I");
+  treeTriggerCells_->Branch("layer", &triggerCellLayer_, "layer/I");
+  treeTriggerCells_->Branch("waferu", &triggerCellWaferU_, "waferu/I");
+  treeTriggerCells_->Branch("waferv", &triggerCellWaferV_, "waferv/I");
+  treeTriggerCells_->Branch("triggercellu", &triggerCellU_, "triggercellu/I");
+  treeTriggerCells_->Branch("triggercellv", &triggerCellV_, "triggercellv/I");
+  treeTriggerCells_->Branch("triggercellieta", &triggerCellIEta_, "triggercellieta/I");
+  treeTriggerCells_->Branch("triggercelliphi", &triggerCellIPhi_, "triggercelliphi/I");
+  treeTriggerCells_->Branch("x", &triggerCellX_, "x/F");
+  treeTriggerCells_->Branch("y", &triggerCellY_, "y/F");
+  treeTriggerCells_->Branch("z", &triggerCellZ_, "z/F");
+  treeTriggerCells_->Branch("neighbor_n", &triggerCellNeighbor_N_, "neighbor_n/I");
+  triggerCellNeighbor_id_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_zside_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_subdet_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_layer_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_waferU_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_waferV_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_cellU_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_cellV_.reset(new int[1], array_deleter<int>());
+  triggerCellNeighbor_distance_.reset(new float[1], array_deleter<float>());
+  treeTriggerCells_->Branch("neighbor_id", triggerCellNeighbor_id_.get(), "neighbor_id[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_zside", triggerCellNeighbor_zside_.get(), "neighbor_zside[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_subdet", triggerCellNeighbor_subdet_.get(), "neighbor_subdet[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_layer", triggerCellNeighbor_layer_.get(), "neighbor_layer[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_waferu", triggerCellNeighbor_waferU_.get(), "neighbor_waferu[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_waferv", triggerCellNeighbor_waferV_.get(), "neighbor_waferv[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_cellu", triggerCellNeighbor_cellU_.get(), "neighbor_cellu[neighbor_n]/I");
+  treeTriggerCells_->Branch("neighbor_cellv", triggerCellNeighbor_cellV_.get(), "neighbor_cellv[neighbor_n]/I");
+  treeTriggerCells_->Branch(
+      "neighbor_distance", triggerCellNeighbor_distance_.get(), "neighbor_distance[neighbor_n]/F");
+  treeTriggerCells_->Branch("c_n", &triggerCellCell_N_, "c_n/I");
+  triggerCellCell_id_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_zside_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_subdet_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_layer_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_waferU_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_waferV_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_cellU_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_cellV_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_ieta_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_iphi_.reset(new int[1], array_deleter<int>());
+  triggerCellCell_x_.reset(new float[1], array_deleter<float>());
+  triggerCellCell_y_.reset(new float[1], array_deleter<float>());
+  triggerCellCell_z_.reset(new float[1], array_deleter<float>());
+  treeTriggerCells_->Branch("c_id", triggerCellCell_id_.get(), "c_id[c_n]/I");
+  treeTriggerCells_->Branch("c_zside", triggerCellCell_zside_.get(), "c_zside[c_n]/I");
+  treeTriggerCells_->Branch("c_subdet", triggerCellCell_subdet_.get(), "c_subdet[c_n]/I");
+  treeTriggerCells_->Branch("c_layer", triggerCellCell_layer_.get(), "c_layer[c_n]/I");
+  treeTriggerCells_->Branch("c_waferu", triggerCellCell_waferU_.get(), "c_waferu[c_n]/I");
+  treeTriggerCells_->Branch("c_waferv", triggerCellCell_waferV_.get(), "c_waferv[c_n]/I");
+  treeTriggerCells_->Branch("c_cellu", triggerCellCell_cellU_.get(), "c_cellu[c_n]/I");
+  treeTriggerCells_->Branch("c_cellv", triggerCellCell_cellV_.get(), "c_cellv[c_n]/I");
+  treeTriggerCells_->Branch("c_ieta", triggerCellCell_ieta_.get(), "c_cell[c_n]/I");
+  treeTriggerCells_->Branch("c_iphi", triggerCellCell_iphi_.get(), "c_cell[c_n]/I");
+  treeTriggerCells_->Branch("c_x", triggerCellCell_x_.get(), "c_x[c_n]/F");
+  treeTriggerCells_->Branch("c_y", triggerCellCell_y_.get(), "c_y[c_n]/F");
+  treeTriggerCells_->Branch("c_z", triggerCellCell_z_.get(), "c_z[c_n]/F");
+  //
+  treeCells_ = fs_->make<TTree>("TreeCells", "Tree of all HGC cells");
+  treeCells_->Branch("id", &cellId_, "id/I");
+  treeCells_->Branch("zside", &cellSide_, "zside/I");
+  treeCells_->Branch("subdet", &cellSubdet_, "subdet/I");
+  treeCells_->Branch("layer", &cellLayer_, "layer/I");
+  treeCells_->Branch("waferu", &cellWaferU_, "waferu/I");
+  treeCells_->Branch("waferv", &cellWaferV_, "waferv/I");
+  treeCells_->Branch("wafertype", &cellWaferType_, "wafertype/I");
+  treeCells_->Branch("waferrow", &cellWaferRow_, "waferrow/I");
+  treeCells_->Branch("wafercolumn", &cellWaferColumn_, "wafercolumn/I");
+  treeCells_->Branch("cellu", &cellU_, "cellu/I");
+  treeCells_->Branch("cellv", &cellV_, "cellv/I");
+  treeCells_->Branch("x", &cellX_, "x/F");
+  treeCells_->Branch("y", &cellY_, "y/F");
+  treeCells_->Branch("z", &cellZ_, "z/F");
+  treeCells_->Branch("corner_n", &cellCornersN_, "corner_n/I");
+  treeCells_->Branch("corner_x", cellCornersX_.get(), "corner_x[corner_n]/F");
+  treeCells_->Branch("corner_y", cellCornersY_.get(), "corner_y[corner_n]/F");
+  treeCells_->Branch("corner_z", cellCornersZ_.get(), "corner_z[corner_n]/F");
+  //
+  treeCellsBH_ = fs_->make<TTree>("TreeCellsBH", "Tree of all BH cells");
+  treeCellsBH_->Branch("id", &cellBHId_, "id/I");
+  treeCellsBH_->Branch("type", &cellBHType_, "type/I");
+  treeCellsBH_->Branch("zside", &cellBHSide_, "zside/I");
+  treeCellsBH_->Branch("subdet", &cellBHSubdet_, "subdet/I");
+  treeCellsBH_->Branch("layer", &cellBHLayer_, "layer/I");
+  treeCellsBH_->Branch("ieta", &cellBHIEta_, "ieta/I");
+  treeCellsBH_->Branch("iphi", &cellBHIPhi_, "iphi/I");
+  treeCellsBH_->Branch("eta", &cellBHEta_, "eta/F");
+  treeCellsBH_->Branch("phi", &cellBHPhi_, "phi/F");
+  treeCellsBH_->Branch("x", &cellBHX_, "x/F");
+  treeCellsBH_->Branch("y", &cellBHY_, "y/F");
+  treeCellsBH_->Branch("z", &cellBHZ_, "z/F");
+  treeCellsBH_->Branch("x1", &cellBHX1_, "x1/F");
+  treeCellsBH_->Branch("y1", &cellBHY1_, "y1/F");
+  treeCellsBH_->Branch("x2", &cellBHX2_, "x2/F");
+  treeCellsBH_->Branch("y2", &cellBHY2_, "y2/F");
+  treeCellsBH_->Branch("x3", &cellBHX3_, "x3/F");
+  treeCellsBH_->Branch("y3", &cellBHY3_, "y3/F");
+  treeCellsBH_->Branch("x4", &cellBHX4_, "x4/F");
+  treeCellsBH_->Branch("y4", &cellBHY4_, "y4/F");
+  //
+  treeCellsNose_ = fs_->make<TTree>("TreeCellsNose", "Tree of all HGCnose cells");
+  treeCellsNose_->Branch("id", &cellId_, "id/I");
+  treeCellsNose_->Branch("zside", &cellSide_, "zside/I");
+  treeCellsNose_->Branch("subdet", &cellSubdet_, "subdet/I");
+  treeCellsNose_->Branch("layer", &cellLayer_, "layer/I");
+  treeCellsNose_->Branch("waferu", &cellWaferU_, "waferu/I");
+  treeCellsNose_->Branch("waferv", &cellWaferV_, "waferv/I");
+  treeCellsNose_->Branch("wafertype", &cellWaferType_, "wafertype/I");
+  treeCellsNose_->Branch("waferrow", &cellWaferRow_, "waferrow/I");
+  treeCellsNose_->Branch("wafercolumn", &cellWaferColumn_, "wafercolumn/I");
+  treeCellsNose_->Branch("cellu", &cellU_, "cellu/I");
+  treeCellsNose_->Branch("cellv", &cellV_, "cellv/I");
+  treeCellsNose_->Branch("x", &cellX_, "x/F");
+  treeCellsNose_->Branch("y", &cellY_, "y/F");
+  treeCellsNose_->Branch("z", &cellZ_, "z/F");
+  treeCellsNose_->Branch("corner_n", &cellCornersN_, "corner_n/I");
+  treeCellsNose_->Branch("corner_x", cellCornersX_.get(), "corner_x[corner_n]/F");
+  treeCellsNose_->Branch("corner_y", cellCornersY_.get(), "corner_y[corner_n]/F");
+  treeCellsNose_->Branch("corner_z", cellCornersZ_.get(), "corner_z[corner_n]/F");
+  //
+  treeModuleErrors_ = fs_->make<TTree>("TreeModuleErrors", "Tree of module mapping errors");
+  treeModuleErrors_->Branch("subdet", &moduleErrorSubdet_, "subdet/I");
+  treeModuleErrors_->Branch("layer", &moduleErrorLayer_, "layer/I");
+  treeModuleErrors_->Branch("waferu", &moduleErrorWaferU_, "waferu/I");
+  treeModuleErrors_->Branch("waferv", &moduleErrorWaferV_, "waferv/I");
+}
+
+/*****************************************************************/
+HGCalTriggerGeomTesterV9Imp3::~HGCalTriggerGeomTesterV9Imp3()
+/*****************************************************************/
+{}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es)
+/*****************************************************************/
+{
+  es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+
+  no_trigger_ = !checkMappingConsistency();
+
+  fillTriggerGeometry();
+}
+
+bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
+  try {
+    // Set of (subdet,layer,waferU,waferV) with module mapping errors
+    std::set<std::tuple<unsigned, unsigned, int, int>> module_errors;
+    trigger_map_set modules_to_triggercells;
+    trigger_map_set modules_to_cells;
+    trigger_map_set triggercells_to_cells;
+    // EE
+    for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
+      HGCSiliconDetId detid(id);
+      if (!triggerGeometry_->eeTopology().valid(id))
+        continue;
+      // fill trigger cells
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = 0;
+      try {
+        module = triggerGeometry_->getModuleFromCell(id);
+        triggerGeometry_->getLinksInModule(module);
+      } catch (const std::exception& e) {
+        module_errors.emplace(std::make_tuple(HGCalModuleDetId(module).triggerSubdetId(),
+                                              HGCalModuleDetId(module).layer(),
+                                              HGCalModuleDetId(module).moduleU(),
+                                              HGCalModuleDetId(module).moduleV()));
+        continue;
+      }
+      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+
+    // HSi
+    for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
+      if (!triggerGeometry_->hsiTopology().valid(id))
+        continue;
+      // fill trigger cells
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = 0;
+      try {
+        module = triggerGeometry_->getModuleFromCell(id);
+        triggerGeometry_->getLinksInModule(module);
+      } catch (const std::exception& e) {
+        module_errors.emplace(std::make_tuple(HGCalModuleDetId(module).triggerSubdetId(),
+                                              HGCalModuleDetId(module).layer(),
+                                              HGCalModuleDetId(module).moduleU(),
+                                              HGCalModuleDetId(module).moduleV()));
+        continue;
+      }
+      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+
+    // HSc
+    for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
+      // fill trigger cells
+      unsigned layer = HGCScintillatorDetId(id).layer();
+      if (HGCScintillatorDetId(id).type() != triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer)) {
+        std::cout << "Sci cell type = " << HGCScintillatorDetId(id).type()
+                  << " != " << triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer) << "\n";
+      }
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = triggerGeometry_->getModuleFromCell(id);
+      if (module != 0) {
+        itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+
+    // NOSE
+    if (triggerGeometry_->isWithNoseGeometry()) {
+      for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
+        if (!triggerGeometry_->noseTopology().valid(id))
+          continue;
+        // fill trigger cells
+        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+        auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+        // fill modules
+        uint32_t module = triggerGeometry_->getModuleFromCell(id);
+        if (module != 0) {
+          itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+          itr_insert.first->second.emplace(id);
+        }
+      }
+    }
+
+    if (module_errors.size() > 0) {
+      for (const auto& module : module_errors) {
+        moduleErrorSubdet_ = std::get<0>(module);
+        moduleErrorLayer_ = std::get<1>(module);
+        moduleErrorWaferU_ = std::get<2>(module);
+        moduleErrorWaferV_ = std::get<3>(module);
+        treeModuleErrors_->Fill();
+      }
+      throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found  module mapping problems. Check the produced "
+                                             "tree to see the list of problematic wafers";
+    }
+
+    edm::LogPrint("TriggerCellCheck") << "Checking cell -> trigger cell -> cell consistency";
+    // Loop over trigger cells
+    for (const auto& triggercell_cells : triggercells_to_cells) {
+      DetId id(triggercell_cells.first);
+
+      // fill modules
+      uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
+      if (module != 0) {
+        if (id.det() != DetId::HGCalHSc) {
+          auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
+          itr_insert.first->second.emplace(id);
+        }
+      }
+
+      // Check consistency of cells included in trigger cell
+      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromTriggerCell(id);
+      const auto& cells = triggercell_cells.second;
+      for (auto cell : cells) {
+        if (cells_geom.find(cell) == cells_geom.end()) {
+          if (id.det() == DetId::HGCalHSc) {
+            edm::LogProblem("BadTriggerCell")
+                << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
+                << ")\n has not been found in \n trigger cell " << HGCScintillatorDetId(id);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else if (HFNoseTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+            edm::LogProblem("BadTriggerCell")
+                << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell) << ")\n has not been found in \n trigger cell "
+                << HFNoseTriggerDetId(triggercell_cells.first);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HFNoseDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else if (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+                     HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+            edm::LogProblem("BadTriggerCell")
+                << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
+                << ")\n has not been found in \n trigger cell " << HGCalTriggerDetId(triggercell_cells.first);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HGCSiliconDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else {
+            edm::LogProblem("BadTriggerCell")
+                << "Unknown detector type " << id.det() << " " << id.subdetId() << " " << id.rawId() << "\n";
+            edm::LogProblem("BadTriggerCell") << " cell " << std::hex << cell << std::dec << " "
+                                              << "\n";
+            edm::LogProblem("BadTriggerCell")
+                << "Cell ID " << HGCSiliconDetId(cell) << " or " << HFNoseDetId(cell) << "\n";
+          }
+          throw cms::Exception("BadGeometry")
+              << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell mapping";
+        }
+      }
+    }
+    edm::LogPrint("ModuleCheck") << "Checking trigger cell -> module -> trigger cell consistency";
+    // Loop over modules
+    for (const auto& module_triggercells : modules_to_triggercells) {
+      DetId id(module_triggercells.first);
+      // Check consistency of trigger cells included in module
+      HGCalTriggerGeometryBase::geom_set triggercells_geom = triggerGeometry_->getTriggerCellsFromModule(id);
+      const auto& triggercells = module_triggercells.second;
+      for (auto cell : triggercells) {
+        if (triggercells_geom.find(cell) == triggercells_geom.end()) {
+          if (id.det() == DetId::HGCalHSc) {
+            HGCScintillatorDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error: \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          } else if (id.det() == DetId::Forward and id.subdetId() == ForwardSubdetector::HFNose) {
+            HFNoseTriggerDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HFNoseTriggerDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          } else {
+            HGCalTriggerDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HGCalTriggerDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          }
+        }
+      }
+    }
+    edm::LogPrint("ModuleCheck") << "Checking cell -> module -> cell consistency";
+    for (const auto& module_cells : modules_to_cells) {
+      HGCalModuleDetId id(module_cells.first);
+      // Check consistency of cells included in module
+      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromModule(id);
+      const auto& cells = module_cells.second;
+      for (auto cell : cells) {
+        if (cells_geom.find(cell) == cells_geom.end()) {
+          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+          } else {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalModuleDetId(id);
+          }
+          std::stringstream output;
+          output << " Available cells are:\n";
+          for (auto cell_geom : cells_geom) {
+            output << cell_geom << " ";
+          }
+          edm::LogProblem("BadModule") << output.str();
+          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found inconsistency in cell <-> module mapping";
+        }
+      }
+    }
+
+    // Filling Stage 1 FPGA -> modules
+
+    edm::LogPrint("ModuleCheck") << "Checking module -> stage-1 -> module consistency";
+    trigger_map_set stage1_to_modules;
+    for (const auto& module_tc : modules_to_triggercells) {
+      HGCalModuleDetId id(module_tc.first);
+      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromModule(id);
+      if (lpgbts.size() == 0)
+        continue;  //Module is not connected to an lpGBT and therefore not to a Stage 1 FPGA
+      uint32_t stage1 = 0;
+      for (const auto& lpgbt : lpgbts) {
+        uint32_t stage1_tmp = triggerGeometry_->getStage1FpgaFromLpgbt(lpgbt);
+        if (stage1 != 0 && stage1_tmp != stage1) {
+          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Module " << HGCalModuleDetId(id)
+                                              << " is split is split into more than one Stage-1 FPGA";
+        }
+        stage1 = stage1_tmp;
+      }
+      auto itr_insert = stage1_to_modules.emplace(stage1, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+    // checking S1 -> module consistency
+
+    for (const auto& stage1_modules : stage1_to_modules) {
+      HGCalBackendDetId stage1(stage1_modules.first);
+      HGCalTriggerGeometryBase::geom_set modules_geom;
+      // Check consistency of modules going to Stage-1 FPGA
+      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
+      for (const auto& lpgbt : lpgbts) {
+        HGCalTriggerGeometryBase::geom_set modules = triggerGeometry_->getModulesFromLpgbt(lpgbt);
+        modules_geom.insert(modules.begin(), modules.end());
+      }
+      const auto& modules = stage1_modules.second;
+      for (auto module : modules) {
+        if (modules_geom.find(module) == modules_geom.end()) {
+          edm::LogProblem("BadStage1") << "Error: \n Module " << module << "(" << HGCalModuleDetId(module)
+                                       << ")\n has not been found in \n stage-1 " << HGCalBackendDetId(stage1);
+          std::stringstream output;
+          output << "   Available modules are:\n";
+          for (auto module_geom : modules_geom) {
+            output << module_geom << " ";
+          }
+          output << "   Connected lpgbts are:\n";
+          for (auto lpgbt : lpgbts) {
+            output << lpgbt << " ";
+          }
+          edm::LogProblem("BadStage1") << output.str();
+          throw cms::Exception("BadGeometry")
+              << "HGCalTriggerGeometry: Found inconsistency in Stage1 <-> module mapping";
+        }
+      }
+    }
+
+    // Filling Stage 2 FPGA -> Stage 1 FPGA
+
+    edm::LogPrint("ModuleCheck") << "Checking Stage 1 -> Stage 2 -> Stage 1 consistency";
+    trigger_map_set stage2_to_stage1;
+    for (const auto& stage1 : stage1_to_modules) {
+      HGCalBackendDetId id(stage1.first);
+      HGCalTriggerGeometryBase::geom_set stage2FPGAs = triggerGeometry_->getStage2FpgasFromStage1Fpga(id);
+      for (const auto& stage2 : stage2FPGAs) {
+        auto itr_insert = stage2_to_stage1.emplace(stage2, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+    // checking S1 -> S2 consistency
+
+    for (const auto& stage2_modules : stage2_to_stage1) {
+      HGCalBackendDetId stage2(stage2_modules.first);
+
+      // Check consistency of Stage-1 FPGA going to Stage 2 FPGA
+      HGCalTriggerGeometryBase::geom_set stage1FPGAs = triggerGeometry_->getStage1FpgasFromStage2Fpga(stage2);
+
+      const auto& stage1fpgas = stage2_modules.second;
+
+      for (auto stage1fpga : stage1fpgas) {
+        if (stage1FPGAs.find(stage1fpga) == stage1FPGAs.end()) {
+          edm::LogProblem("BadStage2") << "Error: \n Stage-1 FPGA " << stage1fpga << "("
+                                       << HGCalBackendDetId(stage1fpga) << ")\n has not been found in \n stage-2 "
+                                       << HGCalBackendDetId(stage2);
+          std::stringstream output;
+          output << "   Available Stage-1 FPGAs are:\n";
+          for (auto stage1FPGA : stage1FPGAs) {
+            output << stage1FPGA << " ";
+          }
+          edm::LogProblem("BadStage2") << output.str();
+          throw cms::Exception("BadGeometry")
+              << "HGCalTriggerGeometry: Found inconsistency in Stage2 <-> Stage1 mapping";
+        }
+      }
+    }
+
+  } catch (const cms::Exception& e) {
+    edm::LogWarning("HGCalTriggerGeometryTester")
+        << "Problem with the trigger geometry detected. Only the basic cells tree will be filled\n";
+    edm::LogWarning("HGCalTriggerGeometryTester") << e.message() << "\n";
+    return false;
+  }
+  return true;
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
+/*****************************************************************/
+{
+  trigger_map_set modules;
+  trigger_map_set trigger_cells;
+
+  // Loop over cells
+  edm::LogPrint("TreeFilling") << "Filling cells tree";
+  // EE
+  std::cout << "Filling EE geometry\n";
+  for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (!triggerGeometry_->eeTopology().valid(id))
+      continue;
+    cellId_ = detid.rawId();
+    cellSide_ = detid.zside();
+    cellSubdet_ = detid.subdet();
+    cellLayer_ = detid.layer();
+    cellWaferU_ = detid.waferU();
+    cellWaferV_ = detid.waferV();
+    cellU_ = detid.cellU();
+    cellV_ = detid.cellV();
+    int type1 = detid.type();
+    int type2 = triggerGeometry_->eeTopology().dddConstants().getTypeHex(cellLayer_, cellWaferU_, cellWaferV_);
+    if (type1 != type2) {
+      std::cout << "Found incompatible wafer types:\n  " << detid << "\n";
+    }
+    //
+    GlobalPoint center = triggerGeometry_->eeGeometry()->getPosition(id);
+    cellX_ = center.x();
+    cellY_ = center.y();
+    cellZ_ = center.z();
+    std::vector<GlobalPoint> corners = triggerGeometry_->eeGeometry()->getCorners(id);
+    cellCornersN_ = corners.size();
+    setTreeCellCornerSize(cellCornersN_);
+    for (unsigned i = 0; i < corners.size(); i++) {
+      cellCornersX_.get()[i] = corners[i].x();
+      cellCornersY_.get()[i] = corners[i].y();
+      cellCornersZ_.get()[i] = corners[i].z();
+    }
+    treeCells_->Fill();
+    // fill trigger cells
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      // Skip trigger cells in module 0
+      // uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+      //if (HGCalDetId(module).wafer() == 0)
+      //  continue;
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+  std::cout << "Filling HSi geometry\n";
+  for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (!triggerGeometry_->hsiTopology().valid(id))
+      continue;
+    cellId_ = detid.rawId();
+    cellSide_ = detid.zside();
+    cellSubdet_ = detid.subdet();
+    cellLayer_ = detid.layer();
+    cellWaferU_ = detid.waferU();
+    cellWaferV_ = detid.waferV();
+    cellU_ = detid.cellU();
+    cellV_ = detid.cellV();
+    int type1 = detid.type();
+    int type2 = triggerGeometry_->hsiTopology().dddConstants().getTypeHex(cellLayer_, cellWaferU_, cellWaferV_);
+    if (type1 != type2) {
+      std::cout << "Found incompatible wafer types:\n  " << detid << "\n";
+    }
+    //
+    GlobalPoint center = triggerGeometry_->hsiGeometry()->getPosition(id);
+    cellX_ = center.x();
+    cellY_ = center.y();
+    cellZ_ = center.z();
+    std::vector<GlobalPoint> corners = triggerGeometry_->hsiGeometry()->getCorners(id);
+    cellCornersN_ = corners.size();
+    setTreeCellCornerSize(cellCornersN_);
+    for (unsigned i = 0; i < corners.size(); i++) {
+      cellCornersX_.get()[i] = corners[i].x();
+      cellCornersY_.get()[i] = corners[i].y();
+      cellCornersZ_.get()[i] = corners[i].z();
+    }
+    treeCells_->Fill();
+    // fill trigger cells
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      // Skip trigger cells in module 0
+      // uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+      //if (HGCalDetId(module).wafer() == 0)
+      //  continue;
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+  std::cout << "Filling HSc geometry\n";
+  for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
+    HGCScintillatorDetId cellid(id);
+    cellBHId_ = cellid.rawId();
+    cellBHType_ = cellid.type();
+    cellBHSide_ = cellid.zside();
+    cellBHSubdet_ = cellid.subdet();
+    cellBHLayer_ = cellid.layer();
+    cellBHIEta_ = cellid.ieta();
+    cellBHIPhi_ = cellid.iphi();
+    //
+    GlobalPoint center = triggerGeometry_->hscGeometry()->getPosition(id);
+    cellBHEta_ = center.eta();
+    cellBHPhi_ = center.phi();
+    cellBHX_ = center.x();
+    cellBHY_ = center.y();
+    cellBHZ_ = center.z();
+    auto corners = triggerGeometry_->hscGeometry()->getCorners(id);
+    if (corners.size() >= 4) {
+      cellBHX1_ = corners[0].x();
+      cellBHY1_ = corners[0].y();
+      cellBHX2_ = corners[1].x();
+      cellBHY2_ = corners[1].y();
+      cellBHX3_ = corners[2].x();
+      cellBHY3_ = corners[2].y();
+      cellBHX4_ = corners[3].x();
+      cellBHY4_ = corners[3].y();
+    }
+    treeCellsBH_->Fill();
+    // fill trigger cells
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+
+  if (triggerGeometry_->isWithNoseGeometry()) {
+    // NOSE
+    std::cout << "Filling NOSE geometry\n";
+    for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
+      HFNoseDetId detid(id);
+      cellId_ = detid.rawId();
+      cellSide_ = detid.zside();
+      cellSubdet_ = detid.subdet();
+      cellLayer_ = detid.layer();
+      cellWaferU_ = detid.waferU();
+      cellWaferV_ = detid.waferV();
+      cellU_ = detid.cellU();
+      cellV_ = detid.cellV();
+      int type1 = detid.type();
+      int type2 = triggerGeometry_->noseTopology().dddConstants().getTypeHex(cellLayer_, cellWaferU_, cellWaferV_);
+      if (type1 != type2) {
+        std::cout << "Found incompatible wafer types:\n  " << detid << "\n";
+      }
+      GlobalPoint center = triggerGeometry_->noseGeometry()->getPosition(id);
+      cellX_ = center.x();
+      cellY_ = center.y();
+      cellZ_ = center.z();
+      std::vector<GlobalPoint> corners = triggerGeometry_->noseGeometry()->getCorners(id);
+      cellCornersN_ = corners.size();
+      setTreeCellCornerSize(cellCornersN_);
+      for (unsigned i = 0; i < corners.size(); i++) {
+        cellCornersX_.get()[i] = corners[i].x();
+        cellCornersY_.get()[i] = corners[i].y();
+        cellCornersZ_.get()[i] = corners[i].z();
+      }
+      treeCellsNose_->Fill();
+      // fill trigger cells
+      if (!no_trigger_) {
+        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+        // Skip trigger cells in module 0
+        // uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+        //if (HGCalDetId(module).wafer() == 0)
+        //  continue;
+        auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+  }
+
+  // if problem detected in the trigger geometry, don't produce trigger trees
+  if (no_trigger_)
+    return;
+
+  // Loop over trigger cells
+  edm::LogPrint("TreeFilling") << "Filling trigger cells tree";
+  for (const auto& triggercell_cells : trigger_cells) {
+    DetId id(triggercell_cells.first);
+    GlobalPoint position = triggerGeometry_->getTriggerCellPosition(triggercell_cells.first);
+    triggerCellId_ = id.rawId();
+    if (id.det() == DetId::HGCalHSc) {
+      HGCScintillatorDetId id_sc(triggercell_cells.first);
+      triggerCellSide_ = id_sc.zside();
+      triggerCellSubdet_ = id_sc.subdet();
+      triggerCellLayer_ = id_sc.layer();
+      triggerCellIEta_ = id_sc.ietaAbs();
+      triggerCellIPhi_ = id_sc.iphi();
+    } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
+               HFNoseTriggerDetId(triggercell_cells.first).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+      HFNoseTriggerDetId id_nose_trig(triggercell_cells.first);
+      triggerCellSide_ = id_nose_trig.zside();
+      triggerCellSubdet_ = id_nose_trig.subdet();
+      triggerCellLayer_ = id_nose_trig.layer();
+      triggerCellWaferU_ = id_nose_trig.waferU();
+      triggerCellWaferV_ = id_nose_trig.waferV();
+      triggerCellU_ = id_nose_trig.triggerCellU();
+      triggerCellV_ = id_nose_trig.triggerCellV();
+    } else {
+      HGCalTriggerDetId id_si_trig(triggercell_cells.first);
+      triggerCellSide_ = id_si_trig.zside();
+      triggerCellSubdet_ = id_si_trig.subdet();
+      triggerCellLayer_ = id_si_trig.layer();
+      triggerCellWaferU_ = id_si_trig.waferU();
+      triggerCellWaferV_ = id_si_trig.waferV();
+      triggerCellU_ = id_si_trig.triggerCellU();
+      triggerCellV_ = id_si_trig.triggerCellV();
+    }
+    triggerCellX_ = position.x();
+    triggerCellY_ = position.y();
+    triggerCellZ_ = position.z();
+    triggerCellCell_N_ = triggercell_cells.second.size();
+    //
+    setTreeTriggerCellSize(triggerCellCell_N_);
+    size_t ic = 0;
+    for (const auto& c : triggercell_cells.second) {
+      if (id.det() == DetId::HGCalHSc) {
+        HGCScintillatorDetId cId(c);
+        GlobalPoint cell_position = triggerGeometry_->hscGeometry()->getPosition(cId);
+        triggerCellCell_id_.get()[ic] = c;
+        triggerCellCell_zside_.get()[ic] = cId.zside();
+        triggerCellCell_subdet_.get()[ic] = cId.subdetId();
+        triggerCellCell_layer_.get()[ic] = cId.layer();
+        triggerCellCell_waferU_.get()[ic] = 0;
+        triggerCellCell_waferV_.get()[ic] = 0;
+        triggerCellCell_cellU_.get()[ic] = 0;
+        triggerCellCell_cellV_.get()[ic] = 0;
+        triggerCellCell_ieta_.get()[ic] = cId.ietaAbs();
+        triggerCellCell_iphi_.get()[ic] = cId.iphi();
+        triggerCellCell_x_.get()[ic] = cell_position.x();
+        triggerCellCell_y_.get()[ic] = cell_position.y();
+        triggerCellCell_z_.get()[ic] = cell_position.z();
+      } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
+                 HFNoseTriggerDetId(triggercell_cells.first).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+        HFNoseDetId cId(c);
+        GlobalPoint cell_position = triggerGeometry_->noseGeometry()->getPosition(cId);
+        triggerCellCell_id_.get()[ic] = c;
+        triggerCellCell_zside_.get()[ic] = cId.zside();
+        triggerCellCell_subdet_.get()[ic] = cId.subdet();
+        triggerCellCell_layer_.get()[ic] = cId.layer();
+        triggerCellCell_waferU_.get()[ic] = cId.waferU();
+        triggerCellCell_waferV_.get()[ic] = cId.waferV();
+        triggerCellCell_cellU_.get()[ic] = cId.cellU();
+        triggerCellCell_cellV_.get()[ic] = cId.cellV();
+        triggerCellCell_ieta_.get()[ic] = 0;
+        triggerCellCell_iphi_.get()[ic] = 0;
+        triggerCellCell_x_.get()[ic] = cell_position.x();
+        triggerCellCell_y_.get()[ic] = cell_position.y();
+        triggerCellCell_z_.get()[ic] = cell_position.z();
+      } else {
+        HGCSiliconDetId cId(c);
+        GlobalPoint cell_position = (cId.det() == DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId)
+                                                                 : triggerGeometry_->hsiGeometry()->getPosition(cId));
+        triggerCellCell_id_.get()[ic] = c;
+        triggerCellCell_zside_.get()[ic] = cId.zside();
+        triggerCellCell_subdet_.get()[ic] = cId.subdet();
+        triggerCellCell_layer_.get()[ic] = cId.layer();
+        triggerCellCell_waferU_.get()[ic] = cId.waferU();
+        triggerCellCell_waferV_.get()[ic] = cId.waferV();
+        triggerCellCell_cellU_.get()[ic] = cId.cellU();
+        triggerCellCell_cellV_.get()[ic] = cId.cellV();
+        triggerCellCell_ieta_.get()[ic] = 0;
+        triggerCellCell_iphi_.get()[ic] = 0;
+        triggerCellCell_x_.get()[ic] = cell_position.x();
+        triggerCellCell_y_.get()[ic] = cell_position.y();
+        triggerCellCell_z_.get()[ic] = cell_position.z();
+      }
+      ic++;
+    }
+
+    treeTriggerCells_->Fill();
+
+    // fill modules
+    uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
+    auto itr_insert = modules.emplace(module, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
+  }
+
+  // Loop over modules
+  edm::LogPrint("TreeFilling") << "Filling modules tree";
+
+  for (const auto& module_triggercells : modules) {
+    HGCalModuleDetId id(module_triggercells.first);
+    GlobalPoint position = triggerGeometry_->getModulePosition(id);
+    moduleId_ = id.rawId();
+    moduleX_ = position.x();
+    moduleY_ = position.y();
+    moduleZ_ = position.z();
+
+    moduleSide_ = id.zside();
+    moduleSubdet_ = id.triggerSubdetId();
+    moduleLayer_ = id.layer();
+    module_ = 0;
+    if (moduleSubdet_ == HGCalTriggerSubdetector::HGCalHScTrigger) {
+      moduleIEta_ = id.eta();
+      moduleIPhi_ = id.phi();
+    } else {
+      moduleIEta_ = 0;
+      moduleIPhi_ = 0;
+    }
+    moduleTC_N_ = module_triggercells.second.size();
+    if (triggerGeometry_->disconnectedModule(id)) {
+      moduleLinks_ = 0;
+    } else {
+      moduleLinks_ = triggerGeometry_->getLinksInModule(id);
+    }
+    //
+    setTreeModuleSize(moduleTC_N_);
+    size_t itc = 0;
+    for (const auto& tc : module_triggercells.second) {
+      moduleTC_id_.get()[itc] = tc;
+      if (moduleSubdet_ == HGCalTriggerSubdetector::HGCalHScTrigger) {
+        HGCScintillatorDetId tcId(tc);
+        moduleTC_zside_.get()[itc] = tcId.zside();
+        moduleTC_subdet_.get()[itc] = tcId.subdet();
+        moduleTC_layer_.get()[itc] = tcId.layer();
+        moduleTC_waferU_.get()[itc] = 0;
+        moduleTC_waferV_.get()[itc] = 0;
+        moduleTC_cellU_.get()[itc] = 0;
+        moduleTC_cellV_.get()[itc] = 0;
+        moduleTC_ieta_.get()[itc] = tcId.ietaAbs();
+        moduleTC_iphi_.get()[itc] = tcId.iphi();
+      } else if (moduleSubdet_ == HGCalTriggerSubdetector::HFNoseTrigger) {
+        HFNoseTriggerDetId tcId(tc);
+        moduleTC_zside_.get()[itc] = tcId.zside();
+        moduleTC_subdet_.get()[itc] = tcId.subdet();
+        moduleTC_layer_.get()[itc] = tcId.layer();
+        moduleTC_waferU_.get()[itc] = tcId.waferU();
+        moduleTC_waferV_.get()[itc] = tcId.waferV();
+        moduleTC_cellU_.get()[itc] = tcId.triggerCellU();
+        moduleTC_cellV_.get()[itc] = tcId.triggerCellV();
+        moduleTC_ieta_.get()[itc] = 0;
+        moduleTC_iphi_.get()[itc] = 0;
+      } else {
+        HGCalTriggerDetId tcId(tc);
+        moduleTC_zside_.get()[itc] = tcId.zside();
+        moduleTC_subdet_.get()[itc] = tcId.subdet();
+        moduleTC_layer_.get()[itc] = tcId.layer();
+        moduleTC_waferU_.get()[itc] = tcId.waferU();
+        moduleTC_waferV_.get()[itc] = tcId.waferV();
+        moduleTC_cellU_.get()[itc] = tcId.triggerCellU();
+        moduleTC_cellV_.get()[itc] = tcId.triggerCellV();
+        moduleTC_ieta_.get()[itc] = 0;
+        moduleTC_iphi_.get()[itc] = 0;
+      }
+      GlobalPoint position = triggerGeometry_->getTriggerCellPosition(tc);
+      moduleTC_x_.get()[itc] = position.x();
+      moduleTC_y_.get()[itc] = position.y();
+      moduleTC_z_.get()[itc] = position.z();
+      itc++;
+    }
+    auto cells_in_module = triggerGeometry_->getCellsFromModule(id);
+    moduleCell_N_ = cells_in_module.size();
+    //
+    setTreeModuleCellSize(moduleCell_N_);
+    size_t ic = 0;
+    for (const auto& c : cells_in_module) {
+      if (moduleSubdet_ == HGCalTriggerSubdetector::HGCalHScTrigger) {
+        HGCScintillatorDetId cId(c);
+        GlobalPoint cell_position = triggerGeometry_->hscGeometry()->getPosition(cId);
+        triggerCellCell_id_.get()[ic] = c;
+        triggerCellCell_zside_.get()[ic] = cId.zside();
+        triggerCellCell_subdet_.get()[ic] = cId.subdetId();
+        triggerCellCell_layer_.get()[ic] = cId.layer();
+        triggerCellCell_waferU_.get()[ic] = 0;
+        triggerCellCell_waferV_.get()[ic] = 0;
+        triggerCellCell_cellU_.get()[ic] = 0;
+        triggerCellCell_cellV_.get()[ic] = 0;
+        triggerCellCell_ieta_.get()[ic] = cId.ietaAbs();
+        triggerCellCell_iphi_.get()[ic] = cId.iphi();
+        triggerCellCell_x_.get()[ic] = cell_position.x();
+        triggerCellCell_y_.get()[ic] = cell_position.y();
+        triggerCellCell_z_.get()[ic] = cell_position.z();
+      } else if (moduleSubdet_ == HGCalTriggerSubdetector::HFNoseTrigger) {
+        HFNoseDetId cId(c);
+        const GlobalPoint position = triggerGeometry_->noseGeometry()->getPosition(c);
+        moduleCell_id_.get()[ic] = c;
+        moduleCell_zside_.get()[ic] = cId.zside();
+        moduleCell_subdet_.get()[ic] = cId.subdetId();
+        moduleCell_layer_.get()[ic] = cId.layer();
+        moduleCell_waferU_.get()[ic] = cId.waferU();
+        moduleCell_waferV_.get()[ic] = cId.waferV();
+        moduleCell_cellU_.get()[ic] = cId.cellU();
+        moduleCell_cellV_.get()[ic] = cId.cellV();
+        moduleCell_x_.get()[ic] = position.x();
+        moduleCell_y_.get()[ic] = position.y();
+        moduleCell_z_.get()[ic] = position.z();
+      } else {
+        HGCSiliconDetId cId(c);
+        const GlobalPoint position = (cId.det() == DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId)
+                                                                  : triggerGeometry_->hsiGeometry()->getPosition(cId));
+        moduleCell_id_.get()[ic] = c;
+        moduleCell_zside_.get()[ic] = cId.zside();
+        moduleCell_subdet_.get()[ic] = cId.subdetId();
+        moduleCell_layer_.get()[ic] = cId.layer();
+        moduleCell_waferU_.get()[ic] = cId.waferU();
+        moduleCell_waferV_.get()[ic] = cId.waferV();
+        moduleCell_cellU_.get()[ic] = cId.cellU();
+        moduleCell_cellV_.get()[ic] = cId.cellV();
+        moduleCell_x_.get()[ic] = position.x();
+        moduleCell_y_.get()[ic] = position.y();
+        moduleCell_z_.get()[ic] = position.z();
+        ic++;
+      }
+    }
+    treeModules_->Fill();
+  }
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::analyze(const edm::Event& e, const edm::EventSetup& es)
+/*****************************************************************/
+{}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::setTreeModuleSize(const size_t n)
+/*****************************************************************/
+{
+  moduleTC_id_.reset(new int[n], array_deleter<int>());
+  moduleTC_zside_.reset(new int[n], array_deleter<int>());
+  moduleTC_subdet_.reset(new int[n], array_deleter<int>());
+  moduleTC_layer_.reset(new int[n], array_deleter<int>());
+  moduleTC_waferU_.reset(new int[n], array_deleter<int>());
+  moduleTC_waferV_.reset(new int[n], array_deleter<int>());
+  moduleTC_cellU_.reset(new int[n], array_deleter<int>());
+  moduleTC_cellV_.reset(new int[n], array_deleter<int>());
+  moduleTC_ieta_.reset(new int[n], array_deleter<int>());
+  moduleTC_iphi_.reset(new int[n], array_deleter<int>());
+  moduleTC_x_.reset(new float[n], array_deleter<float>());
+  moduleTC_y_.reset(new float[n], array_deleter<float>());
+  moduleTC_z_.reset(new float[n], array_deleter<float>());
+
+  treeModules_->GetBranch("tc_id")->SetAddress(moduleTC_id_.get());
+  treeModules_->GetBranch("tc_zside")->SetAddress(moduleTC_zside_.get());
+  treeModules_->GetBranch("tc_subdet")->SetAddress(moduleTC_subdet_.get());
+  treeModules_->GetBranch("tc_layer")->SetAddress(moduleTC_layer_.get());
+  treeModules_->GetBranch("tc_waferu")->SetAddress(moduleTC_waferU_.get());
+  treeModules_->GetBranch("tc_waferv")->SetAddress(moduleTC_waferV_.get());
+  treeModules_->GetBranch("tc_cellu")->SetAddress(moduleTC_cellU_.get());
+  treeModules_->GetBranch("tc_cellv")->SetAddress(moduleTC_cellV_.get());
+  treeModules_->GetBranch("tc_ieta")->SetAddress(moduleTC_ieta_.get());
+  treeModules_->GetBranch("tc_iphi")->SetAddress(moduleTC_iphi_.get());
+  treeModules_->GetBranch("tc_x")->SetAddress(moduleTC_x_.get());
+  treeModules_->GetBranch("tc_y")->SetAddress(moduleTC_y_.get());
+  treeModules_->GetBranch("tc_z")->SetAddress(moduleTC_z_.get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::setTreeModuleCellSize(const size_t n)
+/*****************************************************************/
+{
+  moduleCell_id_.reset(new int[n], array_deleter<int>());
+  moduleCell_zside_.reset(new int[n], array_deleter<int>());
+  moduleCell_subdet_.reset(new int[n], array_deleter<int>());
+  moduleCell_layer_.reset(new int[n], array_deleter<int>());
+  moduleCell_waferU_.reset(new int[n], array_deleter<int>());
+  moduleCell_waferV_.reset(new int[n], array_deleter<int>());
+  moduleCell_cellU_.reset(new int[n], array_deleter<int>());
+  moduleCell_cellV_.reset(new int[n], array_deleter<int>());
+  moduleCell_x_.reset(new float[n], array_deleter<float>());
+  moduleCell_y_.reset(new float[n], array_deleter<float>());
+  moduleCell_z_.reset(new float[n], array_deleter<float>());
+
+  treeModules_->GetBranch("c_id")->SetAddress(moduleCell_id_.get());
+  treeModules_->GetBranch("c_zside")->SetAddress(moduleCell_zside_.get());
+  treeModules_->GetBranch("c_subdet")->SetAddress(moduleCell_subdet_.get());
+  treeModules_->GetBranch("c_layer")->SetAddress(moduleCell_layer_.get());
+  treeModules_->GetBranch("c_waferu")->SetAddress(moduleCell_waferU_.get());
+  treeModules_->GetBranch("c_waferv")->SetAddress(moduleCell_waferV_.get());
+  treeModules_->GetBranch("c_cellu")->SetAddress(moduleCell_cellU_.get());
+  treeModules_->GetBranch("c_cellv")->SetAddress(moduleCell_cellV_.get());
+  treeModules_->GetBranch("c_x")->SetAddress(moduleCell_x_.get());
+  treeModules_->GetBranch("c_y")->SetAddress(moduleCell_y_.get());
+  treeModules_->GetBranch("c_z")->SetAddress(moduleCell_z_.get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::setTreeTriggerCellSize(const size_t n)
+/*****************************************************************/
+{
+  triggerCellCell_id_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_zside_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_subdet_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_layer_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_waferU_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_waferV_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_cellU_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_cellV_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_ieta_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_iphi_.reset(new int[n], array_deleter<int>());
+  triggerCellCell_x_.reset(new float[n], array_deleter<float>());
+  triggerCellCell_y_.reset(new float[n], array_deleter<float>());
+  triggerCellCell_z_.reset(new float[n], array_deleter<float>());
+
+  treeTriggerCells_->GetBranch("c_id")->SetAddress(triggerCellCell_id_.get());
+  treeTriggerCells_->GetBranch("c_zside")->SetAddress(triggerCellCell_zside_.get());
+  treeTriggerCells_->GetBranch("c_subdet")->SetAddress(triggerCellCell_subdet_.get());
+  treeTriggerCells_->GetBranch("c_layer")->SetAddress(triggerCellCell_layer_.get());
+  treeTriggerCells_->GetBranch("c_waferu")->SetAddress(triggerCellCell_waferU_.get());
+  treeTriggerCells_->GetBranch("c_waferv")->SetAddress(triggerCellCell_waferV_.get());
+  treeTriggerCells_->GetBranch("c_cellu")->SetAddress(triggerCellCell_cellU_.get());
+  treeTriggerCells_->GetBranch("c_cellv")->SetAddress(triggerCellCell_cellV_.get());
+  treeTriggerCells_->GetBranch("c_ieta")->SetAddress(triggerCellCell_ieta_.get());
+  treeTriggerCells_->GetBranch("c_iphi")->SetAddress(triggerCellCell_iphi_.get());
+  treeTriggerCells_->GetBranch("c_x")->SetAddress(triggerCellCell_x_.get());
+  treeTriggerCells_->GetBranch("c_y")->SetAddress(triggerCellCell_y_.get());
+  treeTriggerCells_->GetBranch("c_z")->SetAddress(triggerCellCell_z_.get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::setTreeCellCornerSize(const size_t n)
+/*****************************************************************/
+{
+  cellCornersX_.reset(new float[n], array_deleter<float>());
+  cellCornersY_.reset(new float[n], array_deleter<float>());
+  cellCornersZ_.reset(new float[n], array_deleter<float>());
+
+  treeCells_->GetBranch("corner_x")->SetAddress(cellCornersX_.get());
+  treeCells_->GetBranch("corner_y")->SetAddress(cellCornersY_.get());
+  treeCells_->GetBranch("corner_z")->SetAddress(cellCornersZ_.get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp3::setTreeTriggerCellNeighborSize(const size_t n)
+/*****************************************************************/
+{
+  triggerCellNeighbor_id_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_zside_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_subdet_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_layer_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_waferU_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_waferV_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_cellU_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_cellV_.reset(new int[n], array_deleter<int>());
+  triggerCellNeighbor_distance_.reset(new float[n], array_deleter<float>());
+  treeTriggerCells_->GetBranch("neighbor_id")->SetAddress(triggerCellNeighbor_id_.get());
+  treeTriggerCells_->GetBranch("neighbor_zside")->SetAddress(triggerCellNeighbor_zside_.get());
+  treeTriggerCells_->GetBranch("neighbor_subdet")->SetAddress(triggerCellNeighbor_subdet_.get());
+  treeTriggerCells_->GetBranch("neighbor_layer")->SetAddress(triggerCellNeighbor_layer_.get());
+  treeTriggerCells_->GetBranch("neighbor_waferu")->SetAddress(triggerCellNeighbor_waferU_.get());
+  treeTriggerCells_->GetBranch("neighbor_waferv")->SetAddress(triggerCellNeighbor_waferV_.get());
+  treeTriggerCells_->GetBranch("neighbor_cellu")->SetAddress(triggerCellNeighbor_cellU_.get());
+  treeTriggerCells_->GetBranch("neighbor_cellv")->SetAddress(triggerCellNeighbor_cellV_.get());
+  treeTriggerCells_->GetBranch("neighbor_distance")->SetAddress(triggerCellNeighbor_distance_.get());
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HGCalTriggerGeomTesterV9Imp3);

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp3_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp3_cfg.py
@@ -1,0 +1,122 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('SIM',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test_triggergeom.root")
+    )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(10.01),
+        MinPt = cms.double(9.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(2.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-2.5),
+        MinPhi = cms.double(-3.14159265359)
+    ),
+    Verbosity = cms.untracked.int32(0),
+    psethack = cms.string('single electron pt 10'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
+
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V11
+process = custom_geometry_decentralized_V11(process, implementation=2)
+
+process.hgcaltriggergeomtester = cms.EDAnalyzer(
+    "HGCalTriggerGeomTesterV9Imp3"
+    )
+process.test_step = cms.Path(process.hgcaltriggergeomtester)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.test_step,process.endjob_step)
+#  process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.test_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+#process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+    getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)


### PR DESCRIPTION
#### PR description:

Replacement/continuation of #459, after implementation of module rotation class in https://github.com/cms-sw/cmssw/pull/32684. Note that the changes from PR32684 have been copied here, as they do not currently exist in the PFCal-dev repository.
This adds new functionality to obtain the mapping between modules, lpgbts, and stage 1 and 2 FPGAs.
These are in the form of a `.json' file, which is then read-in and manipulated (json file only an example skeleton at present)

#### PR validation:

Tested that the code compiles and each function works in isolation.

