### PR TITLE
Use full module sums in towers

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -32,7 +32,7 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                threshold_scintillator = cms.double(2.), # MipT
                                coarsenTriggerCells = cms.vuint32(0,0,0),
                                fixedDataSizePerHGCROC = cms.bool(False),
-                               allTrigCellsInTrigSums = cms.bool(False),
+                               allTrigCellsInTrigSums = cms.bool(True),
                                ctcSize = cms.vuint32(CTC_SIZE),
                                )
 

--- a/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerProducer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 import L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi as hgcalTowerMapProducer_cfi
 
 tower = cms.PSet( ProcessorName  = cms.string('HGCalTowerProcessor'),
-      includeTrigCells = cms.bool(True),
+      includeTrigCells = cms.bool(False),
       towermap_parameters = hgcalTowerMapProducer_cfi.towerMap2D_parValues.clone()
                   )
 


### PR DESCRIPTION
Switch to all trigger cells to build the module sums, and build towers only from the module sums.
