### PR TITLE
[Backport 11_2_0] normalize AE inputs using bit shifting to MSB to replicate ECON behavior

### DIFF
--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
@@ -76,6 +76,7 @@ private:
   std::vector<unsigned int> linkToGraphMap_;
 
   double zeroSuppresionThreshold_;
+  bool bitShiftNormalization_;
   bool saveEncodedValues_;
   bool preserveModuleSum_;
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -209,6 +209,7 @@ autoEncoder_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorP
                                  modelFiles = cms.VPSet([autoEncoder_training_2eLinks, autoEncoder_training_3eLinks, autoEncoder_training_4eLinks, autoEncoder_training_5eLinks]),
                                  linkToGraphMap = cms.vuint32(linkToGraphMapping),
                                  zeroSuppresionThreshold = cms.double(0.1),
+                                 bitShiftNormalization = cms.bool(True),
                                  saveEncodedValues = cms.bool(False),
                                  preserveModuleSum = cms.bool(True),
                                  threshold_silicon = cms.double(2.), # MipT

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
@@ -17,6 +17,7 @@ HGCalConcentratorAutoEncoderImpl::HGCalConcentratorAutoEncoderImpl(const edm::Pa
       modelFilePaths_(conf.getParameter<std::vector<edm::ParameterSet>>("modelFiles")),
       linkToGraphMap_(conf.getParameter<std::vector<unsigned int>>("linkToGraphMap")),
       zeroSuppresionThreshold_(conf.getParameter<double>("zeroSuppresionThreshold")),
+      bitShiftNormalization_(conf.getParameter<bool>("bitShiftNormalization")),
       saveEncodedValues_(conf.getParameter<bool>("saveEncodedValues")),
       preserveModuleSum_(conf.getParameter<bool>("preserveModuleSum")) {
   // find total size of the expected input shape
@@ -173,6 +174,13 @@ void HGCalConcentratorAutoEncoderImpl::select(unsigned nLinks,
   }
 
   if (modSum > 0) {
+    //Use a bit shift normalization like will be implemented in ECON, rather than floating point sum
+    //Normalizes to the MSB value of the module sum
+    if (bitShiftNormalization_) {
+      int msb = int(log2(modSum));
+      modSum = pow(2, msb);
+    }
+
     //normalize inputs to module sum
     for (uint i = 0; i < nInputs_; i++) {
       int remapIndex = cellRemap_[i];


### PR DESCRIPTION
Backport of #469 