### PR TITLE
Tower eta & phi when running standalone configuration

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
@@ -11,7 +11,7 @@ namespace l1thgcfirmware {
   class HGCalTowerMap {
   public:
     HGCalTowerMap(){};
-    HGCalTowerMap(const std::vector<unsigned short>& tower_ids);
+    HGCalTowerMap(const std::vector<l1thgcfirmware::HGCalTowerCoord>& tower_ids);
 
     ~HGCalTowerMap(){};
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -1,14 +1,15 @@
 #ifndef L1Trigger_L1THGCal_HGCalTower_SA_h
 #define L1Trigger_L1THGCal_HGCalTower_SA_h
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace l1thgcfirmware {
 
   class HGCalTower {
   public:
     HGCalTower() {}
-    HGCalTower(double etEm, double etHad, float eta, float phi, uint32_t rawId ) : etEm_(etEm), etHad_(etHad), eta_(eta), phi_(phi), id_(rawId) {}
+    HGCalTower(double etEm, double etHad, float eta, float phi, uint32_t rawId)
+        : etEm_(etEm), etHad_(etHad), eta_(eta), phi_(phi), id_(rawId) {}
 
     ~HGCalTower(){};
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -1,17 +1,23 @@
 #ifndef L1Trigger_L1THGCal_HGCalTower_SA_h
 #define L1Trigger_L1THGCal_HGCalTower_SA_h
 
+#include <stdint.h>
+
 namespace l1thgcfirmware {
 
   class HGCalTower {
   public:
     HGCalTower() {}
-    HGCalTower(double etEm, double etHad) : etEm_(etEm), etHad_(etHad) {}
+    HGCalTower(double etEm, double etHad, float eta, float phi, uint32_t rawId ) : etEm_(etEm), etHad_(etHad), eta_(eta), phi_(phi), id_(rawId) {}
 
     ~HGCalTower(){};
 
-    double etEm() const { return etEm_; };
-    double etHad() const { return etHad_; };
+    double etEm() const { return etEm_; }
+    double etHad() const { return etHad_; }
+
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    uint32_t id() const { return id_; }
 
     void addEtEm(double et);
     void addEtHad(double et);
@@ -21,6 +27,18 @@ namespace l1thgcfirmware {
   private:
     double etEm_;
     double etHad_;
+
+    float eta_;
+    float phi_;
+    uint32_t id_;
+  };
+
+  struct HGCalTowerCoord {
+    HGCalTowerCoord(uint32_t rawId, float eta, float phi) : rawId(rawId), eta(eta), phi(phi) {}
+
+    const uint32_t rawId;
+    const float eta;
+    const float phi;
   };
 }  // namespace l1thgcfirmware
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -43,9 +43,9 @@ HGCalTowerMapsWrapper::HGCalTowerMapsWrapper(const edm::ParameterSet& conf) : HG
 void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
                                                std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const {
   for (const auto& map : inputTowerMaps) {
-    std::vector<unsigned short> tower_ids;
+    std::vector<l1thgcfirmware::HGCalTowerCoord> tower_ids;
     for (const auto& tower : map->towers()) {
-      tower_ids.push_back(tower.first);
+      tower_ids.emplace_back(tower.first, tower.second.eta(), tower.second.phi());
     }
 
     l1thgcfirmware::HGCalTowerMap towerMapSA(tower_ids);
@@ -60,8 +60,7 @@ void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::H
 void HGCalTowerMapsWrapper::convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towers_SA,
                                                     l1t::HGCalTowerBxCollection& outputTowerMaps) const {
   for (const auto& towerSA : towers_SA) {
-    // Need to carry eta, phi, ID through the SA emulation
-    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), 0, 0, 0));
+    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), towerSA.eta(), towerSA.phi(), towerSA.id()));
   }
 }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -60,7 +60,8 @@ void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::H
 void HGCalTowerMapsWrapper::convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towers_SA,
                                                     l1t::HGCalTowerBxCollection& outputTowerMaps) const {
   for (const auto& towerSA : towers_SA) {
-    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), towerSA.eta(), towerSA.phi(), towerSA.id()));
+    outputTowerMaps.push_back(
+        0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), towerSA.eta(), towerSA.phi(), towerSA.id()));
   }
 }
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
@@ -7,9 +7,9 @@ void HGCalTowerMapImplSA::runAlgorithm(const std::vector<HGCalTowerMap>& inputTo
   // Need better way to initialise the output tower map
   if (inputTowerMaps_SA.empty())
     return;
-  std::vector<unsigned short> tower_ids;
+  std::vector<HGCalTowerCoord> tower_ids;
   for (const auto& tower : inputTowerMaps_SA.front().towers()) {
-    tower_ids.push_back(tower.first);
+    tower_ids.emplace_back(tower.first, tower.second.eta(), tower.second.phi());
   }
   HGCalTowerMap towerMap(tower_ids);
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
@@ -4,9 +4,9 @@
 
 using namespace l1thgcfirmware;
 
-HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids) {
+HGCalTowerMap::HGCalTowerMap(const std::vector<l1thgcfirmware::HGCalTowerCoord>& tower_ids) {
   for (const auto tower_id : tower_ids) {
-    towerMap_[tower_id] = l1thgcfirmware::HGCalTower(0., 0.);
+    towerMap_[tower_id.rawId] = l1thgcfirmware::HGCalTower(0., 0., tower_id.eta, tower_id.phi, tower_id.rawId);
   }
 }
 


### PR DESCRIPTION
#### PR description:

The eta and phi of the output towers were set to zero in the original implementation of the standalone configuration/wrapper structure for the stage 2 tower sums.  This is fixed here, with the eta, phi and tower ID carried through the standalone implementation.

#### PR validation:

Eta and phi of towers in the ntuples are now non-zero when running the standalone configuration, and match that produced with the existing framework.
