### PR TITLE
Refactor trigger chains

### DIFF
--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -28,7 +28,6 @@ def create_topological(process, inputs,
                        cluster_threshold=topological_C2d_params.clustering_threshold_silicon  # MipT
                        ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            #  InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
             InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = topological_C2d_params.clone()
@@ -60,7 +59,7 @@ class CreateDummy(object):
         producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
         return producer
 
-def CreateTruthDummy(process, inputs):
+class CreateTruthDummy(object):
     def __call__(self, process, inputs):
         producer = process.hgcalBackEndLayer1Producer.clone(
                 InputTriggerCells = cms.InputTag(inputs)

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, \
                                                               distance_C2d_params, \
                                                               topological_C2d_params, \
-                                                              constrTopological_C2d_params
+                                                              constrTopological_C2d_params, \
+                                                              stage1truncation_proc, \
+                                                              truncation_params
 from L1Trigger.L1THGCal.customClustering import set_threshold_params
 
 
@@ -12,7 +14,7 @@ def create_distance(process, inputs,
                     cluster_threshold=distance_C2d_params.clustering_threshold_silicon  # MipT
                     ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = distance_C2d_params.clone(
             dR_cluster = distance
@@ -26,7 +28,8 @@ def create_topological(process, inputs,
                        cluster_threshold=topological_C2d_params.clustering_threshold_silicon  # MipT
                        ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            #  InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = topological_C2d_params.clone()
     set_threshold_params(producer.ProcessorParameters.C2d_parameters, seed_threshold, cluster_threshold)
@@ -39,7 +42,7 @@ def create_constrainedtopological(process, inputs,
                                   cluster_threshold=constrTopological_C2d_params.clustering_threshold_silicon  # MipT
                                   ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = constrTopological_C2d_params.clone(
             dR_cluster = distance
@@ -48,16 +51,36 @@ def create_constrainedtopological(process, inputs,
     return producer
 
 
-def create_dummy(process, inputs):
-    producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
-            )
-    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
-    return producer
 
-def create_truth_dummy(process, inputs):
-    producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}'.format(inputs))
-            )
-    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
-    return producer
+class CreateDummy(object):
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
+        return producer
+
+def CreateTruthDummy(process, inputs):
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
+        return producer
+
+
+class RozBinTruncation(object):
+    def __init__(self,
+            maxTcsPerBin=truncation_params.maxTcsPerBin):
+        self.processor = stage1truncation_proc.clone(
+                truncation_parameters=truncation_params.clone(
+                    maxTcsPerBin=maxTcsPerBin
+                    )
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -79,9 +79,7 @@ class CreateHistoMaxVariableDr(object):
                 dR_multicluster_byLayer_coefficientA = distances
                 )
         self.seeding_parameters = histoMax_C3d_seeding_params.clone()
-
-        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-                seed_threshold)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
 
     def __call__(self, process, inputs):
@@ -106,9 +104,7 @@ class CreateHistoMaxXYVariableDr(object):
                 dR_multicluster_byLayer_coefficientA = distances
                 )
         self.seeding_parameters = histoMaxXYVariableDR_C3d_params.clone()
-
-        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto,
-                seed_threshold)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
 
     def __call__(self, process, inputs):
@@ -134,8 +130,7 @@ class CreateHistoInterpolatedMax1stOrder(object):
                 neighbour_weights = neighbour_weights_1stOrder
                 )
         self.clustering_parameters = histoMax_C3d_clustering_params.clone()
-        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-                seed_threshold)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
     def __call__(self, process, inputs):
@@ -161,8 +156,7 @@ class CreateHistoInterpolatedMax2ndOrder(object):
                 neighbour_weights = neighbour_weights_2ndOrder
                 )
         self.clustering_parameters = histoMax_C3d_clustering_params.clone()
-        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-                seed_threshold)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
     def __call__(self, process, inputs):
@@ -186,8 +180,7 @@ class CreateHistoThreshold(object):
             ):
         self.seeding_parameters = histoThreshold_C3d_params.clone()
         self.clustering_parameters = histoMax_C3d_clustering_params.clone()
-        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-                seed_threshold)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
     def __call__(self, process, inputs):

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -19,7 +19,7 @@ def create_distance(process, inputs,
                     distance=distance_C3d_params.dR_multicluster
                     ):
     producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+            InputCluster = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C3d_parameters = distance_C3d_params.clone(
             dR_multicluster = distance
@@ -32,7 +32,7 @@ def create_dbscan(process, inputs,
                   min_points=dbscan_C3d_params.minN_dbscan_multicluster
                   ):
     producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+            InputCluster = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C3d_parameters = dbscan_C3d_params.clone(
             dist_dbscan_multicluster = distance,
@@ -41,137 +41,159 @@ def create_dbscan(process, inputs,
     return producer
 
 
-def create_histoMax(process, inputs,
-                    distance=histoMax_C3d_clustering_params.dR_multicluster,
-                    nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
-                    nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
-                    binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
-                    seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
-                    shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                    shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                    ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
+class CreateHistoMax(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
+            seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
-    return producer
-
-
-def create_histoMax_variableDr(process, inputs,
-                               distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                               nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
-                               nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
-                               binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
-                               seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
-                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
-                               shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
-                               ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone(
-            dR_multicluster_byLayer_coefficientA = distances
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone()
-
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, 0, shape_threshold, shape_distance)
-   
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoMaxXY_variableDr(process, inputs,
-                               distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                               nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
-                               nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
-                               seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
-                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
-                               shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
-                               ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone(
-            dR_multicluster_byLayer_coefficientA = distances
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMaxXYVariableDR_C3d_params.clone()
+class CreateHistoMaxVariableDr(object):
+    def __init__(self,
+            distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+            nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
+            seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
+            shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
+            ):
+        self.clustering_parameters= histoMax_C3d_clustering_params.clone(
+                dR_multicluster_byLayer_coefficientA = distances
+                )
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
 
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, 0, shape_threshold, shape_distance)
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
+                seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
 
-    return producer
-
-
-def create_histoInterpolatedMax1stOrder(process, inputs,
-                                        distance=histoMax_C3d_clustering_params.dR_multicluster,
-                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
-                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
-                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
-                                        shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                                        shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                                        ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoInterpolatedMax_C3d_params.clone(
-            neighbour_weights = neighbour_weights_1stOrder
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
-
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoInterpolatedMax2ndOrder(process, inputs,
-                                        distance=histoMax_C3d_clustering_params.dR_multicluster,
-                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
-                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
-                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
-                                        shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                                        shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                                        ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoInterpolatedMax_C3d_params.clone(
-            neighbour_weights = neighbour_weights_2ndOrder
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
-    
-    return producer
+class CreateHistoMaxXYVariableDr(object):
+    def __init__(self,
+            distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+            nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
+            seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
+            shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
+            ):
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone(
+                dR_multicluster_byLayer_coefficientA = distances
+                )
+        self.seeding_parameters = histoMaxXYVariableDR_C3d_params.clone()
+
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto,
+                seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoThreshold(process, inputs,
-                          threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
-                          distance=histoMax_C3d_clustering_params.dR_multicluster,
-                          nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
-                          nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
-                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
-                          shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                          shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                          ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoThreshold_C3d_params.clone()
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
+class CreateHistoInterpolatedMax1stOrder(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+            seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoInterpolatedMax_C3d_params.clone(
+                neighbour_weights = neighbour_weights_1stOrder
+                )
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
+                seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer
+
+
+class CreateHistoInterpolatedMax2ndOrder(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+            seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoInterpolatedMax_C3d_params.clone(
+                neighbour_weights = neighbour_weights_2ndOrder
+                )
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
+                seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer
+
+
+class CreateHistoThreshold(object):
+    def __init__(self,
+            seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoThreshold_C3d_params.clone()
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
+                seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -4,156 +4,184 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, custom_conc_proc, autoEncoder_conc_proc
 
 
-def create_supertriggercell(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize,
-                            type_energy_division=supertc_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
-                            coarsenTriggerCells=supertc_conc_proc.coarsenTriggerCells,
-                            ctcSize=supertc_conc_proc.ctcSize,
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = supertc_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            coarsenTriggerCells = coarsenTriggerCells,
-            ctcSize = ctcSize,
-            )
-    return producer
+class CreateSuperTriggerCell(object):
+    def __init__(self,
+            stcSize=supertc_conc_proc.stcSize,
+            type_energy_division=supertc_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
+            coarsenTriggerCells=supertc_conc_proc.coarsenTriggerCells,
+            ctcSize=supertc_conc_proc.ctcSize,
+            ):
+        self.processor = supertc_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                coarsenTriggerCells = coarsenTriggerCells,
+                ctcSize = ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_threshold(process, inputs,
-                     threshold_silicon=threshold_conc_proc.threshold_silicon,  # in mipT
-                     threshold_scintillator=threshold_conc_proc.threshold_scintillator  # in mipT
-                     ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = threshold_conc_proc.clone(
-            threshold_silicon = threshold_silicon,  # MipT
-            threshold_scintillator = threshold_scintillator  # MipT
-            )
-    return producer
+class CreateThreshold(object):
+    def __init__(self,
+            threshold_silicon=threshold_conc_proc.threshold_silicon,  # in mipT
+            threshold_scintillator=threshold_conc_proc.threshold_scintillator  # in mipT
+            ):
+        self.processor = threshold_conc_proc.clone(
+                threshold_silicon = threshold_silicon,  # MipT
+                threshold_scintillator = threshold_scintillator  # MipT
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_bestchoice(process, inputs,
-                      triggercells=best_conc_proc.NData,
-                      coarsenTriggerCells=best_conc_proc.coarsenTriggerCells,
-                      ctcSize=best_conc_proc.ctcSize,
-                      ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = best_conc_proc.clone(
-            NData = triggercells,
-            coarsenTriggerCells = coarsenTriggerCells,
-            ctcSize=ctcSize,
-            )
-    return producer
+class CreateBestChoice(object):
+    def __init__(self,
+            triggercells=best_conc_proc.NData,
+            coarsenTriggerCells=best_conc_proc.coarsenTriggerCells,
+            ctcSize=best_conc_proc.ctcSize,
+            ):
+        self.processor = best_conc_proc.clone(
+                NData = triggercells,
+                coarsenTriggerCells = coarsenTriggerCells,
+                ctcSize=ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_autoencoder(process, inputs,
-                       cellRemap = autoEncoder_conc_proc.cellRemap,
-                       cellRemapNoDuplicates = autoEncoder_conc_proc.cellRemapNoDuplicates,
-                       nBitsPerInput = autoEncoder_conc_proc.nBitsPerInput,
-                       maxBitsPerOutput = autoEncoder_conc_proc.maxBitsPerOutput,
-                       bitsPerLink = autoEncoder_conc_proc.bitsPerLink,
-                       modelFiles = autoEncoder_conc_proc.modelFiles,
-                       linkToGraphMap = autoEncoder_conc_proc.linkToGraphMap,
-                       encoderShape = autoEncoder_conc_proc.encoderShape,
-                       decoderShape = autoEncoder_conc_proc.decoderShape,
-                       zeroSuppresionThreshold = autoEncoder_conc_proc.zeroSuppresionThreshold,
-                       saveEncodedValues = autoEncoder_conc_proc.saveEncodedValues,
-                       preserveModuleSum = autoEncoder_conc_proc.preserveModuleSum,
-                       scintillatorMethod = 'thresholdSelect',
-                     ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = autoEncoder_conc_proc.clone(
-            cellRemap = cellRemap,
-            cellRemapNoDuplicates = cellRemapNoDuplicates,
-            nBitsPerInput = nBitsPerInput,
-            maxBitsPerOutput = maxBitsPerOutput,
-            bitsPerLink = bitsPerLink,
-            modelFiles = modelFiles,
-            linkToGraphMap = linkToGraphMap,
-            encoderShape = encoderShape,
-            decoderShape = decoderShape,
-            zeroSuppresionThreshold = zeroSuppresionThreshold,
-            saveEncodedValues = saveEncodedValues,
-            preserveModuleSum = preserveModuleSum,
-            Method = cms.vstring(['autoEncoder','autoEncoder', scintillatorMethod]),
-            )
-    return producer
+class CreateAutoencoder(object):
+    def __init__(self,
+            cellRemap = autoEncoder_conc_proc.cellRemap,
+            cellRemapNoDuplicates = autoEncoder_conc_proc.cellRemapNoDuplicates,
+            nBitsPerInput = autoEncoder_conc_proc.nBitsPerInput,
+            maxBitsPerOutput = autoEncoder_conc_proc.maxBitsPerOutput,
+            bitsPerLink = autoEncoder_conc_proc.bitsPerLink,
+            modelFiles = autoEncoder_conc_proc.modelFiles,
+            linkToGraphMap = autoEncoder_conc_proc.linkToGraphMap,
+            encoderShape = autoEncoder_conc_proc.encoderShape,
+            decoderShape = autoEncoder_conc_proc.decoderShape,
+            zeroSuppresionThreshold = autoEncoder_conc_proc.zeroSuppresionThreshold,
+            saveEncodedValues = autoEncoder_conc_proc.saveEncodedValues,
+            preserveModuleSum = autoEncoder_conc_proc.preserveModuleSum,
+            scintillatorMethod = 'thresholdSelect',
+            ):
+         self.processor = autoEncoder_conc_proc.clone(
+                cellRemap = cellRemap,
+                cellRemapNoDuplicates = cellRemapNoDuplicates,
+                nBitsPerInput = nBitsPerInput,
+                maxBitsPerOutput = maxBitsPerOutput,
+                bitsPerLink = bitsPerLink,
+                modelFiles = modelFiles,
+                linkToGraphMap = linkToGraphMap,
+                encoderShape = encoderShape,
+                decoderShape = decoderShape,
+                zeroSuppresionThreshold = zeroSuppresionThreshold,
+                saveEncodedValues = saveEncodedValues,
+                preserveModuleSum = preserveModuleSum,
+                Method = cms.vstring(['autoEncoder','autoEncoder', scintillatorMethod]),
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_onebitfraction(process, inputs,
-                            stcSize=coarsetc_onebitfraction_proc.stcSize,
-                            fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = coarsetc_onebitfraction_proc.clone(
-            stcSize = stcSize,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
-            )
-    return producer
+class CreateOneBitFraction(object):
+    def __init__(self,
+            stcSize=coarsetc_onebitfraction_proc.stcSize,
+            fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC
+            ):
+        self.processor = coarsetc_onebitfraction_proc.clone(
+                stcSize = stcSize,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_mixedfeoptions(process, inputs,
-                            stcSize=custom_conc_proc.stcSize,
-                            type_energy_division=custom_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=custom_conc_proc.NData
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = custom_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells,
-            Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
-            )
-    return producer
+class CreateMixedFeOptions(object):
+    def __init__(self,
+            stcSize=custom_conc_proc.stcSize,
+            type_energy_division=custom_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+            triggercells=custom_conc_proc.NData
+            ):
+        self.processor = custom_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                NData = triggercells,
+                Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_custom(process, inputs,
-                            stcSize=custom_conc_proc.stcSize,
-                            type_energy_division=custom_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=custom_conc_proc.NData,
-                            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
-                            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
-                            Method = custom_conc_proc.Method,
-                            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
-                            ctcSize=custom_conc_proc.ctcSize,
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = custom_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells,
-            threshold_silicon = threshold_silicon,  # MipT
-            threshold_scintillator = threshold_scintillator,  # MipT
-            Method = Method,
-            coarsenTriggerCells=coarsenTriggerCells,
-            ctcSize = ctcSize,
-            )
-    return producer
+class CreateCustom(object):
+    def __init__(self,
+            stcSize=custom_conc_proc.stcSize,
+            type_energy_division=custom_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+            triggercells=custom_conc_proc.NData,
+            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
+            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
+            Method = custom_conc_proc.Method,
+            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
+            ctcSize=custom_conc_proc.ctcSize,
+            ):
+        self.processor = custom_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                NData = triggercells,
+                threshold_silicon = threshold_silicon,  # MipT
+                threshold_scintillator = threshold_scintillator,  # MipT
+                Method = Method,
+                coarsenTriggerCells=coarsenTriggerCells,
+                ctcSize = ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -33,7 +33,8 @@ def custom_ntuples_standalone_tower(process):
     return process
 
 
-def create_ntuple(process, inputs,
+class CreateNtuple(object):
+    def __init__(self,
         ntuple_list=[
             'event',
             'gen', 'genjet', 'gentau',
@@ -41,22 +42,25 @@ def create_ntuple(process, inputs,
             'triggercells',
             'clusters', 'multiclusters'
             ]
-        ):
-    vpset = []
-    for ntuple in ntuple_list:
-        pset = getattr(process, 'ntuple_'+ntuple).clone()
-        if ntuple=='triggercells':
-            pset.TriggerCells = cms.InputTag(inputs[0])
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        elif ntuple=='clusters':
-            pset.Clusters = cms.InputTag(inputs[1])
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        elif ntuple=='multiclusters':
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        vpset.append(pset)
-    ntuplizer = process.hgcalTriggerNtuplizer.clone()
-    ntuplizer.Ntuples = cms.VPSet(vpset)
-    return ntuplizer
+            ):
+        self.ntuple_list = ntuple_list
+
+    def __call__(self, process, inputs):
+        vpset = []
+        for ntuple in self.ntuple_list:
+            pset = getattr(process, 'ntuple_'+ntuple).clone()
+            if ntuple=='triggercells':
+                pset.TriggerCells = cms.InputTag(inputs[0])
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            elif ntuple=='clusters':
+                pset.Clusters = cms.InputTag(inputs[1])
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            elif ntuple=='multiclusters':
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            vpset.append(pset)
+        ntuplizer = process.hgcalTriggerNtuplizer.clone()
+        ntuplizer.Ntuples = cms.VPSet(vpset)
+        return ntuplizer
 
 
 

--- a/L1Trigger/L1THGCalUtilities/python/selectors.py
+++ b/L1Trigger/L1THGCalUtilities/python/selectors.py
@@ -1,10 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-def create_genmatch(process, inputs,
-        distance=0.3
-        ):
-    producer = process.hgc3DClusterGenMatchSelector.clone(
-            dR = cms.double(distance),
-            src = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs))
-            )
-    return producer
+class CreateGenMatch(object):
+    def __init__(self,
+            distance=0.3
+            ):
+        self.dR = distance
+
+    def __call__(self, process, inputs):
+        producer = process.hgc3DClusterGenMatchSelector.clone(
+                dR = cms.double(self.dR),
+                src = cms.InputTag(inputs)
+                )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/vfe.py
+++ b/L1Trigger/L1THGCalUtilities/python/vfe.py
@@ -2,18 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 
-def create_vfe(process,
-        linearization_si=vfe_proc.linearizationCfg_si,
-        linearization_sc=vfe_proc.linearizationCfg_sc,
-        compression_ldm=vfe_proc.compressionCfg_ldm,
-        compression_hdm=vfe_proc.compressionCfg_hdm,
-        ):
-    producer = process.hgcalVFEProducer.clone(
-        ProcessorParameters = vfe_proc.clone(
+class CreateVfe(object):
+    def __init__(self,
+            linearization_si=vfe_proc.linearizationCfg_si,
+            linearization_sc=vfe_proc.linearizationCfg_sc,
+            compression_ldm=vfe_proc.compressionCfg_ldm,
+            compression_hdm=vfe_proc.compressionCfg_hdm,
+            ):
+        self.processor = vfe_proc.clone(
             linearizationCfg_si = linearization_si,
             linearizationCfg_sc = linearization_sc,
             compressionCfg_ldm = compression_ldm,
             compressionCfg_hdm = compression_hdm,
         )
-    )
-    return producer
+
+    def __call__(self, process):
+        producer = process.hgcalVFEProducer.clone(
+            ProcessorParameters = self.processor
+        )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V11_cfg.py
@@ -77,21 +77,23 @@ import L1Trigger.L1THGCalUtilities.customNtuples as ntuple
 chains = HGCalTriggerChains()
 # Register algorithms
 ## VFE
-chains.register_vfe("Floatingpoint", vfe.create_vfe)
+chains.register_vfe("Floatingpoint", vfe.CreateVfe())
 ## ECON
-chains.register_concentrator("Supertriggercell", concentrator.create_supertriggercell)
-chains.register_concentrator("Threshold", concentrator.create_threshold)
-chains.register_concentrator("Bestchoice", concentrator.create_bestchoice)
-chains.register_concentrator("AutoEncoder", concentrator.create_autoencoder)
+chains.register_concentrator("Supertriggercell", concentrator.CreateSuperTriggerCell())
+chains.register_concentrator("Threshold", concentrator.CreateThreshold())
+chains.register_concentrator("Bestchoice", concentrator.CreateBestChoice())
+chains.register_concentrator("AutoEncoder", concentrator.CreateAutoencoder())
 ## BE1
-chains.register_backend1("Dummy", clustering2d.create_dummy)
+chains.register_backend1("Dummy", clustering2d.CreateDummy())
 ## BE2
-chains.register_backend2("Histomax", clustering3d.create_histoMax)
+chains.register_backend2("Histomax", clustering3d.CreateHistoMax())
 # Register selector
-chains.register_selector("Genmatch", selectors.create_genmatch)
+chains.register_selector("Genmatch", selectors.CreateGenMatch())
+
+
 # Register ntuples
 ntuple_list = ['event', 'gen', 'multiclusters']
-chains.register_ntuple("Genclustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
+chains.register_ntuple("Genclustersntuple", ntuple.CreateNtuple(ntuple_list))
 
 # Register trigger chains
 concentrator_algos = ['Supertriggercell', 'Threshold', 'Bestchoice', 'AutoEncoder']


### PR DESCRIPTION
- Remove hardcoded processor names in input tags and instead automatically fetch the processor names from the producer parameters
- Simplify customisation of algo parameters using functors instead of functions