### PR TITLE
Stage 2 clustering emulator

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -14,7 +14,7 @@
 typedef HGCalAlgoWrapperBaseT<
     const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>,
     std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>,
-    std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    std::tuple<const edm::EventSetup&, const edm::ParameterSet&, const unsigned int, const int>>
     HGCalHistoClusteringWrapperBase;
 
 typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTowerMap>>,

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 typedef HGCalAlgoWrapperBaseT<
-    std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>,
+    const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>,
     std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>,
     std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
     HGCalHistoClusteringWrapperBase;

--- a/L1Trigger/L1THGCal/interface/backend_emulator/CentroidHelper.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/CentroidHelper.h
@@ -1,0 +1,70 @@
+#ifndef __L1Trigger_L1THGCal_CentroidHelper_h__
+#define __L1Trigger_L1THGCal_CentroidHelper_h__
+
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+    class CentroidHelper {
+    public:
+        CentroidHelper() : CentroidHelper(0,0,0,0,0,0,0,false) {}
+        CentroidHelper( unsigned int clock,
+                        unsigned int index,
+                        unsigned int dataValid
+                      )
+             : CentroidHelper(clock, index,0,0,0,0,0,dataValid) {}
+        CentroidHelper( unsigned int clock,
+                        unsigned int index,
+                        unsigned int column,
+                        unsigned int row,
+                        unsigned int energy,
+                        unsigned int X,
+                        unsigned int Y,
+                        unsigned int dataValid
+                      )
+             : clock_(clock),
+               index_(index),
+               column_(column),
+               row_(row),
+               energy_(energy),
+               X_(X),
+               Y_(Y),
+               dataValid_(dataValid)
+               {}
+        ~CentroidHelper() {}
+
+    // Getters
+    unsigned int clock() const { return clock_; }
+    unsigned int index() const { return index_; }
+    unsigned int column() const { return column_; }
+    unsigned int row() const { return row_; }
+    unsigned int energy() const { return energy_; }
+    unsigned int X() const { return X_; }
+    unsigned int Y() const { return Y_; }
+    bool dataValid() const { return dataValid_; }
+
+    // Setters
+    void setClock( const unsigned int clock ) { clock_ = clock; }
+    void setIndex( const unsigned int index ) { index_ = index; }
+
+    // Operators
+    bool operator> (const CentroidHelper& ch_other) { return true; } // Nothing implemented?
+
+    private:
+        unsigned int clock_;
+        unsigned int index_;
+        unsigned int column_;
+        unsigned int row_;
+        unsigned int energy_;
+        unsigned int X_;
+        unsigned int Y_;
+        bool dataValid_;
+    };
+
+    typedef std::shared_ptr<CentroidHelper> CentroidHelperPtr;
+    typedef std::vector<CentroidHelperPtr> CentroidHelperPtrCollection;
+    typedef std::vector< std::vector<CentroidHelperPtr> > CentroidHelperPtrCollections;
+}
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/DistServer.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/DistServer.h
@@ -1,0 +1,33 @@
+#ifndef __L1Trigger_L1THGCal_DistServer_h__
+#define __L1Trigger_L1THGCal_DistServer_h__
+
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h"
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+    class DistServer {
+    public:
+        DistServer( unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving );
+        ~DistServer() {}
+
+        HGCalTriggerCellSAPtrCollection clock(HGCalTriggerCellSAPtrCollection& inputs);
+
+        unsigned int nInputs() const { return nInputs_; }
+        unsigned int nOutputs() const { return nOutputs_; }
+        unsigned int nInterleaving() const { return nInterleaving_; }
+        std::vector< std::vector< unsigned int> >& addr() { return addr_; }
+        l1thgcfirmware::HGCalTriggerCellSAPtrCollections& inputs() { return inputs_; }
+
+    private:
+        unsigned int nInputs_;
+        unsigned int nOutputs_;
+        unsigned int nInterleaving_;
+
+        l1thgcfirmware::HGCalTriggerCellSAPtrCollections inputs_;
+        std::vector< std::vector< unsigned int> > addr_;        
+    };
+}
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
@@ -40,8 +40,10 @@ namespace l1thgcfirmware {
 
     ~HGCalCluster(){}
 
+    // Setters
     void setClock( const unsigned int clock ) { clock_ = clock; }
     void setIndex( const unsigned int index ) { index_ = index; }
+    void setDataValid( const bool dataValid ) { dataValid_ = dataValid; }
 
     void set_n_tc( unsigned int n_tc ) { n_tc_ = n_tc; }
     void set_e( unsigned int e ) { e_ = e; }
@@ -63,6 +65,7 @@ namespace l1thgcfirmware {
     void set_sat_tc( bool sat_tc ) { sat_tc_ = sat_tc; }
     void set_shapeq( unsigned int shapeq ) { shapeq_ = shapeq; }
 
+    // Getters
     unsigned int clock() const { return clock_; }
     unsigned int index() const { return index_; }
     bool frameValid() const { return frameValid_; }
@@ -87,6 +90,9 @@ namespace l1thgcfirmware {
     unsigned int layerbits() const { return layerbits_; }
     bool sat_tc() const { return sat_tc_; }
     unsigned int shapeq() const { return shapeq_; }
+
+    // Operators
+    const HGCalCluster& operator+=(const HGCalCluster& hc);
 
   private:
     unsigned int clock_;
@@ -118,7 +124,10 @@ namespace l1thgcfirmware {
   };
 
   typedef std::vector<HGCalCluster> HGCalClusterSACollection;
-  typedef std::vector<std::shared_ptr<HGCalCluster> > HGCalClusterSAPtrCollection;
+  typedef std::shared_ptr<HGCalCluster> HGCalClusterSAPtr;
+  typedef std::vector<HGCalClusterSAPtr > HGCalClusterSAPtrCollection;
+  typedef std::vector< HGCalClusterSAPtrCollection > HGCalClusterSAPtrCollections;
+
 }  // namespace l1thgcfirmware
 
 #endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
@@ -35,10 +35,44 @@ namespace l1thgcfirmware {
                   wroz2_(0),
                   layerbits_(0),
                   sat_tc_(false),
-                  shapeq_(1)
+                  shapeq_(1),
+                  Sigma_E_Quotient_(0),
+                  Sigma_E_Fraction_(0),
+                  Mean_z_Quotient_(0),
+                  Mean_z_Fraction_(0),
+                  Mean_phi_Quotient_(0),
+                  Mean_phi_Fraction_(0),
+                  Mean_eta_Quotient_(0),
+                  Mean_eta_Fraction_(0),
+                  Mean_roz_Quotient_(0),
+                  Mean_roz_Fraction_(0),
+                  Sigma_z_Quotient_(0),
+                  Sigma_z_Fraction_(0),
+                  Sigma_phi_Quotient_(0),
+                  Sigma_phi_Fraction_(0),
+                  Sigma_eta_Quotient_(0),
+                  Sigma_eta_Fraction_(0),
+                  Sigma_roz_Quotient_(0),
+                  Sigma_roz_Fraction_(0),
+                  FirstLayer_(0),
+                  LastLayer_(0),
+                  ShowerLen_(0),
+                  CoreShowerLen_(0),
+                  E_EM_over_E_Quotient_(0),
+                  E_EM_over_E_Fraction_(0),
+                  E_EM_core_over_E_EM_Quotient_(0),
+                  E_EM_core_over_E_EM_Fraction_(0),
+                  E_H_early_over_E_Quotient_(0),
+                  E_H_early_over_E_Fraction_(0)
                   {}
 
     ~HGCalCluster(){}
+
+    std::pair< unsigned int, unsigned int > Sigma_Energy(unsigned int N_TC_W, unsigned long int Sum_W2, unsigned int Sum_W);
+    std::pair< unsigned int, unsigned int > Mean_coordinate(unsigned int Sum_Wc, unsigned int Sum_W);
+    std::pair< unsigned int, unsigned int > Sigma_Coordinate(unsigned int Sum_W, unsigned long int Sum_Wc2, unsigned int Sum_Wc);
+    std::pair< unsigned int, unsigned int > Energy_ratio(unsigned int E_N, unsigned int E_D);
+    std::vector<int> ShowerLengthProperties(unsigned long int layerBits);
 
     // Setters
     void setClock( const unsigned int clock ) { clock_ = clock; }
@@ -65,6 +99,37 @@ namespace l1thgcfirmware {
     void set_sat_tc( bool sat_tc ) { sat_tc_ = sat_tc; }
     void set_shapeq( unsigned int shapeq ) { shapeq_ = shapeq; }
 
+    void set_Sigma_E_Quotient( unsigned long int Sigma_E_Quotient ) { Sigma_E_Quotient_ = Sigma_E_Quotient; } 
+    void set_Sigma_E_Fraction( unsigned long int Sigma_E_Fraction ) { Sigma_E_Fraction_ = Sigma_E_Fraction; }
+    void set_Mean_z_Quotient( unsigned long int Mean_z_Quotient ) { Mean_z_Quotient_ = Mean_z_Quotient; }
+    void set_Mean_z_Fraction( unsigned long int Mean_z_Fraction ) { Mean_z_Fraction_ = Mean_z_Fraction; }
+    void set_Mean_phi_Quotient( unsigned long int Mean_phi_Quotient ) { Mean_phi_Quotient_ = Mean_phi_Quotient; }
+    void set_Mean_phi_Fraction( unsigned long int Mean_phi_Fraction ) { Mean_phi_Fraction_ = Mean_phi_Fraction; }
+    void set_Mean_eta_Quotient( unsigned long int Mean_eta_Quotient ) { Mean_eta_Quotient_ = Mean_eta_Quotient; }
+    void set_Mean_eta_Fraction( unsigned long int Mean_eta_Fraction ) { Mean_eta_Fraction_ = Mean_eta_Fraction; }
+    void set_Mean_roz_Quotient( unsigned long int Mean_roz_Quotient ) { Mean_roz_Quotient_ = Mean_roz_Quotient; }
+    void set_Mean_roz_Fraction( unsigned long int Mean_roz_Fraction ) { Mean_roz_Fraction_ = Mean_roz_Fraction; }
+    void set_Sigma_z_Quotient( unsigned long int Sigma_z_Quotient ) { Sigma_z_Quotient_ = Sigma_z_Quotient; }
+    void set_Sigma_z_Fraction( unsigned long int Sigma_z_Fraction ) { Sigma_z_Fraction_ = Sigma_z_Fraction; }
+    void set_Sigma_phi_Quotient( unsigned long int Sigma_phi_Quotient ) { Sigma_phi_Quotient_ = Sigma_phi_Quotient; }
+    void set_Sigma_phi_Fraction( unsigned long int Sigma_phi_Fraction ) { Sigma_phi_Fraction_ = Sigma_phi_Fraction; }
+    void set_Sigma_eta_Quotient( unsigned long int Sigma_eta_Quotient ) { Sigma_eta_Quotient_ = Sigma_eta_Quotient; }
+    void set_Sigma_eta_Fraction( unsigned long int Sigma_eta_Fraction ) { Sigma_eta_Fraction_ = Sigma_eta_Fraction; }
+    void set_Sigma_roz_Quotient( unsigned long int Sigma_roz_Quotient ) { Sigma_roz_Quotient_ = Sigma_roz_Quotient; }
+    void set_Sigma_roz_Fraction( unsigned long int Sigma_roz_Fraction ) { Sigma_roz_Fraction_ = Sigma_roz_Fraction; }
+    void set_FirstLayer( unsigned long int FirstLayer ) { FirstLayer_ = FirstLayer; }
+    void set_LastLayer( unsigned long int LastLayer ) { LastLayer_ = LastLayer; }
+    void set_ShowerLen( unsigned long int ShowerLen ) { ShowerLen_ = ShowerLen; }
+    void set_CoreShowerLen( unsigned long int CoreShowerLen ) { CoreShowerLen_ = CoreShowerLen; }
+    void set_E_EM_over_E_Quotient( unsigned long int E_EM_over_E_Quotient ) { E_EM_over_E_Quotient_ = E_EM_over_E_Quotient; }
+    void set_E_EM_over_E_Fraction( unsigned long int E_EM_over_E_Fraction ) { E_EM_over_E_Fraction_ = E_EM_over_E_Fraction; }
+    void set_E_EM_core_over_E_EM_Quotient( unsigned long int E_EM_core_over_E_EM_Quotient ) { E_EM_core_over_E_EM_Quotient_ = E_EM_core_over_E_EM_Quotient; }
+    void set_E_EM_core_over_E_EM_Fraction( unsigned long int E_EM_core_over_E_EM_Fraction ) { E_EM_core_over_E_EM_Fraction_ = E_EM_core_over_E_EM_Fraction; }
+    void set_E_H_early_over_E_Quotient( unsigned long int E_H_early_over_E_Quotient ) { E_H_early_over_E_Quotient_ = E_H_early_over_E_Quotient; }
+    void set_E_H_early_over_E_Fraction( unsigned long int E_H_early_over_E_Fraction ) { E_H_early_over_E_Fraction_ = E_H_early_over_E_Fraction; }
+
+
+
     // Getters
     unsigned int clock() const { return clock_; }
     unsigned int index() const { return index_; }
@@ -90,6 +155,35 @@ namespace l1thgcfirmware {
     unsigned long int layerbits() const { return layerbits_; }
     bool sat_tc() const { return sat_tc_; }
     unsigned int shapeq() const { return shapeq_; }
+
+    unsigned long int Sigma_E_Quotient()  const { return Sigma_E_Quotient_; }
+    unsigned long int Sigma_E_Fraction() const { return Sigma_E_Fraction_; }
+    unsigned long int Mean_z_Quotient() const { return Mean_z_Quotient_; }
+    unsigned long int Mean_z_Fraction() const { return Mean_z_Fraction_; }
+    unsigned long int Mean_phi_Quotient() const { return Mean_phi_Quotient_; }
+    unsigned long int Mean_phi_Fraction() const { return Mean_phi_Fraction_; }
+    unsigned long int Mean_eta_Quotient() const { return Mean_eta_Quotient_; }
+    unsigned long int Mean_eta_Fraction() const { return Mean_eta_Fraction_; }
+    unsigned long int Mean_roz_Quotient() const { return Mean_roz_Quotient_; }
+    unsigned long int Mean_roz_Fraction() const { return Mean_roz_Fraction_; }
+    unsigned long int Sigma_z_Quotient() const { return Sigma_z_Quotient_; }
+    unsigned long int Sigma_z_Fraction() const { return Sigma_z_Fraction_; }
+    unsigned long int Sigma_phi_Quotient() const { return Sigma_phi_Quotient_; }
+    unsigned long int Sigma_phi_Fraction() const { return Sigma_phi_Fraction_; }
+    unsigned long int Sigma_eta_Quotient() const { return Sigma_eta_Quotient_; }
+    unsigned long int Sigma_eta_Fraction() const { return Sigma_eta_Fraction_; }
+    unsigned long int Sigma_roz_Quotient() const { return Sigma_roz_Quotient_; }
+    unsigned long int Sigma_roz_Fraction() const { return Sigma_roz_Fraction_; }
+    unsigned long int FirstLayer() const { return FirstLayer_; }
+    unsigned long int LastLayer() const { return LastLayer_; }
+    unsigned long int ShowerLen() const { return ShowerLen_; }
+    unsigned long int CoreShowerLen() const { return CoreShowerLen_; }
+    unsigned long int E_EM_over_E_Quotient() const { return E_EM_over_E_Quotient_; }
+    unsigned long int E_EM_over_E_Fraction() const { return E_EM_over_E_Fraction_; }
+    unsigned long int E_EM_core_over_E_EM_Quotient() const { return E_EM_core_over_E_EM_Quotient_; }
+    unsigned long int E_EM_core_over_E_EM_Fraction() const { return E_EM_core_over_E_EM_Fraction_; }
+    unsigned long int E_H_early_over_E_Quotient() const { return E_H_early_over_E_Quotient_; }
+    unsigned long int E_H_early_over_E_Fraction() const { return E_H_early_over_E_Fraction_; }
 
     // Operators
     const HGCalCluster& operator+=(const HGCalCluster& hc);
@@ -120,7 +214,36 @@ namespace l1thgcfirmware {
     unsigned long int layerbits_;
     bool sat_tc_;
     unsigned int shapeq_;
+    unsigned long int Sigma_E_Quotient_;
+    unsigned long int Sigma_E_Fraction_;
+    unsigned long int Mean_z_Quotient_;
+    unsigned long int Mean_z_Fraction_;
+    unsigned long int Mean_phi_Quotient_;
+    unsigned long int Mean_phi_Fraction_;
+    unsigned long int Mean_eta_Quotient_;
+    unsigned long int Mean_eta_Fraction_;
+    unsigned long int Mean_roz_Quotient_;
+    unsigned long int Mean_roz_Fraction_;
+    unsigned long int Sigma_z_Quotient_;
+    unsigned long int Sigma_z_Fraction_;
+    unsigned long int Sigma_phi_Quotient_;
+    unsigned long int Sigma_phi_Fraction_;
+    unsigned long int Sigma_eta_Quotient_;
+    unsigned long int Sigma_eta_Fraction_;
+    unsigned long int Sigma_roz_Quotient_;
+    unsigned long int Sigma_roz_Fraction_;
+    unsigned long int FirstLayer_;
+    unsigned long int LastLayer_;
+    unsigned long int ShowerLen_;
+    unsigned long int CoreShowerLen_;
+    unsigned long int E_EM_over_E_Quotient_;
+    unsigned long int E_EM_over_E_Fraction_;
+    unsigned long int E_EM_core_over_E_EM_Quotient_;
+    unsigned long int E_EM_core_over_E_EM_Fraction_;
+    unsigned long int E_H_early_over_E_Quotient_;
+    unsigned long int E_H_early_over_E_Fraction_;
 
+ 
   };
 
   typedef std::vector<HGCalCluster> HGCalClusterSACollection;

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
@@ -52,16 +52,16 @@ namespace l1thgcfirmware {
     void set_e_h_early( unsigned int e_h_early ) { e_h_early_ = e_h_early; }
     void set_w( unsigned int w ) { w_ = w; }
     void set_n_tc_w( unsigned int n_tc_w ) { n_tc_w_ = n_tc_w; }
-    void set_w2( unsigned int w2 ) { w2_ = w2; }
+    void set_w2( unsigned long int w2 ) { w2_ = w2; }
     void set_wz( unsigned int wz ) { wz_ = wz; }
     void set_weta( unsigned int weta ) { weta_ = weta; }
     void set_wphi( unsigned int wphi ) { wphi_ = wphi; }
     void set_wroz( unsigned int wroz ) { wroz_ = wroz; }
-    void set_wz2( unsigned int wz2 ) { wz2_ = wz2; }
-    void set_weta2( unsigned int weta2 ) { weta2_ = weta2; }
-    void set_wphi2( unsigned int wphi2 ) { wphi2_ = wphi2; }
-    void set_wroz2( unsigned int wroz2 ) { wroz2_ = wroz2; }
-    void set_layerbits( unsigned int layerbits ) { layerbits_ = layerbits; }
+    void set_wz2( unsigned long int wz2 ) { wz2_ = wz2; }
+    void set_weta2( unsigned long int weta2 ) { weta2_ = weta2; }
+    void set_wphi2( unsigned long int wphi2 ) { wphi2_ = wphi2; }
+    void set_wroz2( unsigned long int wroz2 ) { wroz2_ = wroz2; }
+    void set_layerbits( unsigned long int layerbits ) { layerbits_ = layerbits; }
     void set_sat_tc( bool sat_tc ) { sat_tc_ = sat_tc; }
     void set_shapeq( unsigned int shapeq ) { shapeq_ = shapeq; }
 
@@ -78,16 +78,16 @@ namespace l1thgcfirmware {
     unsigned int e_h_early() const { return e_h_early_; }
     unsigned int w() const { return w_; }
     unsigned int n_tc_w() const { return n_tc_w_; }
-    unsigned int w2() const { return w2_; }
+    unsigned long int w2() const { return w2_; }
     unsigned int wz() const { return wz_; }
     unsigned int weta() const { return weta_; }
     unsigned int wphi() const { return wphi_; }
     unsigned int wroz() const { return wroz_; }
-    unsigned int wz2() const { return wz2_; }
-    unsigned int weta2() const { return weta2_; }
-    unsigned int wphi2() const { return wphi2_; }
-    unsigned int wroz2() const { return wroz2_; }
-    unsigned int layerbits() const { return layerbits_; }
+    unsigned long int wz2() const { return wz2_; }
+    unsigned long int weta2() const { return weta2_; }
+    unsigned long int wphi2() const { return wphi2_; }
+    unsigned long int wroz2() const { return wroz2_; }
+    unsigned long int layerbits() const { return layerbits_; }
     bool sat_tc() const { return sat_tc_; }
     unsigned int shapeq() const { return shapeq_; }
 
@@ -108,16 +108,16 @@ namespace l1thgcfirmware {
     unsigned int e_h_early_;
     unsigned int w_;
     unsigned int n_tc_w_;
-    unsigned int w2_;
+    unsigned long int w2_;
     unsigned int wz_;
     unsigned int weta_;
     unsigned int wphi_;
     unsigned int wroz_;
-    unsigned int wz2_;
-    unsigned int weta2_;
-    unsigned int wphi2_;
-    unsigned int wroz2_;
-    unsigned int layerbits_;
+    unsigned long int wz2_;
+    unsigned long int weta2_;
+    unsigned long int wphi2_;
+    unsigned long int wroz2_;
+    unsigned long int layerbits_;
     bool sat_tc_;
     unsigned int shapeq_;
 

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h
@@ -1,0 +1,124 @@
+#ifndef L1Trigger_L1THGCal_HGCalCluster_SA_h
+#define L1Trigger_L1THGCal_HGCalCluster_SA_h
+
+#include <vector>
+#include <memory>
+#include <iostream>
+namespace l1thgcfirmware {
+
+  class HGCalCluster {
+  public:
+    HGCalCluster( unsigned int clock,
+                  unsigned int index,
+                  bool frameValid,
+                  bool dataValid)
+                : clock_( clock ),
+                  index_(index),
+                  layerBits_(0),
+                  frameValid_(frameValid),
+                  dataValid_(dataValid),
+                  n_tc_(0),
+                  e_(0),
+                  e_em_(0),
+                  e_em_core_(0),
+                  e_h_early_(0),
+                  w_(0),
+                  n_tc_w_(0),
+                  w2_(0),
+                  wz_(0),
+                  weta_(0),
+                  wphi_(0),
+                  wroz_(0),
+                  wz2_(0),
+                  weta2_(0),
+                  wphi2_(0),
+                  wroz2_(0),
+                  layerbits_(0),
+                  sat_tc_(false),
+                  shapeq_(1)
+                  {}
+
+    ~HGCalCluster(){}
+
+    void setClock( const unsigned int clock ) { clock_ = clock; }
+    void setIndex( const unsigned int index ) { index_ = index; }
+
+    void set_n_tc( unsigned int n_tc ) { n_tc_ = n_tc; }
+    void set_e( unsigned int e ) { e_ = e; }
+    void set_e_em( unsigned int e_em ) { e_em_ = e_em; }
+    void set_e_em_core( unsigned int e_em_core ) { e_em_core_ = e_em_core; }
+    void set_e_h_early( unsigned int e_h_early ) { e_h_early_ = e_h_early; }
+    void set_w( unsigned int w ) { w_ = w; }
+    void set_n_tc_w( unsigned int n_tc_w ) { n_tc_w_ = n_tc_w; }
+    void set_w2( unsigned int w2 ) { w2_ = w2; }
+    void set_wz( unsigned int wz ) { wz_ = wz; }
+    void set_weta( unsigned int weta ) { weta_ = weta; }
+    void set_wphi( unsigned int wphi ) { wphi_ = wphi; }
+    void set_wroz( unsigned int wroz ) { wroz_ = wroz; }
+    void set_wz2( unsigned int wz2 ) { wz2_ = wz2; }
+    void set_weta2( unsigned int weta2 ) { weta2_ = weta2; }
+    void set_wphi2( unsigned int wphi2 ) { wphi2_ = wphi2; }
+    void set_wroz2( unsigned int wroz2 ) { wroz2_ = wroz2; }
+    void set_layerbits( unsigned int layerbits ) { layerbits_ = layerbits; }
+    void set_sat_tc( bool sat_tc ) { sat_tc_ = sat_tc; }
+    void set_shapeq( unsigned int shapeq ) { shapeq_ = shapeq; }
+
+    unsigned int clock() const { return clock_; }
+    unsigned int index() const { return index_; }
+    bool frameValid() const { return frameValid_; }
+    bool dataValid() const { return dataValid_; }
+
+    unsigned int n_tc() const { return n_tc_; }
+    unsigned int e() const { return e_; }
+    unsigned int e_em() const { return e_em_; }
+    unsigned int e_em_core() const { return e_em_core_; }
+    unsigned int e_h_early() const { return e_h_early_; }
+    unsigned int w() const { return w_; }
+    unsigned int n_tc_w() const { return n_tc_w_; }
+    unsigned int w2() const { return w2_; }
+    unsigned int wz() const { return wz_; }
+    unsigned int weta() const { return weta_; }
+    unsigned int wphi() const { return wphi_; }
+    unsigned int wroz() const { return wroz_; }
+    unsigned int wz2() const { return wz2_; }
+    unsigned int weta2() const { return weta2_; }
+    unsigned int wphi2() const { return wphi2_; }
+    unsigned int wroz2() const { return wroz2_; }
+    unsigned int layerbits() const { return layerbits_; }
+    bool sat_tc() const { return sat_tc_; }
+    unsigned int shapeq() const { return shapeq_; }
+
+  private:
+    unsigned int clock_;
+    unsigned int index_;
+    unsigned int layerBits_;
+    bool frameValid_;
+    bool dataValid_;
+
+    unsigned int n_tc_;
+    unsigned int e_;
+    unsigned int e_em_;
+    unsigned int e_em_core_;
+    unsigned int e_h_early_;
+    unsigned int w_;
+    unsigned int n_tc_w_;
+    unsigned int w2_;
+    unsigned int wz_;
+    unsigned int weta_;
+    unsigned int wphi_;
+    unsigned int wroz_;
+    unsigned int wz2_;
+    unsigned int weta2_;
+    unsigned int wphi2_;
+    unsigned int wroz2_;
+    unsigned int layerbits_;
+    bool sat_tc_;
+    unsigned int shapeq_;
+
+  };
+
+  typedef std::vector<HGCalCluster> HGCalClusterSACollection;
+  typedef std::vector<std::shared_ptr<HGCalCluster> > HGCalClusterSAPtrCollection;
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHisotgramCell_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHisotgramCell_SA.h
@@ -1,0 +1,90 @@
+#ifndef L1Trigger_L1THGCal_HGCalHistogramCell_SA_h
+#define L1Trigger_L1THGCal_HGCalHistogramCell_SA_h
+
+#include <vector>
+#include <memory>
+#include <iostream>
+namespace l1thgcfirmware {
+
+class HGCalHistogramCell {
+  public:
+    HGCalHistogramCell( unsigned int clock,
+                        unsigned int index,
+                        unsigned int S,
+                        unsigned int X,
+                        unsigned int Y,
+                        unsigned int N,
+                        unsigned int sortKey )
+                        : clock_(clock),
+                          index_(index),
+                          S_(S),
+                          X_(X),
+                          Y_(Y),
+                          N_(N),
+                          sortKey_(sortKey),
+                          frameValid_(true),
+                          dataValid_(true) {}
+
+    HGCalHistogramCell() : clock_(0),
+                           index_(0),
+                           S_(0),
+                           X_(0),
+                           Y_(0),
+                           N_(0),
+                           sortKey_(0),
+                           frameValid_(false),
+                           dataValid_(false) {}
+
+    HGCalHistogramCell( unsigned int clock,
+                        unsigned int index,
+                        unsigned int sortKey )
+                        : HGCalHistogramCell ( 4*sortKey + clock, index, 0, 0, 0, 0, sortKey) {}
+
+    ~HGCalHistogramCell(){}
+
+    // Setters
+    void setClock( const unsigned int clock ) { clock_ = clock; }
+    void addLatency( const unsigned int latency ) { clock_ += latency; }
+    void setIndex( const unsigned int index ) { index_ = index; }
+    void setSortKey( const unsigned int sortKey ) { sortKey_ = sortKey; }
+    void setS( const unsigned int S ) { S_ = S; }
+    void setX( const unsigned int X ) { X_ = X; }
+    void setY( const unsigned int Y ) { Y_ = Y; }
+    void setN( const unsigned int N ) { N_ = N; }
+
+    // Getters
+    unsigned int clock() const { return clock_; }
+    unsigned int index() const { return index_; }
+    unsigned int S() const { return S_; }
+    unsigned int X() const { return X_; }
+    unsigned int Y() const { return Y_; }
+    unsigned int N() const { return N_; }
+    unsigned int sortKey() const { return sortKey_; }
+    bool frameValid() const { return frameValid_; }
+    bool dataValid() const { return dataValid_; }
+
+    // Operators
+    const HGCalHistogramCell& operator+=(const HGCalHistogramCell& hc);
+    const HGCalHistogramCell operator/(const unsigned int factor) const;
+    const HGCalHistogramCell operator+(const HGCalHistogramCell& hc) const;
+    const HGCalHistogramCell& operator*=(const unsigned int factor);
+
+
+  private:
+    unsigned int clock_;
+    unsigned int index_;
+    unsigned int S_;
+    unsigned int X_;
+    unsigned int Y_;
+    unsigned int N_;
+    unsigned int sortKey_;
+    bool frameValid_;
+    bool dataValid_;
+
+  };
+
+  typedef std::vector<HGCalHistogramCell> HGCalHistogramCellSACollection;
+  typedef std::vector<std::shared_ptr<HGCalHistogramCell>> HGCalHistogramCellSAPtrCollection;
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
@@ -33,6 +33,12 @@ namespace l1thgcfirmware {
 
     void setParameters() {}
 
+    void setSector( const unsigned int sector ) { sector_ = sector; }
+    unsigned int sector() const { return sector_; }
+
+    void setZSide( const int zSide ) { zSide_ = zSide; }
+    int zSide() const { return zSide_; }
+
     unsigned int getStepLatency( const Step step ) const { return stepLatency_.at(step); }
     unsigned int getLatencyUpToAndIncluding( const Step step );
     unsigned int clusterizerOffset() const { return clusterizerOffset_; }
@@ -89,6 +95,9 @@ namespace l1thgcfirmware {
     std::vector<unsigned int> layerWeights_E_H_early_;
     unsigned int correction_;
     unsigned int saturation_;
+
+    unsigned int sector_;
+    int zSide_;
 
   };
 

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
@@ -39,32 +39,120 @@ namespace l1thgcfirmware {
     void setZSide( const int zSide ) { zSide_ = zSide; }
     int zSide() const { return zSide_; }
 
+    void setStepLatencies( const std::vector<unsigned int> latencies );
     unsigned int getStepLatency( const Step step ) const { return stepLatency_.at(step); }
     unsigned int getLatencyUpToAndIncluding( const Step step );
+
+    void setClusterizerOffset( const unsigned clusterizerOffset ) { clusterizerOffset_ = clusterizerOffset ;}
     unsigned int clusterizerOffset() const { return clusterizerOffset_; }
+
+    void setCClocks( const unsigned cClocks ) { cClocks_ = cClocks;}
     unsigned int cClocks() const { return cClocks_; }
+
+    void setCInputs( const unsigned cInputs ) { cInputs_ = cInputs;}
     unsigned int cInputs() const { return cInputs_; }
+
+    void setCInputs2( const unsigned cInputs2 ) { cInputs2_ = cInputs2;}
     unsigned int cInputs2() const { return cInputs2_; }
+
+    void setCInt( const unsigned cInt ) { cInt_ = cInt;}
     unsigned int cInt() const { return cInt_; }
+
+    void setCColumns( const unsigned cColumns ) { cColumns_ = cColumns;}
     unsigned int cColumns() const { return cColumns_; }
+
+    void setCRows( const unsigned cRows ) { cRows_ = cRows;}
     unsigned int cRows() const { return cRows_; }
+
+    void setROverZHistOffset( const unsigned rOverZHistOffset ) { rOverZHistOffset_ = rOverZHistOffset;}
+    unsigned int rOverZHistOffset() const { return rOverZHistOffset_; }
+
+    void setROverZBinSize( const unsigned rOverZBinSize ) { rOverZBinSize_ = rOverZBinSize;}
+    unsigned int rOverZBinSize() const { return rOverZBinSize_; }
+
     unsigned int kernelWidth( unsigned int iBin ) const { return kernelWidths_.at(iBin); }
     unsigned int areaNormalization( unsigned int iBin ) const { return areaNormalizations_.at(iBin); }
+    
+    void setROverZRange( const float rOverZRange ) { rOverZRange_ = rOverZRange_; }
+    unsigned int rOverZRange() const { return rOverZRange_; }
+    void setROverZNValues( const float rOverZNValues ) { rOverZNValues_ = rOverZNValues_; }
+    unsigned int rOverZNValues() const { return rOverZNValues_; }
+    void setPhiRange( const float phiRange ) { phiRange_ = phiRange_; }
+    unsigned int phiRange() const { return phiRange_; }
+    void setPhiNValues( const float phiNValues ) { phiNValues_ = phiNValues_; }
+    unsigned int phiNValues() const { return phiNValues_; }
+
+    void setThresholdParams( const unsigned int a, const unsigned int b, const int c ) { 
+      thresholdMaximaParam_a_ = a;
+      thresholdMaximaParam_b_ = b;
+      thresholdMaximaParam_c_ = c;
+    }
     unsigned int thresholdMaxima( unsigned int iBin ) const { return thresholdMaximaConstants_.at(iBin); }
+
+    void setNBinsCosLUT( const unsigned int nBinsCosLUT ) { nBinsCosLUT_ = nBinsCosLUT; }
+    unsigned int nBinsCosLUT() const { return nBinsCosLUT_; }
+
     unsigned int cosLUT( unsigned int iBin ) const { return cosLUT_.at(iBin); }
+
+    void setClusterizerMagicTime( const unsigned clusterizerMagicTime ) { clusterizerMagicTime_ = clusterizerMagicTime;}
     unsigned int clusterizerMagicTime() const { return clusterizerMagicTime_; }
+
+    void setDepths( const std::vector<unsigned int> depths ) {
+      depths_.clear();
+      for ( const auto& depth : depths ) depths_.push_back( depth );
+    }
+    std::vector<unsigned int> depths() const { return depths_; }
     unsigned int depth( unsigned int iLayer ) const { return depths_.at(iLayer); }
+
+    void setTriggerLayers( const std::vector<unsigned int> triggerLayers ) {
+      triggerLayers_.clear();
+      for ( const auto& triggerLayer : triggerLayers ) triggerLayers_.push_back( triggerLayer );
+    }
+    std::vector<unsigned int> triggerLayers() const { return triggerLayers_; }
     unsigned int triggerLayer( unsigned int iLayer ) const { return triggerLayers_.at(iLayer); }
+    
+    void setLayerWeights_E( const std::vector<unsigned int> layerWeights_E ) {
+      layerWeights_E_.clear();
+      for ( const auto& weight : layerWeights_E ) layerWeights_E_.push_back( weight );
+    }
+    std::vector<unsigned int> layerWeights_E() const { return layerWeights_E_; }
     unsigned int layerWeight_E( unsigned int iTriggerLayer ) const { return layerWeights_E_.at(iTriggerLayer); }
+
+    void setLayerWeights_E_EM( const std::vector<unsigned int> layerWeights_E_EM ) {
+      layerWeights_E_EM_.clear();
+      for ( const auto& weight : layerWeights_E_EM ) layerWeights_E_EM_.push_back( weight );
+    }
+    std::vector<unsigned int> layerWeights_E_EM() const { return layerWeights_E_EM_; }
     unsigned int layerWeight_E_EM( unsigned int iTriggerLayer ) const { return layerWeights_E_EM_.at(iTriggerLayer); }
+    
+    void setLayerWeights_E_EM_core( const std::vector<unsigned int> layerWeights_E_EM_core ) {
+      layerWeights_E_EM_core_.clear();
+      for ( const auto& weight : layerWeights_E_EM_core ) layerWeights_E_EM_core_.push_back( weight );
+    }
+    std::vector<unsigned int> layerWeights_E_EM_core() const { return layerWeights_E_EM_core_; }
     unsigned int layerWeight_E_EM_core( unsigned int iTriggerLayer ) const { return layerWeights_E_EM_core_.at(iTriggerLayer); }
+
+
+    void setLayerWeights_E_H_early( const std::vector<unsigned int> layerWeights_E_H_early ) {
+      layerWeights_E_H_early_.clear();
+      for ( const auto& weight : layerWeights_E_H_early ) layerWeights_E_H_early_.push_back( weight );
+    }
+    std::vector<unsigned int> layerWeights_E_H_early() const { return layerWeights_E_H_early_; }
     unsigned int layerWeight_E_H_early( unsigned int iTriggerLayer ) const { return layerWeights_E_H_early_.at(iTriggerLayer); }
+
+    void setCorrection( const unsigned correction ) { correction_ = correction;}
     unsigned int correction() const { return correction_; }
+
+    void setSaturation( const unsigned saturation ) { saturation_ = saturation;}
     unsigned int saturation() const { return saturation_; }
+
+    void initializeLUTs();
+
+    void printConfiguration(); // For debugging
 
   private:
     void initializeSmearingKernelConstants( unsigned int bins, unsigned int offset, unsigned int height );
-    void initializeThresholdMaximaConstants( unsigned int bins );
+    void initializeThresholdMaximaConstants( unsigned int bins, unsigned int a, unsigned int b, int c );
     void initializeCosLUT();
 
     unsigned int histogramOffset_;
@@ -75,11 +163,23 @@ namespace l1thgcfirmware {
     unsigned int cInt_;
     unsigned int cColumns_;
     unsigned int cRows_;
+    unsigned int rOverZHistOffset_;
+    unsigned int rOverZBinSize_;
+
+    float rOverZRange_;
+    float rOverZNValues_;
+    float phiRange_;
+    float phiNValues_;
 
     std::vector<unsigned int> kernelWidths_;
     std::vector<unsigned int> areaNormalizations_;
+
+    unsigned int thresholdMaximaParam_a_;
+    unsigned int thresholdMaximaParam_b_;
+    int thresholdMaximaParam_c_;
     std::vector<int> thresholdMaximaConstants_;
 
+    unsigned int nBinsCosLUT_;
     std::vector<unsigned int> cosLUT_;
 
     unsigned int clusterizerMagicTime_;

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h
@@ -1,0 +1,97 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+
+#include <map>
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  enum Step { Uninitialized = -1, 
+              Input = 0,
+              Dist0 = 1,
+              Dist1 = 2,
+              Dist2 = 3,
+              Dist3 = 4,
+              Dist4 = 5,
+              Dist5 = 6,
+              TcToHc = 7,
+              Hist = 8,
+              Smearing1D = 9,
+              NormArea = 10,
+              Smearing2D = 11,
+              Maxima1D = 12, // Not actually used currently
+              Maxima2D = 13,
+              CalcAverage = 14,
+              Clusterizer = 15,
+              TriggerCellToCluster = 16,
+              ClusterSum = 17
+            };
+
+  class ClusterAlgoConfig {
+  public:
+    ClusterAlgoConfig();
+
+    void setParameters() {}
+
+    unsigned int getStepLatency( const Step step ) const { return stepLatency_.at(step); }
+    unsigned int getLatencyUpToAndIncluding( const Step step );
+    unsigned int clusterizerOffset() const { return clusterizerOffset_; }
+    unsigned int cClocks() const { return cClocks_; }
+    unsigned int cInputs() const { return cInputs_; }
+    unsigned int cInputs2() const { return cInputs2_; }
+    unsigned int cInt() const { return cInt_; }
+    unsigned int cColumns() const { return cColumns_; }
+    unsigned int cRows() const { return cRows_; }
+    unsigned int kernelWidth( unsigned int iBin ) const { return kernelWidths_.at(iBin); }
+    unsigned int areaNormalization( unsigned int iBin ) const { return areaNormalizations_.at(iBin); }
+    unsigned int thresholdMaxima( unsigned int iBin ) const { return thresholdMaximaConstants_.at(iBin); }
+    unsigned int cosLUT( unsigned int iBin ) const { return cosLUT_.at(iBin); }
+    unsigned int clusterizerMagicTime() const { return clusterizerMagicTime_; }
+    unsigned int depth( unsigned int iLayer ) const { return depths_.at(iLayer); }
+    unsigned int triggerLayer( unsigned int iLayer ) const { return triggerLayers_.at(iLayer); }
+    unsigned int layerWeight_E( unsigned int iTriggerLayer ) const { return layerWeights_E_.at(iTriggerLayer); }
+    unsigned int layerWeight_E_EM( unsigned int iTriggerLayer ) const { return layerWeights_E_EM_.at(iTriggerLayer); }
+    unsigned int layerWeight_E_EM_core( unsigned int iTriggerLayer ) const { return layerWeights_E_EM_core_.at(iTriggerLayer); }
+    unsigned int layerWeight_E_H_early( unsigned int iTriggerLayer ) const { return layerWeights_E_H_early_.at(iTriggerLayer); }
+    unsigned int correction() const { return correction_; }
+    unsigned int saturation() const { return saturation_; }
+
+  private:
+    void initializeSmearingKernelConstants( unsigned int bins, unsigned int offset, unsigned int height );
+    void initializeThresholdMaximaConstants( unsigned int bins );
+    void initializeCosLUT();
+
+    unsigned int histogramOffset_;
+    unsigned int clusterizerOffset_;
+    unsigned int cClocks_;
+    unsigned int cInputs_;
+    unsigned int cInputs2_; // Better name for variable?
+    unsigned int cInt_;
+    unsigned int cColumns_;
+    unsigned int cRows_;
+
+    std::vector<unsigned int> kernelWidths_;
+    std::vector<unsigned int> areaNormalizations_;
+    std::vector<int> thresholdMaximaConstants_;
+
+    std::vector<unsigned int> cosLUT_;
+
+    unsigned int clusterizerMagicTime_;
+
+    std::map<Step,unsigned int> stepLatency_;
+
+    // Parameters for triggerCellToCluster
+    std::vector<unsigned int> depths_;
+    std::vector<unsigned int> triggerLayers_;
+    std::vector<unsigned int> layerWeights_E_;
+    std::vector<unsigned int> layerWeights_E_EM_;
+    std::vector<unsigned int> layerWeights_E_EM_core_;
+    std::vector<unsigned int> layerWeights_E_H_early_;
+    unsigned int correction_;
+    unsigned int saturation_;
+
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
@@ -51,6 +51,13 @@ private:
   // Cluster properties
   l1thgcfirmware::HGCalClusterSAPtrCollection triggerCellToCluster( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTriggerCells ) const;
   void clusterSum( l1thgcfirmware::HGCalClusterSAPtrCollection& protoClusters, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags, l1thgcfirmware::HGCalClusterSAPtrCollection& clusterAccumulation, l1thgcfirmware::HGCalClusterSAPtrCollection& clusterSums ) const;
+  std::pair< unsigned int, unsigned int > sigma_Energy(unsigned int N_TC_W, unsigned long int Sum_W2, unsigned int Sum_W) const;
+  std::pair< unsigned int, unsigned int > mean_coordinate(unsigned int Sum_Wc, unsigned int Sum_W) const;
+  std::pair< unsigned int, unsigned int > sigma_Coordinate(unsigned int Sum_W, unsigned long int Sum_Wc2, unsigned int Sum_Wc) const;
+  std::pair< unsigned int, unsigned int > energy_ratio(unsigned int E_N, unsigned int E_D) const;
+  std::vector<int> showerLengthProperties(unsigned long int layerBits) const;
+  void clusterProperties(l1thgcfirmware::HGCalClusterSAPtrCollection& clusterSums) const;
+
 
   // Useful functions
   void initializeTriggerCellDistGrid( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const;

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
@@ -46,7 +46,10 @@ private:
   // Clustering
   // l1thgcfirmware::DOICollection domainOfInfluence( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
   void clusterizer( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn, l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTriggerCells, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& unclusteredTriggerCells, l1thgcfirmware::CentroidHelperPtrCollection& prioritizedMaxima, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags ) const;
+
+  // Cluster properties
   l1thgcfirmware::HGCalClusterSAPtrCollection triggerCellToCluster( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTriggerCells ) const;
+  void clusterSum( l1thgcfirmware::HGCalClusterSAPtrCollection& protoClusters, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags, l1thgcfirmware::HGCalClusterSAPtrCollection& clusterAccumulation, l1thgcfirmware::HGCalClusterSAPtrCollection& clusterSums ) const;
 
   // Useful functions
   void initializeTriggerCellDistGrid( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const;

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
@@ -16,7 +16,8 @@ public:
   HGCalHistoClusteringImplSA(l1thgcfirmware::ClusterAlgoConfig& config);
   ~HGCalHistoClusteringImplSA() {}
 
-  void runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags ) const;
+  void runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags,
+  HGCalClusterSAPtrCollection& clusterSums ) const;
 
 private:
   // TC input step

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h
@@ -1,0 +1,69 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistogramCell_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/CentroidHelper.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h"
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+class HGCalHistoClusteringImplSA {
+public:
+  HGCalHistoClusteringImplSA(l1thgcfirmware::ClusterAlgoConfig& config);
+  ~HGCalHistoClusteringImplSA() {}
+
+  void runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags ) const;
+
+private:
+  // TC input step
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollection triggerCellInput( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& inputs ) const;
+
+  // TC distribution steps
+  void triggerCellDistribution0( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const;
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollections triggerCellDistribution1( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const;
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollections triggerCellDistribution2( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn, l1thgcfirmware::HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const;
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollections triggerCellDistribution3( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn, l1thgcfirmware::HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const;
+  void triggerCellDistribution4( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const;
+  void triggerCellDistribution5( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn, l1thgcfirmware::HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const;
+
+  // Histogram steps
+  l1thgcfirmware::HGCalHistogramCellSAPtrCollection triggerCellToHistogramCell( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const;
+  l1thgcfirmware::HGCalHistogramCellSAPtrCollection makeHistogram( l1thgcfirmware::HGCalHistogramCellSAPtrCollection histogramCells ) const;
+
+  // Smearing steps
+  void smearing1D( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+  void areaNormalization( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+  void smearing2D( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+
+  // Maxima finding
+  void thresholdMaximaFinder( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+  void calculateAveragePosition( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+
+  // Clustering
+  // l1thgcfirmware::DOICollection domainOfInfluence( l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram ) const;
+  void clusterizer( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& triggerCellsIn, l1thgcfirmware::HGCalHistogramCellSAPtrCollection& histogram, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTriggerCells, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& unclusteredTriggerCells, l1thgcfirmware::CentroidHelperPtrCollection& prioritizedMaxima, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags ) const;
+  l1thgcfirmware::HGCalClusterSAPtrCollection triggerCellToCluster( l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTriggerCells ) const;
+
+  // Useful functions
+  void initializeTriggerCellDistGrid( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const;
+
+  void runDistServers( const l1thgcfirmware::HGCalTriggerCellSAPtrCollections& gridIn,
+                       l1thgcfirmware::HGCalTriggerCellSAPtrCollections& gridOut,
+                       l1thgcfirmware::HGCalTriggerCellSAPtrCollection& tcsOut,
+                       unsigned int latency,
+                       unsigned int nDistServers,
+                       unsigned int nInputs,
+                       unsigned int nOutputs,
+                       unsigned int nInterleave,
+                      bool setOutputGrid ) const;
+
+  l1thgcfirmware::ClusterAlgoConfig& config_;
+};
+
+}
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistogramCell_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistogramCell_SA.h
@@ -1,0 +1,91 @@
+#ifndef L1Trigger_L1THGCal_HGCalHistogramCell_SA_h
+#define L1Trigger_L1THGCal_HGCalHistogramCell_SA_h
+
+#include <vector>
+#include <memory>
+#include <iostream>
+namespace l1thgcfirmware {
+
+class HGCalHistogramCell {
+  public:
+    HGCalHistogramCell( unsigned int clock,
+                        unsigned int index,
+                        unsigned int S,
+                        unsigned int X,
+                        unsigned int Y,
+                        unsigned int N,
+                        unsigned int sortKey )
+                        : clock_(clock),
+                          index_(index),
+                          S_(S),
+                          X_(X),
+                          Y_(Y),
+                          N_(N),
+                          sortKey_(sortKey),
+                          frameValid_(true),
+                          dataValid_(true) {}
+
+    HGCalHistogramCell() : clock_(0),
+                           index_(0),
+                           S_(0),
+                           X_(0),
+                           Y_(0),
+                           N_(0),
+                           sortKey_(0),
+                           frameValid_(false),
+                           dataValid_(false) {}
+
+    HGCalHistogramCell( unsigned int clock,
+                        unsigned int index,
+                        unsigned int sortKey )
+                        : HGCalHistogramCell ( 4*sortKey + clock, index, 0, 0, 0, 0, sortKey) {}
+
+    ~HGCalHistogramCell(){}
+
+    // Setters
+    void setClock( const unsigned int clock ) { clock_ = clock; }
+    void addLatency( const unsigned int latency ) { clock_ += latency; }
+    void setIndex( const unsigned int index ) { index_ = index; }
+    void setSortKey( const unsigned int sortKey ) { sortKey_ = sortKey; }
+    void setS( const unsigned int S ) { S_ = S; }
+    void setX( const unsigned int X ) { X_ = X; }
+    void setY( const unsigned int Y ) { Y_ = Y; }
+    void setN( const unsigned int N ) { N_ = N; }
+
+    // Getters
+    unsigned int clock() const { return clock_; }
+    unsigned int index() const { return index_; }
+    unsigned int S() const { return S_; }
+    unsigned int X() const { return X_; }
+    unsigned int Y() const { return Y_; }
+    unsigned int N() const { return N_; }
+    unsigned int sortKey() const { return sortKey_; }
+    bool frameValid() const { return frameValid_; }
+    bool dataValid() const { return dataValid_; }
+
+    // Operators
+    const HGCalHistogramCell& operator+=(const HGCalHistogramCell& hc);
+    const HGCalHistogramCell operator/(const unsigned int factor) const;
+    const HGCalHistogramCell operator+(const HGCalHistogramCell& hc) const;
+    const HGCalHistogramCell& operator*=(const unsigned int factor);
+
+
+  private:
+    unsigned int clock_;
+    unsigned int index_;
+    unsigned int S_;
+    unsigned int X_;
+    unsigned int Y_;
+    unsigned int N_;
+    unsigned int sortKey_;
+    bool frameValid_;
+    bool dataValid_;
+
+  };
+
+  typedef std::vector<HGCalHistogramCell> HGCalHistogramCellSACollection;
+  typedef std::vector<std::shared_ptr<HGCalHistogramCell>> HGCalHistogramCellSAPtrCollection;
+}  // namespace l1thgcfirmware
+
+#endif
+

--- a/L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h
@@ -1,0 +1,83 @@
+#ifndef L1Trigger_L1THGCal_HGCalTriggerCell_SA_h
+#define L1Trigger_L1THGCal_HGCalTriggerCell_SA_h
+
+#include <vector>
+#include <memory>
+#include <iostream>
+namespace l1thgcfirmware {
+
+  class HGCalTriggerCell {
+  public:
+    HGCalTriggerCell() : HGCalTriggerCell(false, false, 0, 0, 0, 0) {}
+    HGCalTriggerCell(bool frameValid,
+                 bool dataValid,
+                 unsigned int rOverZ,
+                 unsigned int phi,
+                 unsigned int layer,
+                 unsigned int energy)
+        : clock_(0),
+          index_(0),
+          rOverZ_(rOverZ),
+          layer_(layer),
+          energy_(energy),
+          phi_(phi),
+          sortKey_(0),
+          deltaR2_(0),
+          dX_(0),
+          Y_(0),
+          frameValid_(frameValid),
+          dataValid_(dataValid) {}
+
+    ~HGCalTriggerCell(){}
+
+    // Setters
+    void setClock( const unsigned int clock ) { clock_ = clock; }
+    void addLatency( const unsigned int latency ) { clock_ += latency; }
+    void setIndex( const unsigned int index ) { index_ = index; }
+    void setSortKey( const unsigned int sortKey ) { sortKey_ = sortKey; }
+    void setDX( const int dX ) { dX_ = dX; }
+    void setY( const unsigned int Y ) { Y_ = Y; }
+    void setDeltaR2( const unsigned int deltaR2 ) { deltaR2_ = deltaR2; }
+
+    // Getters
+    unsigned int clock() const { return clock_; }
+    unsigned int index() const { return index_; }
+    unsigned int rOverZ() const { return rOverZ_; }
+    unsigned int layer() const { return layer_; }
+    unsigned int energy() const { return energy_; }
+    unsigned int phi() const { return phi_; }
+    unsigned int sortKey() const { return sortKey_; }
+    unsigned int deltaR2() const { return deltaR2_; }
+    int dX() const { return dX_; }
+    unsigned int Y() const { return Y_; }
+    bool frameValid() const { return frameValid_; }
+    bool dataValid() const { return dataValid_; }
+
+    // Operators
+    bool operator==(const HGCalTriggerCell& rhs) const;
+    bool operator==(const std::shared_ptr<HGCalTriggerCell>& rhs) const;
+
+  private:
+    unsigned int clock_;
+    unsigned int index_;
+    unsigned int rOverZ_;
+    unsigned int layer_;
+    unsigned int energy_;
+    unsigned int phi_;
+    unsigned int sortKey_;
+    unsigned int deltaR2_;
+    int dX_;
+    unsigned int Y_;
+    bool frameValid_;
+    bool dataValid_;
+
+  };
+
+  typedef std::vector<HGCalTriggerCell> HGCalTriggerCellSACollection;
+  typedef std::shared_ptr<HGCalTriggerCell> HGCalTriggerCellSAPtr;
+  typedef std::vector<HGCalTriggerCellSAPtr> HGCalTriggerCellSAPtrCollection;
+  typedef std::vector< std::vector<std::shared_ptr<HGCalTriggerCell> > > HGCalTriggerCellSAPtrCollections;
+  typedef std::vector< std::vector< std::vector<std::shared_ptr<HGCalTriggerCell> > > > HGCalTriggerCellSAPtrCollectionss;
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
@@ -73,7 +73,7 @@ public:
         unsigned sector60 = 999;
         if ( !isDuplicatedRegion ) sector60 = 1;
         else if ( stage2_fpga_id.zside() == 1 ) {
-          sector60 = ( stage2_sector == stage1_sector ) ? 2 : 0;
+          sector60 = ( stage2_sector == stage1_sector ) ? 0 : 2;
         }
         else {
           sector60 = ( stage2_sector == stage1_sector ) ? 0 : 2;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
@@ -215,6 +215,32 @@ void HGCalHistoClusteringWrapper::configure(
 
   theConfiguration_.setSector( std::get<2>(configuration) );
   theConfiguration_.setZSide( std::get<3>(configuration) );
+
+  const edm::ParameterSet pset = std::get<1>(configuration).getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_clustering_parameters").getParameterSet("layer2FwClusteringParameters");
+
+  theConfiguration_.setClusterizerOffset( pset.getParameter<unsigned int>("clusterizerOffset"));
+  theConfiguration_.setStepLatencies( pset.getParameter<std::vector<unsigned int>>("stepLatencies"));
+  theConfiguration_.setCClocks( pset.getParameter<unsigned int>("cClocks") );
+  theConfiguration_.setCInputs( pset.getParameter<unsigned int>("cInputs") );
+  theConfiguration_.setCInputs2( pset.getParameter<unsigned int>("cInputs2") );
+  theConfiguration_.setCInt( pset.getParameter<unsigned int>("cInt") );
+  theConfiguration_.setCColumns( pset.getParameter<unsigned int>("cColumns") );
+  theConfiguration_.setCRows( pset.getParameter<unsigned int>("cRows") );
+  theConfiguration_.setROverZHistOffset( pset.getParameter<unsigned int>("rOverZHistOffset") );
+  theConfiguration_.setROverZBinSize( pset.getParameter<unsigned int>("rOverZBinSize") );
+  theConfiguration_.setClusterizerMagicTime( pset.getParameter<unsigned int>("clusterizerMagicTime") );
+  theConfiguration_.setNBinsCosLUT( pset.getParameter<unsigned int>("nBinsCosLUT") );
+  theConfiguration_.setDepths( pset.getParameter<std::vector<unsigned int>>("depths"));
+  theConfiguration_.setTriggerLayers( pset.getParameter<std::vector<unsigned int>>("triggerLayers"));
+  theConfiguration_.setLayerWeights_E( pset.getParameter<std::vector<unsigned int>>("layerWeights_E"));
+  theConfiguration_.setLayerWeights_E_EM( pset.getParameter<std::vector<unsigned int>>("layerWeights_E_EM"));
+  theConfiguration_.setLayerWeights_E_EM_core( pset.getParameter<std::vector<unsigned int>>("layerWeights_E_EM_core"));
+  theConfiguration_.setLayerWeights_E_H_early( pset.getParameter<std::vector<unsigned int>>("layerWeights_E_H_early"));
+  theConfiguration_.setCorrection( pset.getParameter<unsigned int>("correction") );
+  theConfiguration_.setSaturation( pset.getParameter<unsigned int>("saturation") );
+  const edm::ParameterSet thresholdParams = pset.getParameterSet("thresholdMaximaParams");
+  theConfiguration_.setThresholdParams( thresholdParams.getParameter<unsigned int>("a"), thresholdParams.getParameter<unsigned int>("b"), thresholdParams.getParameter<int>("c") );
+  theConfiguration_.initializeLUTs();
 };
 
 DEFINE_EDM_PLUGIN(HGCalHistoClusteringWrapperBaseFactory, HGCalHistoClusteringWrapper, "HGCalHistoClusteringWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
@@ -1,17 +1,19 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
-#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h"
 
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 
-#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
-#include "L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h"
-#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
@@ -22,147 +24,115 @@ public:
 
   void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
 
-  void process(const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>,
-                               const std::vector<std::pair<GlobalPoint, double>>>& inputClustersAndSeeds,
+  void process(const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>& inputClusters,
                std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
                    outputMulticlustersAndRejectedClusters) const override;
 
 private:
-  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-                          l1thgcfirmware::HGCalClusterSACollection& clusters_SA,
-                          const std::vector<std::pair<GlobalPoint, double>>& seeds,
-                          l1thgcfirmware::HGCalSeedSACollection& seeds_SA) const;
-  void convertAlgorithmOutputs(const l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_out,
-                               const l1thgcfirmware::HGCalClusterSACollection& rejected_clusters_out,
-                               const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-                               l1t::HGCalMulticlusterBxCollection& multiclusters,
-                               l1t::HGCalClusterBxCollection& rejected_clusters) const;
+  void convertCMSSWInputs(const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>& clustersPtrs,
+                          l1thgcfirmware::HGCalTriggerCellSAPtrCollections& clusters_SA) const;
+  void convertAlgorithmOutputs() const {}
 
-  void clusterizeHisto(const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
-                       const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
-                       l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
-                       l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const;
+  void clusterizeHisto( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& triggerCells_in_SA, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTCs, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& unclusteredTCs, l1thgcfirmware::CentroidHelperPtrCollection& prioritizedMaxima, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags ) const;
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es);
+                                               es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+                                             }
 
   HGCalTriggerTools triggerTools_;
 
-  HGCalHistoClusteringImplSA theAlgo_;
-
   l1thgcfirmware::ClusterAlgoConfig theConfiguration_;
 
-  static constexpr double kMidRadius_ = 2.3;
+  l1thgcfirmware::HGCalHistoClusteringImplSA theAlgo_;
+
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 };
 
 HGCalHistoClusteringWrapper::HGCalHistoClusteringWrapper(const edm::ParameterSet& conf)
     : HGCalHistoClusteringWrapperBase(conf),
-      theAlgo_(),
-      theConfiguration_(kMidRadius_,
-                        conf.getParameter<double>("dR_multicluster"),
-                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
-                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
-                            : std::vector<double>(),
-                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
-                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
-                            : std::vector<double>(),
-                        conf.getParameter<double>("minPt_multicluster")) {}
+      theConfiguration_(),
+      theAlgo_(theConfiguration_) {}
 
-void HGCalHistoClusteringWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-                                                     std::vector<l1thgcfirmware::HGCalCluster>& clusters_SA,
-                                                     const std::vector<std::pair<GlobalPoint, double>>& seeds,
-                                                     std::vector<l1thgcfirmware::HGCalSeed>& seeds_SA) const {
-  clusters_SA.clear();
-  clusters_SA.reserve(clustersPtrs.size());
-  unsigned int clusterIndex = 0;
-  for (const auto& cluster : clustersPtrs) {
-    clusters_SA.emplace_back(cluster->centreProj().x(),
-                             cluster->centreProj().y(),
-                             cluster->centre().z(),
-                             triggerTools_.zside(cluster->detId()),
-                             triggerTools_.layerWithOffset(cluster->detId()),
-                             cluster->eta(),
-                             cluster->phi(),
-                             cluster->pt(),
-                             cluster->mipPt(),
-                             clusterIndex);
-    ++clusterIndex;
-  }
+void HGCalHistoClusteringWrapper::convertCMSSWInputs(const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>& clustersPtrs, l1thgcfirmware::HGCalTriggerCellSAPtrCollections& clusters_SA ) const {
 
-  seeds_SA.clear();
-  seeds_SA.reserve(seeds.size());
-  for (const auto& seed : seeds) {
-    seeds_SA.emplace_back(seed.first.x(), seed.first.y(), seed.first.z(), seed.second);
-  }
-}
-
-void HGCalHistoClusteringWrapper::convertAlgorithmOutputs(
-    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
-    const std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_out,
-    const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
-    l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection,
-    l1t::HGCalClusterBxCollection& rejected_clusters) const {
-  // Not doing completely the correct thing here
-  // Taking the multiclusters from the stand alone emulation
-  // Getting their consistuent clusters (stand alone objects)
-  // Linking back to the original CMSSW-type cluster
-  // And creating a CMSSW-type multicluster based from these clusters
-  // So the output multiclusters will not be storing bit accurate quantities (or whatever was derived by the stand along emulation)
-  // As these inherit from L1Candidate, could set their HW quantities to the bit accurate ones
-  for (const auto& rejected_cluster : rejected_clusters_out) {
-    rejected_clusters.push_back(0, *clustersPtrs.at(rejected_cluster.index_cmssw()));
-  }
-
-  std::vector<l1t::HGCalMulticluster> multiclusters;
-  multiclusters.reserve(multiclusters_out.size());
-  for (unsigned int imulticluster = 0; imulticluster < multiclusters_out.size(); ++imulticluster) {
-    bool firstConstituent = true;
-    for (const auto& constituent : multiclusters_out[imulticluster].constituents()) {
-      if (firstConstituent) {
-        multiclusters.emplace_back(clustersPtrs.at(constituent.index_cmssw()), 1.);
-      } else {
-        multiclusters.at(imulticluster).addConstituent(clustersPtrs.at(constituent.index_cmssw()), 1.);
-      }
-      firstConstituent = false;
+  // Convert trigger cells to format required by emulator
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollections clusters_SA_perSector60(3, l1thgcfirmware::HGCalTriggerCellSAPtrCollection() );
+  unsigned iSector60 = 0;
+  for (const auto& sector60 : clustersPtrs) {
+    for (const auto& cluster : sector60) {
+      const GlobalPoint& position = cluster->position();
+      double x = position.x();
+      double y = position.y();
+      double z = position.z();
+      unsigned int digi_rOverZ = ( std::sqrt(x * x + y * y) / std::abs(z) ) * 4096/ 0.7; // Magic numbers
+      double phi = cluster->phi();
+      phi += ( phi < 0 ) ? 2 * M_PI : 0;
+      unsigned int digi_phi = ( phi ) * 1944 / M_PI; // Magic numbers
+      unsigned int digi_energy = ( cluster->energy() ) * 10000; // Magic numbers
+      clusters_SA_perSector60[iSector60].emplace_back( 
+                                            std::make_shared<l1thgcfirmware::HGCalTriggerCell>(
+                                              true,
+                                              true,
+                                              digi_rOverZ,
+                                              digi_phi,
+                                              triggerTools_.layerWithOffset(cluster->detId()),
+                                              digi_energy
+                                          ) );
     }
+      ++iSector60;
   }
 
-  for (const auto& multicluster : multiclusters) {
-    multiclustersBXCollection.push_back(0, multicluster);
+  // Distribute trigger cells to links and frames
+  // Current firmware expects trigger cells from each S1 FPGA are ordered by r/z in time (r/z increase with frame number), and links from same 60 degree sector are grouped together
+  // As first (optimistic) step, all trigger cells within a 60 degree sector are combined and sorted in r/z
+  // Ultimately, links/ordering in time should come from S1 emulation
+  // Sort by r/z in each 60 degree sector
+  for (auto& clusters : clusters_SA_perSector60) {
+    std::sort(clusters.begin(), clusters.end(), [](l1thgcfirmware::HGCalTriggerCellSAPtr a, l1thgcfirmware::HGCalTriggerCellSAPtr b) { return a->rOverZ()<b->rOverZ(); });
+  }
+
+  // Distribute to links
+  clusters_SA.clear();
+  clusters_SA.resize( 212, l1thgcfirmware::HGCalTriggerCellSAPtrCollection() ); // Magic numbers
+  for ( auto& clusters : clusters_SA ) {
+    clusters.resize(72, l1thgcfirmware::HGCalTriggerCellSAPtr( std::make_shared<l1thgcfirmware::HGCalTriggerCell>() ) ); // Magic numbers
+  }
+  iSector60 = 0;
+  for (const auto& sector60 : clusters_SA_perSector60) {
+    unsigned iCluster = 0;
+    for ( const auto& cluster : sector60 ) {
+      // Leave first two frames empty
+      unsigned frame = 2 + iCluster / 24; // Magic numbers
+      unsigned link = iCluster % 24 + iSector60 * 24; // Magic numbers
+      if ( frame >= 212 ) break;
+      clusters_SA[frame][link] = cluster;
+      ++iCluster;
+    }
+    ++iSector60;
   }
 }
 
 void HGCalHistoClusteringWrapper::process(
-    const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>&
-        inputClustersAndSeeds,
+    const std::vector<std::vector<edm::Ptr<l1t::HGCalCluster>>>&
+        inputClusters,
     std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
         outputMulticlustersAndRejectedClusters) const {
-  l1thgcfirmware::HGCalClusterSACollection clusters_SA;
-  l1thgcfirmware::HGCalSeedSACollection seeds_SA;
-  convertCMSSWInputs(inputClustersAndSeeds.first, clusters_SA, inputClustersAndSeeds.second, seeds_SA);
 
-  l1thgcfirmware::HGCalClusterSACollection rejected_clusters_finalized_SA;
-  l1thgcfirmware::HGCalMulticlusterSACollection multiclusters_finalized_SA;
-  clusterizeHisto(clusters_SA, seeds_SA, multiclusters_finalized_SA, rejected_clusters_finalized_SA);
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollections triggerCells_in_SA;
+  convertCMSSWInputs(inputClusters, triggerCells_in_SA);
 
-  convertAlgorithmOutputs(multiclusters_finalized_SA,
-                          rejected_clusters_finalized_SA,
-                          inputClustersAndSeeds.first,
-                          outputMulticlustersAndRejectedClusters.first,
-                          outputMulticlustersAndRejectedClusters.second);
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollection clusteredTCs_out_SA;
+  l1thgcfirmware::HGCalTriggerCellSAPtrCollection unclusteredTCs_out_SA;
+  l1thgcfirmware::CentroidHelperPtrCollection prioritizedMaxima_out_SA;
+  l1thgcfirmware::CentroidHelperPtrCollection readoutFlags_out_SA;
+  clusterizeHisto(triggerCells_in_SA, clusteredTCs_out_SA, unclusteredTCs_out_SA, prioritizedMaxima_out_SA, readoutFlags_out_SA);
+
+  // convertAlgorithmOutputs();
 }
 
-void HGCalHistoClusteringWrapper::clusterizeHisto(
-    const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
-    const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
-    l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
-    l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const {
-  // Call SA clustering
-  std::vector<l1thgcfirmware::HGCalCluster> rejected_clusters_vec_SA;
-  std::vector<l1thgcfirmware::HGCalMulticluster> multiclusters_vec_SA =
-      theAlgo_.clusterSeedMulticluster_SA(inputClusters, inputSeeds, rejected_clusters_vec_SA, theConfiguration_);
+void HGCalHistoClusteringWrapper::clusterizeHisto( l1thgcfirmware::HGCalTriggerCellSAPtrCollections& triggerCells_in_SA, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& clusteredTCs, l1thgcfirmware::HGCalTriggerCellSAPtrCollection& unclusteredTCs, l1thgcfirmware::CentroidHelperPtrCollection& prioritizedMaxima, l1thgcfirmware::CentroidHelperPtrCollection& readoutFlags ) const {
 
-  theAlgo_.finalizeClusters_SA(
-      multiclusters_vec_SA, rejected_clusters_vec_SA, outputMulticlusters, outputRejectedClusters, theConfiguration_);
+  theAlgo_.runAlgorithm( triggerCells_in_SA, clusteredTCs, unclusteredTCs, prioritizedMaxima, readoutFlags );
 }
 
 void HGCalHistoClusteringWrapper::configure(
@@ -170,16 +140,6 @@ void HGCalHistoClusteringWrapper::configure(
   eventSetup(configuration.first);
 
   // theConfiguration_.setParameters( ... );
-
-  if ((!theConfiguration_.dr_byLayer_coefficientA().empty() &&
-       (theConfiguration_.dr_byLayer_coefficientA().size() - 1) < triggerTools_.lastLayerBH()) ||
-      (!theConfiguration_.dr_byLayer_coefficientB().empty() &&
-       (theConfiguration_.dr_byLayer_coefficientB().size() - 1) < triggerTools_.lastLayerBH())) {
-    throw cms::Exception("Configuration")
-        << "The per-layer dR values go up to " << (theConfiguration_.dr_byLayer_coefficientA().size() - 1) << "(A) and "
-        << (theConfiguration_.dr_byLayer_coefficientB().size() - 1) << "(B), while layers go up to "
-        << triggerTools_.lastLayerBH() << "\n";
-  }
 };
 
 DEFINE_EDM_PLUGIN(HGCalHistoClusteringWrapperBaseFactory, HGCalHistoClusteringWrapper, "HGCalHistoClusteringWrapper");

--- a/L1Trigger/L1THGCal/python/customNewProcessors.py
+++ b/L1Trigger/L1THGCal/python/customNewProcessors.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import truncation_params
+from L1Trigger.L1THGCal.hgcalBackendLayer2_fwClustering_cfi import layer2ClusteringFw_Params
 
 def custom_stage1_truncation(process):
     parameters = stage1truncation_proc.clone()
@@ -12,6 +13,7 @@ def custom_stage1_truncation(process):
 def custom_clustering_standalone(process):
     process.hgcalBackEndLayer2Producer.ProcessorParameters.ProcessorName = cms.string('HGCalBackendLayer2Processor3DClusteringSA')
     process.hgcalBackEndLayer2Producer.ProcessorParameters.DistributionParameters = truncation_params
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters.layer2FwClusteringParameters = layer2ClusteringFw_Params
     return process
 
 def custom_tower_standalone(process):

--- a/L1Trigger/L1THGCal/python/hgcalBackendLayer2_fwClustering_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackendLayer2_fwClustering_cfi.py
@@ -1,0 +1,94 @@
+import FWCore.ParameterSet.Config as cms
+from math import pi
+
+layer2ClusteringFw_Params = cms.PSet(
+    # Latencies
+    # histogramOffset=cms.uint32(216),
+    clusterizerOffset=cms.uint32(276),
+    stepLatencies=cms.vuint32(  0,      # Input 
+                                1,      # Dist0 
+                                1,      # Dist1 
+                                6,      # Dist2 
+                                0,      # Dist3 
+                                1,      # Dist4 
+                                7,      # Dist5 
+                                1,      # TcToHc
+                                216 + 1,# Hist, histogramOffset + 1
+                                5,      # Smearing1D
+                                3,      # NormArea  
+                                6,      # Smearing2D
+                                0,      # Maxima1D  
+                                2,      # Maxima2D  
+                                6,      # CalcAverage
+                                0,      # Clusterizer
+                                18,     # TriggerCellToCluster
+                                0 ),    # ClusterSum
+    cClocks=cms.uint32(250),
+    cInputs=cms.uint32(72),
+    cInputs2=cms.uint32(75),
+    cInt=cms.uint32(90),
+
+    # Digitzation parameters
+    digiParams = cms.PSet(
+        rOverZRange = cms.double(0.7),
+        rOverZNValues = cms.double(4096), # 12 bits
+        phiRange = cms.double(pi),
+        phiNValues = cms.double(1944), # 12 bits, but range over 2pi is 3888
+        ptDigiFactor = cms.double(10000),
+    ),
+
+    # Histogram parameters
+    cColumns=cms.uint32(108),
+    cRows=cms.uint32(44),
+    rOverZHistOffset = cms.uint32(440), # offset of first r/z bin in number of LSB
+    rOverZBinSize = cms.uint32(64), # in number of LSB
+
+    # Threshold maxima parameters
+    # Threshold for given histogram row (r/z bin) paramaterized as a+b*bin+c*bin^2
+    thresholdMaximaParams = cms.PSet(
+        a=cms.uint32(18000),
+        b=cms.uint32(800),
+        c=cms.int32(-20)
+    ),
+    clusterizerMagicTime=cms.uint32(434),
+    nBinsCosLUT = cms.uint32(77), # Number of entries in 1-cos(delta phi) LUT when clustering to seeds
+    depths = cms.vuint32(0 , # No zero layer
+          0 , 30 , 59 , 89 , 118 , 148 , 178 , 208 , 237 , 267 , 297 , 327 , 356 , 386 , # CE-E
+          415 , 445 , 475 , 505 , 534 , 564 , 594 , 624 , 653 , 683 , 712 , 742 , 772 , 802 , # CE-E
+          911 , 1020 , 1129 , 1238 , 1347 , 1456 , 1565 , 1674 , # CE-FH
+          1783 , 1892 , 2001 , 2110 , 2281 , 2452 , 2623 , 2794 , 2965 , 3136 , 3307 , 3478 , 3649 , 3820 , # CE-BH
+          0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ),
+    triggerLayers = cms.vuint32(0 , # No zero layer
+                  1 , 0 , 2 , 0 , 3 , 0 , # CE-E (early)
+                  4 , 0 , 5 , 0 , 6 , 0 , 7 , 0 , 8 , 0 , # CE-E (core)
+                  9 , 0 , 10 , 0 , 11 , 0 , 12 , 0 , 13 , 0 , 14 , 0 , # CE-E (back)
+                  15 , 16 , 17 , 18 , # CE-H (early)
+                  19 , 20 , 21 , 22 , 23 , 24 , 25 , 26 , 27 , 28 , 29 , 30 , 31 , 32 , 33 , 34 , 35 , 36 , 0 , 0 , # CE-H (back)
+                  0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0  ), # Padding
+    layerWeights_E = cms.vuint32(0 , # No zero layer
+                 1 , 1 , 1 , # CE-E (early)
+                 1 , 1 , 1 , 1 , 1 , # CE-E (core)
+                 1 , 1 , 1 , 1 , 1 , 1 , # CE-E (back)
+                 1 , 1 , 1 , 1 , # CE-H (early)
+                 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1), # CE-H (back)
+    layerWeights_E_EM = cms.vuint32(0 , # No zero layer
+                    252969 , 254280 , 255590 , # CE-E (early)
+                    256901 , 258212 , 259523 , 260833 , 262144 , # CE-E (core)
+                    263455 , 264765 , 266076 , 267387 , 268698 , 270008 , # CE-E (back)
+                    0 , 0 , 0 , 0 , # CE-H (early)
+                    0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ), # CE-H (back)
+    layerWeights_E_EM_core = cms.vuint32(0 , # No zero layer
+                         0 , 0 , 0 , # CE-E (early)
+                         256901 , 258212 , 259523 , 260833 , 262144 , # CE-E (core)
+                         0 , 0 , 0 , 0 , 0 , 0 , # CE-E (back)
+                         0 , 0 , 0 , 0 , # CE-H (early)
+                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ), # CE-H (back)
+    layerWeights_E_H_early = cms.vuint32( 0 , # No zero layer
+                         0 , 0 , 0 , # CE-E (early)
+                         0 , 0 , 0 , 0 , 0 , # CE-E (core)
+                         0 , 0 , 0 , 0 , 0 , 0 , # CE-E (back)
+                         1 , 1 , 1 , 1 , # CE-H (early)
+                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0), # CE-H 
+    correction=cms.uint32(131071), # 0b011111111111111111
+    saturation=cms.uint32(524287) # (2 ** 19) - 1
+)

--- a/L1Trigger/L1THGCal/src/backend_emulator/DistServer.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/DistServer.cc
@@ -1,0 +1,64 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/DistServer.h"
+
+#include <algorithm>
+#include<iostream>
+
+using namespace std;
+using namespace l1thgcfirmware;
+
+DistServer::DistServer( unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving ) : 
+    nInputs_(nInputs),
+    nOutputs_(nOutputs),
+    nInterleaving_(nInterleaving),
+    inputs_(nInputs_) {
+        for ( unsigned int iInput=0; iInput<this->nInputs(); ++iInput ) {
+            addr_.emplace_back(this->nInterleaving(),0);
+            for ( unsigned int iInterleave=0; iInterleave<this->nInterleaving(); ++iInterleave ) {
+                addr_[iInput][iInterleave] = iInterleave;
+            }
+        }
+    }
+
+HGCalTriggerCellSAPtrCollection DistServer::clock(HGCalTriggerCellSAPtrCollection& data) {
+    for ( unsigned int iInput=0; iInput<nInputs(); ++iInput ) {
+        if ( data[iInput]->dataValid() ) {
+            inputs()[iInput].push_back( data[iInput] );
+        }
+    }
+    
+    vector< vector< bool > > lMap(nInputs(), vector<bool>(nOutputs()) );
+
+    HGCalTriggerCellSAPtrCollection lInputs(nInputs(),std::make_shared<HGCalTriggerCell>());
+
+    std::vector< std::vector< unsigned int> >& addr = this->addr();
+
+    for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
+        unsigned int lAddr = addr[iInput][0];
+        if ( lAddr < inputs()[iInput].size() ) {
+            lInputs[iInput] = inputs()[iInput][lAddr];
+            lMap[iInput][ lInputs[iInput]->sortKey() ] = true;
+        }
+    }
+    
+    for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
+        vector< unsigned int>& toRotate = addr[iInput];
+        rotate(toRotate.begin(),  toRotate.begin()+1, toRotate.end() );
+    }
+
+    HGCalTriggerCellSAPtrCollection lOutputs(nOutputs(),std::make_shared<HGCalTriggerCell>());
+
+    unsigned int nOutputs = 0;
+    for ( unsigned int iOutput = 0; iOutput<lOutputs.size(); ++iOutput ) {
+        for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
+            if ( lMap[iInput][iOutput] ) {
+                lOutputs[iOutput] = lInputs[iInput];
+                addr[iInput].back() += this->nInterleaving();
+                nOutputs++;
+                break;
+            }
+        }
+    }
+
+
+    return lOutputs; 
+}

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalCluster_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalCluster_SA.cc
@@ -1,0 +1,65 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h"
+
+using namespace l1thgcfirmware;
+
+const HGCalCluster& HGCalCluster::operator+=(const HGCalCluster& c) {
+  // Not handling field widths
+  HGCalCluster original( *this );
+  this->set_n_tc( this->n_tc() + c.n_tc() );
+  this->set_e( this->e() + c.e() );
+  this->set_e_em( this->e_em() + c.e_em() );
+  this->set_e_em_core( this->e_em_core() + c.e_em_core() );
+  this->set_e_h_early( this->e_h_early() + c.e_h_early() );
+  this->set_w( this->w() + c.w() );
+  this->set_n_tc_w( this->n_tc_w() + c.n_tc_w() );
+  this->set_w2( this->w2() + c.w2() );
+  this->set_wz( this->wz() + c.wz() );
+  this->set_weta( this->weta() + c.weta() );
+  this->set_wphi( this->wphi() + c.wphi() );
+  this->set_wroz( this->wroz() + c.wroz() );
+  this->set_wz2( this->wz2() + c.wz2() );
+  this->set_weta2( this->weta2() + c.weta2() );
+  this->set_wphi2( this->wphi2() + c.wphi2() );
+  this->set_wroz2( this->wroz2() + c.wroz2() );
+
+  this->set_layerbits( this->layerbits() | c.layerbits() );
+  this->set_sat_tc( this->sat_tc() | c.sat_tc() );
+  this->set_shapeq( this->shapeq() | c.shapeq() );
+
+  if ( w_ <= 52438 && original.shapeq() == 1 && c.shapeq() == 1 ) { // Magic numbers
+    this->set_shapeq(1);
+  }
+  else {
+    this->set_shapeq(0);
+
+    if ( this->w() > c.w() ) {
+      this->set_w( original.w() );
+      this->set_w2( original.w2() );
+      this->set_wz( original.wz() );
+      this->set_weta( original.weta() );
+      this->set_wphi( original.wphi() );
+      this->set_wroz( original.wroz() );
+      this->set_wz2( original.wz2() );
+      this->set_weta2( original.weta2() );
+      this->set_wphi2( original.wphi2() );
+      this->set_wroz2( original.wroz2() );
+      this->set_n_tc_w( original.n_tc_w() );
+    }
+    else {
+      this->set_w( c.w() );
+      this->set_w2( c.w2() );
+      this->set_wz( c.wz() );
+      this->set_weta( c.weta() );
+      this->set_wphi( c.wphi() );
+      this->set_wroz( c.wroz() );
+      this->set_wz2( c.wz2() );
+      this->set_weta2( c.weta2() );
+      this->set_wphi2( c.wphi2() );
+      this->set_wroz2( c.wroz2() );
+      this->set_n_tc_w( c.n_tc_w() );
+    }
+
+  }
+
+  return *this;
+}

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalCluster_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalCluster_SA.cc
@@ -1,6 +1,10 @@
 #include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalCluster_SA.h"
+#include <math.h>
+#include <algorithm>
+
 
 using namespace l1thgcfirmware;
+
 
 const HGCalCluster& HGCalCluster::operator+=(const HGCalCluster& c) {
   // Not handling field widths

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringConfig_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringConfig_SA.cc
@@ -4,82 +4,58 @@
 using namespace std;
 using namespace l1thgcfirmware;
 ClusterAlgoConfig::ClusterAlgoConfig() :
-  histogramOffset_(216), // All constants to be read from config file
-  clusterizerOffset_(276),
-  cClocks_(250),
-  cInputs_(72),
-  cInputs2_(75),
-  cInt_(90),
-  cColumns_(108),
-  cRows_(44),
+  clusterizerOffset_(0),
+  cClocks_(0),
+  cInputs_(0),
+  cInputs2_(0),
+  cInt_(0),
+  cColumns_(0),
+  cRows_(0),
+  rOverZHistOffset_(0),
+  rOverZBinSize_(0),
   kernelWidths_(),
   areaNormalizations_(),
   thresholdMaximaConstants_(),
+  nBinsCosLUT_(0),
   cosLUT_(),
-  clusterizerMagicTime_(434),
+  clusterizerMagicTime_(0),
   stepLatency_({
     { Input  ,  0 },
-    { Dist0  ,  1 },
-    { Dist1  ,  1 },
-    { Dist2  ,  6 },
+    { Dist0  ,  0 },
+    { Dist1  ,  0 },
+    { Dist2  ,  0 },
     { Dist3  ,  0 },
-    { Dist4  ,  1 },
-    { Dist5  ,  7 },
-    { TcToHc , 1 },
-    { Hist   , histogramOffset_ + 1 },
-    { Smearing1D , 5 },
-    { NormArea   , 3 },
-    { Smearing2D , 6 },
+    { Dist4  ,  0 },
+    { Dist5  ,  0 },
+    { TcToHc , 0 },
+    { Hist   , 0 },
+    { Smearing1D , 0 },
+    { NormArea   , 0 },
+    { Smearing2D , 0 },
     { Maxima1D   , 0 },
-    { Maxima2D   , 2 },
-    { CalcAverage , 6 },
+    { Maxima2D   , 0 },
+    { CalcAverage , 0 },
     { Clusterizer , 0 },
-    { TriggerCellToCluster , 18 },
+    { TriggerCellToCluster , 0 },
     { ClusterSum , 0 }
   }),
-  depths_({0 , // No zero layer
-          0 , 30 , 59 , 89 , 118 , 148 , 178 , 208 , 237 , 267 , 297 , 327 , 356 , 386 , // CE-E
-          415 , 445 , 475 , 505 , 534 , 564 , 594 , 624 , 653 , 683 , 712 , 742 , 772 , 802 , // CE-E
-          911 , 1020 , 1129 , 1238 , 1347 , 1456 , 1565 , 1674 , // CE-FH
-          1783 , 1892 , 2001 , 2110 , 2281 , 2452 , 2623 , 2794 , 2965 , 3136 , 3307 , 3478 , 3649 , 3820 , // CE-BH
-          0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0}), // Padding
-  triggerLayers_({0 , // No zero layer
-                  1 , 0 , 2 , 0 , 3 , 0 , // CE-E (early)
-                  4 , 0 , 5 , 0 , 6 , 0 , 7 , 0 , 8 , 0 , // CE-E (core)
-                  9 , 0 , 10 , 0 , 11 , 0 , 12 , 0 , 13 , 0 , 14 , 0 , // CE-E (back)
-                  15 , 16 , 17 , 18 , // CE-H (early)
-                  19 , 20 , 21 , 22 , 23 , 24 , 25 , 26 , 27 , 28 , 29 , 30 , 31 , 32 , 33 , 34 , 35 , 36 , 0 , 0 , // CE-H (back)
-                  0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0  }), // Padding
-  layerWeights_E_({0 , // No zero layer
-                 1 , 1 , 1 , // CE-E (early)
-                 1 , 1 , 1 , 1 , 1 , // CE-E (core)
-                 1 , 1 , 1 , 1 , 1 , 1 , // CE-E (back)
-                 1 , 1 , 1 , 1 , // CE-H (early)
-                 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1}), // CE-H (back)
-  layerWeights_E_EM_({0 , // No zero layer
-                    252969 , 254280 , 255590 , // CE-E (early)
-                    256901 , 258212 , 259523 , 260833 , 262144 , // CE-E (core)
-                    263455 , 264765 , 266076 , 267387 , 268698 , 270008 , // CE-E (back)
-                    0 , 0 , 0 , 0 , // CE-H (early)
-                    0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }), // CE-H (back)
-  layerWeights_E_EM_core_({0 , // No zero layer
-                         0 , 0 , 0 , // CE-E (early)
-                         256901 , 258212 , 259523 , 260833 , 262144 , // CE-E (core)
-                         0 , 0 , 0 , 0 , 0 , 0 , // CE-E (back)
-                         0 , 0 , 0 , 0 , // CE-H (early)
-                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }), // CE-H (back)
- layerWeights_E_H_early_({ 0 , // No zero layer
-                         0 , 0 , 0 , // CE-E (early)
-                         0 , 0 , 0 , 0 , 0 , // CE-E (core)
-                         0 , 0 , 0 , 0 , 0 , 0 , // CE-E (back)
-                         1 , 1 , 1 , 1 , // CE-H (early)
-                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0}), // CE-H 
-  correction_(131071), // 0b011111111111111111
-  saturation_(524287) // (2 ** 19) - 1
+  depths_(),
+  triggerLayers_(),
+  layerWeights_E_(),
+  layerWeights_E_EM_(),
+  layerWeights_E_EM_core_(),
+  layerWeights_E_H_early_(),
+  correction_(), // 0b011111111111111111
+  saturation_() // (2 ** 19) - 1
 {
-  initializeSmearingKernelConstants( cRows_, 440, 64 ); // Magic numbers
-  initializeThresholdMaximaConstants( cRows_ );
-  initializeCosLUT();
+}
+
+void ClusterAlgoConfig::setStepLatencies( const std::vector<unsigned int> latencies ) {
+  // Add check that stepLatency is at least same size as latencies
+  // But not as cms.exception
+  for ( unsigned int iStep = 0; iStep < latencies.size(); ++iStep ) {
+    stepLatency_.at(Step(iStep)) = latencies.at(iStep);
+  }
 }
 
 unsigned int ClusterAlgoConfig::getLatencyUpToAndIncluding( const Step step ) {
@@ -88,9 +64,15 @@ unsigned int ClusterAlgoConfig::getLatencyUpToAndIncluding( const Step step ) {
   return latency;
 }
 
+void ClusterAlgoConfig::initializeLUTs() {
+  initializeSmearingKernelConstants( cRows_, rOverZHistOffset_, rOverZBinSize_ );
+  initializeThresholdMaximaConstants( cRows_, thresholdMaximaParam_a_, thresholdMaximaParam_b_, thresholdMaximaParam_c_  );
+  initializeCosLUT();
+}
+
 void ClusterAlgoConfig::initializeSmearingKernelConstants( unsigned int bins, unsigned int offset, unsigned int height ) {
   const unsigned int lWidth0 = offset + (0.5*height);
-  const unsigned int lTarget = int( 6.5*lWidth0 - 0.5 );
+  const unsigned int lTarget = int( 6.5*lWidth0 - 0.5 ); // Magic numbers
 
   for ( unsigned int iBin = 0; iBin < bins; ++iBin ) {
     unsigned int lCentre = lWidth0 + ( height * iBin );
@@ -106,11 +88,7 @@ void ClusterAlgoConfig::initializeSmearingKernelConstants( unsigned int bins, un
   }
 }
 
-void ClusterAlgoConfig::initializeThresholdMaximaConstants( unsigned int bins ) {
-  unsigned int a = 18000; // Magic numbers
-  unsigned int b = 800; // Magic numbers
-  int c = -20; // Magic numbers
-
+void ClusterAlgoConfig::initializeThresholdMaximaConstants( unsigned int bins, unsigned int a, unsigned int b, int c ) {
   for ( unsigned int iBin = 0; iBin < bins; ++iBin ) {
     int threshold = a + b*iBin + c*iBin*iBin;
     thresholdMaximaConstants_.push_back( threshold );
@@ -118,10 +96,48 @@ void ClusterAlgoConfig::initializeThresholdMaximaConstants( unsigned int bins ) 
 }
 
 void ClusterAlgoConfig::initializeCosLUT() {
-  for ( unsigned int iBin = 0; iBin < 78; ++iBin ) { // Magic numbers
+  for ( unsigned int iBin = 0; iBin < nBinsCosLUT_+1; ++iBin ) { 
     unsigned int cosBin = round( pow(2,18) * ( 1 - cos(iBin*M_PI/1944) ) ); // Magic numbers
     cosLUT_.push_back( cosBin );
   }
+}
+
+void ClusterAlgoConfig::printConfiguration() {
+  cout << "Running the algorithm" << endl;
+  cout << "Config params" << endl;
+  cout << "Clusterizer offset : " << clusterizerOffset() << endl;
+  cout << "Latencies : ";
+  for ( const auto& latency : stepLatency_ ) cout << latency.first << " " << latency.second << " ";
+  cout << endl;
+  cout << "cClocks : " << cClocks() << endl;
+  cout << "cInputs : " << cInputs() << endl;
+  cout << "cInputs2 : " << cInputs2() << endl;
+  cout << "cColumns : " << cColumns() << endl;
+  cout << "cRows : " << cRows() << endl;
+  cout << "rOverZHistOffset : " << rOverZHistOffset() << endl;
+  cout << "rOverZBinSize : " << rOverZBinSize() << endl;
+  cout << "nBinsCosLUT : " << nBinsCosLUT() << endl;
+  cout << "clusterizerMagicTime : " << clusterizerMagicTime() << endl;
+  cout << "depths : ";
+  for ( const auto& depth : depths() ) cout << depth << " ";
+  cout << endl;
+  cout << "triggerLayers : ";
+  for ( const auto& triggerLayer : triggerLayers() ) cout << triggerLayer << " ";
+  cout << endl;
+  cout << "layerWeights_E : ";
+  for ( const auto& weight : layerWeights_E() ) cout << weight << " ";
+  cout << endl;
+  cout << "layerWeights_E_EM : ";
+  for ( const auto& weight : layerWeights_E_EM() ) cout << weight << " ";
+  cout << endl;
+  cout << "layerWeights_E_EM_core : ";
+  for ( const auto& weight : layerWeights_E_EM_core() ) cout << weight << " ";
+  cout << endl;
+  cout << "layerWeights_E_H_early : ";
+  for ( const auto& weight : layerWeights_E_H_early() ) cout << weight << " ";
+  cout << endl;
+  cout << "correction : " << correction() << endl;
+  cout << "saturation : " << saturation() << endl;
 }
 
 

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringConfig_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringConfig_SA.cc
@@ -1,0 +1,127 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringConfig_SA.h"
+#include <math.h>
+#include <iostream>
+using namespace std;
+using namespace l1thgcfirmware;
+ClusterAlgoConfig::ClusterAlgoConfig() :
+  histogramOffset_(216), // All constants to be read from config file
+  clusterizerOffset_(276),
+  cClocks_(250),
+  cInputs_(72),
+  cInputs2_(75),
+  cInt_(90),
+  cColumns_(108),
+  cRows_(44),
+  kernelWidths_(),
+  areaNormalizations_(),
+  thresholdMaximaConstants_(),
+  cosLUT_(),
+  clusterizerMagicTime_(434),
+  stepLatency_({
+    { Input  ,  0 },
+    { Dist0  ,  1 },
+    { Dist1  ,  1 },
+    { Dist2  ,  6 },
+    { Dist3  ,  0 },
+    { Dist4  ,  1 },
+    { Dist5  ,  7 },
+    { TcToHc , 1 },
+    { Hist   , histogramOffset_ + 1 },
+    { Smearing1D , 5 },
+    { NormArea   , 3 },
+    { Smearing2D , 6 },
+    { Maxima1D   , 0 },
+    { Maxima2D   , 2 },
+    { CalcAverage , 6 },
+    { Clusterizer , 0 },
+    { TriggerCellToCluster , 18 },
+    { ClusterSum , 0 }
+  }),
+  depths_({0 , // No zero layer
+          0 , 30 , 59 , 89 , 118 , 148 , 178 , 208 , 237 , 267 , 297 , 327 , 356 , 386 , // CE-E
+          415 , 445 , 475 , 505 , 534 , 564 , 594 , 624 , 653 , 683 , 712 , 742 , 772 , 802 , // CE-E
+          911 , 1020 , 1129 , 1238 , 1347 , 1456 , 1565 , 1674 , // CE-FH
+          1783 , 1892 , 2001 , 2110 , 2281 , 2452 , 2623 , 2794 , 2965 , 3136 , 3307 , 3478 , 3649 , 3820 , // CE-BH
+          0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0}), // Padding
+  triggerLayers_({0 , // No zero layer
+                  1 , 0 , 2 , 0 , 3 , 0 , // CE-E (early)
+                  4 , 0 , 5 , 0 , 6 , 0 , 7 , 0 , 8 , 0 , // CE-E (core)
+                  9 , 0 , 10 , 0 , 11 , 0 , 12 , 0 , 13 , 0 , 14 , 0 , // CE-E (back)
+                  15 , 16 , 17 , 18 , // CE-H (early)
+                  19 , 20 , 21 , 22 , 23 , 24 , 25 , 26 , 27 , 28 , 29 , 30 , 31 , 32 , 33 , 34 , 35 , 36 , 0 , 0 , // CE-H (back)
+                  0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0  }), // Padding
+  layerWeights_E_({0 , // No zero layer
+                 1 , 1 , 1 , // CE-E (early)
+                 1 , 1 , 1 , 1 , 1 , // CE-E (core)
+                 1 , 1 , 1 , 1 , 1 , 1 , // CE-E (back)
+                 1 , 1 , 1 , 1 , // CE-H (early)
+                 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1}), // CE-H (back)
+  layerWeights_E_EM_({0 , // No zero layer
+                    252969 , 254280 , 255590 , // CE-E (early)
+                    256901 , 258212 , 259523 , 260833 , 262144 , // CE-E (core)
+                    263455 , 264765 , 266076 , 267387 , 268698 , 270008 , // CE-E (back)
+                    0 , 0 , 0 , 0 , // CE-H (early)
+                    0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }), // CE-H (back)
+  layerWeights_E_EM_core_({0 , // No zero layer
+                         0 , 0 , 0 , // CE-E (early)
+                         256901 , 258212 , 259523 , 260833 , 262144 , // CE-E (core)
+                         0 , 0 , 0 , 0 , 0 , 0 , // CE-E (back)
+                         0 , 0 , 0 , 0 , // CE-H (early)
+                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }), // CE-H (back)
+ layerWeights_E_H_early_({ 0 , // No zero layer
+                         0 , 0 , 0 , // CE-E (early)
+                         0 , 0 , 0 , 0 , 0 , // CE-E (core)
+                         0 , 0 , 0 , 0 , 0 , 0 , // CE-E (back)
+                         1 , 1 , 1 , 1 , // CE-H (early)
+                         0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0}), // CE-H 
+  correction_(131071), // 0b011111111111111111
+  saturation_(524287) // (2 ** 19) - 1
+{
+  initializeSmearingKernelConstants( cRows_, 440, 64 ); // Magic numbers
+  initializeThresholdMaximaConstants( cRows_ );
+  initializeCosLUT();
+}
+
+unsigned int ClusterAlgoConfig::getLatencyUpToAndIncluding( const Step step ) {
+  unsigned int latency = 0;
+  for ( int iStep = 0; iStep <= step; ++iStep ) latency += getStepLatency(Step(iStep));
+  return latency;
+}
+
+void ClusterAlgoConfig::initializeSmearingKernelConstants( unsigned int bins, unsigned int offset, unsigned int height ) {
+  const unsigned int lWidth0 = offset + (0.5*height);
+  const unsigned int lTarget = int( 6.5*lWidth0 - 0.5 );
+
+  for ( unsigned int iBin = 0; iBin < bins; ++iBin ) {
+    unsigned int lCentre = lWidth0 + ( height * iBin );
+    const unsigned int lBins = int( round(1.0 * lTarget / lCentre) );
+
+    kernelWidths_.push_back( lBins );
+
+    lCentre *= lBins;
+
+    const unsigned int lRatio = int( round(1.0*lTarget/lCentre * pow(2,17) ) ); // Magic numbers
+
+    areaNormalizations_.push_back( lRatio );
+  }
+}
+
+void ClusterAlgoConfig::initializeThresholdMaximaConstants( unsigned int bins ) {
+  unsigned int a = 18000; // Magic numbers
+  unsigned int b = 800; // Magic numbers
+  int c = -20; // Magic numbers
+
+  for ( unsigned int iBin = 0; iBin < bins; ++iBin ) {
+    int threshold = a + b*iBin + c*iBin*iBin;
+    thresholdMaximaConstants_.push_back( threshold );
+  }
+}
+
+void ClusterAlgoConfig::initializeCosLUT() {
+  for ( unsigned int iBin = 0; iBin < 78; ++iBin ) { // Magic numbers
+    unsigned int cosBin = round( pow(2,18) * ( 1 - cos(iBin*M_PI/1944) ) ); // Magic numbers
+    cosLUT_.push_back( cosBin );
+  }
+}
+
+

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -2,6 +2,7 @@
 #include "L1Trigger/L1THGCal/interface/backend_emulator/DistServer.h"
 #include "L1Trigger/L1THGCal/interface/backend_emulator/CentroidHelper.h"
 
+#include <math.h>
 #include <map>
 #include <vector>
 #include <algorithm>
@@ -45,6 +46,7 @@ void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& 
   HGCalClusterSAPtrCollection protoClusters = triggerCellToCluster( clusteredTCs );
   HGCalClusterSAPtrCollection clusterAccumulation;
   clusterSum( protoClusters, readoutFlags, clusterAccumulation, clusterSums );
+  clusterProperties(clusterSums);
 
 }
 
@@ -629,14 +631,134 @@ void HGCalHistoClusteringImplSA::clusterSum( HGCalClusterSAPtrCollection& protoC
   // }
   // std::cout << nTCs << std::endl;
   // nTCs = 0;
-  // std::cout << "Cluster sums" << std::endl;
-  // for ( const auto& c : clusterSums ) {
-  //   std::cout << c->clock() << " " << c->index() << " " << c->n_tc() << " " << c->e() << " " << c->e_em() << " " << c->e_em_core() << " " << c->e_h_early() << std::endl;
-  //   nTCs += c->n_tc();
-  // }
+  //unsigned int ID = 0;
+  // Print the info as the Python emu format
+  //std::cout << "ID,event_ID,cluster_ID,N_TC,E,E_EM,E_EM_core,E_H_early,W,N_TC_W,W2,Wz,Weta,Wphi,Wroz,Wz2,Weta2,Wphi2,Wroz2,LayerBits,Sat_TC,ShapeQ,SortKey" << std::endl;
+  //for ( const auto& c : clusterSums ) {
+     //std::cout << ID << ",0," << c->index() << "," << c->n_tc() << "," << c->e() << "," << c->e_em() << "," << c->e_em_core() << "," << c->e_h_early() << "," << c->w() << "," << c->n_tc_w() << "," << c->w2() << "," << c->wz() << "," << c->weta() << "," << c->wphi() << "," << c->wroz() << "," << c->wz2() << "," << c->weta2() << "," << c->wphi2() << "," << c->wroz2() << "," << c->layerbits() << "," << c->sat_tc() << "," << c->shapeq() << ",0" << std::endl;
+     //ID++;
+     //nTCs += c->n_tc();
+  //}
   // std::cout << nTCs << std::endl;
+
+
 }
 
+std::pair< unsigned int, unsigned int > HGCalHistoClusteringImplSA::sigma_Energy(unsigned int N_TC_W, unsigned long int Sum_W2, unsigned int Sum_W) const {
+  unsigned long int N = N_TC_W*Sum_W2 - pow(Sum_W,2);
+  unsigned long int D = pow(N_TC_W,2);
+  double intpart;
+  double frac =  modf(sqrt(N/D),&intpart)*pow(2,1);
+  return { (unsigned int)intpart, (unsigned int)frac };
+}
+
+std::pair< unsigned int, unsigned int > HGCalHistoClusteringImplSA::mean_coordinate(unsigned int Sum_Wc, unsigned int Sum_W) const {
+  double intpart;
+  double frac =  modf((double)Sum_Wc/Sum_W,&intpart)*pow(2,2);
+  return { (unsigned int)intpart, (unsigned int)frac };
+}
+
+std::pair< unsigned int, unsigned int > HGCalHistoClusteringImplSA::sigma_Coordinate(unsigned int Sum_W, unsigned long int Sum_Wc2, unsigned int Sum_Wc) const {
+  unsigned long int N = Sum_W*Sum_Wc2 - pow(Sum_Wc,2);
+  unsigned long int D = pow(Sum_W,2);
+  double intpart;
+  double frac =  modf((double)sqrt(N/D),&intpart)*pow(2,1);
+  return { (unsigned int)intpart, (unsigned int)frac };
+}
+
+std::pair< unsigned int, unsigned int > HGCalHistoClusteringImplSA::energy_ratio(unsigned int E_N, unsigned int E_D) const {
+  if ( E_D == 0 ) {
+    return { 0 , 0 };
+  } else {
+    double intpart;
+    double frac =  modf((double)E_N/E_D,&intpart)*pow(2,8);
+    return { (unsigned int)intpart, (unsigned int)frac };
+  }
+}
+
+std::vector<int> HGCalHistoClusteringImplSA::showerLengthProperties(unsigned long int layerBits) const {
+  int counter = 0;
+  int firstLayer = 0;
+  bool firstLayerFound = false;
+  int lastLayer = 0;
+  std::vector<int> layerBits_array;
+
+  for (int idx = 0; idx<36; idx++) {
+    if ( (layerBits&(1L<<(35-idx)) ) >= 1L ) {
+      if ( !firstLayerFound ) {
+        firstLayer = idx+1;
+        firstLayerFound=true;
+      }
+      lastLayer = idx+1;
+      counter += 1;
+    } else {
+      layerBits_array.push_back(counter);
+      counter = 0;
+    }
+  }
+  int showerLen = lastLayer - firstLayer + 1;
+  int coreShowerLen = 36;
+  if ( layerBits_array.size()>0 ) {
+    coreShowerLen = *std::max_element(layerBits_array.begin(), layerBits_array.end());
+  }
+
+  std::vector<int> output = {firstLayer,lastLayer, showerLen, coreShowerLen};
+
+  return output;
+}
+
+void HGCalHistoClusteringImplSA::clusterProperties(  HGCalClusterSAPtrCollection& clusterSums ) const {
+   unsigned int nTCs = 0;
+   std::cout << "Cluster Prop" << std::endl;
+   for ( const auto& c : clusterSums ) {
+      std::pair< unsigned int, unsigned int > sigmaEnergy = sigma_Energy( c->n_tc_w(), c->w2(), c->w() );
+      c->set_Sigma_E_Quotient( sigmaEnergy.first );
+      c->set_Sigma_E_Fraction( sigmaEnergy.second );
+      std::pair< unsigned int, unsigned int > Mean_z = mean_coordinate( c->wz(), c->w() );
+      c->set_Mean_z_Quotient( Mean_z.first );
+      c->set_Mean_z_Fraction( Mean_z.second );
+      std::pair< unsigned int, unsigned int > Mean_phi = mean_coordinate( c->wphi(), c->w() );      
+      c->set_Mean_phi_Quotient( Mean_phi.first );
+      c->set_Mean_phi_Fraction( Mean_phi.second );
+      std::pair< unsigned int, unsigned int > Mean_eta = mean_coordinate( c->weta(), c->w() );
+      c->set_Mean_eta_Quotient( Mean_eta.first );
+      c->set_Mean_eta_Fraction( Mean_eta.second );
+      std::pair< unsigned int, unsigned int > Mean_roz = mean_coordinate( c->wroz(), c->w() );
+      c->set_Mean_roz_Quotient( Mean_roz.first );
+      c->set_Mean_roz_Fraction( Mean_roz.second );
+      std::pair< unsigned int, unsigned int > Sigma_z = sigma_Coordinate( c->w(), c->wz2(), c->wz() );
+      c->set_Sigma_z_Quotient( Sigma_z.first );
+      c->set_Sigma_z_Fraction( Sigma_z.second );
+      std::pair< unsigned int, unsigned int > Sigma_phi = sigma_Coordinate( c->w(), c->wphi2(), c->wphi() );
+      c->set_Sigma_phi_Quotient( Sigma_phi.first );
+      c->set_Sigma_phi_Fraction( Sigma_phi.second );
+      std::pair< unsigned int, unsigned int > Sigma_eta = sigma_Coordinate( c->w(), c->weta2(), c->weta() );
+      c->set_Sigma_eta_Quotient( Sigma_eta.first );
+      c->set_Sigma_eta_Fraction( Sigma_eta.second );
+      std::pair< unsigned int, unsigned int > Sigma_roz = sigma_Coordinate( c->w(), c->wroz2(), c->wroz() );
+      c->set_Sigma_roz_Quotient( Sigma_roz.first );
+      c->set_Sigma_roz_Fraction( Sigma_roz.second );
+      std::vector<int> layeroutput = showerLengthProperties( c->layerbits() ); 
+      c->set_FirstLayer( layeroutput[0] );
+      c->set_LastLayer( layeroutput[1] );
+      c->set_ShowerLen( layeroutput[2] );
+      c->set_CoreShowerLen( layeroutput[3] );
+      std::pair< unsigned int, unsigned int > E_EM_over_E = energy_ratio( c->e_em() , c->e() ); 
+      c->set_E_EM_over_E_Quotient( E_EM_over_E.first );
+      c->set_E_EM_over_E_Fraction( E_EM_over_E.second );
+      std::pair< unsigned int, unsigned int > E_EM_core_over_E_EM = energy_ratio( c->e_em_core() , c->e() );
+      c->set_E_EM_core_over_E_EM_Quotient( E_EM_core_over_E_EM.first );
+      c->set_E_EM_core_over_E_EM_Fraction( E_EM_core_over_E_EM.second );
+      std::pair< unsigned int, unsigned int > E_H_early_over_E =  energy_ratio( c->e_h_early() , c->e() );
+      c->set_E_H_early_over_E_Quotient( E_H_early_over_E.first );
+      c->set_E_H_early_over_E_Fraction( E_H_early_over_E.second );
+
+
+      std::cout << c->clock() << " " << c->index() << " " << c->n_tc() << " " << c->e() << " " << c->e_em() << " " << c->e_em_core() << " " << c->e_h_early() << " N "<< c->Sigma_E_Quotient()<< " " <<c->Sigma_E_Fraction() << " " << c->Mean_z_Quotient() << " " << c->Mean_z_Fraction() << " " << c->Mean_phi_Quotient() << " "<< c->Mean_phi_Fraction() << " " << c->Mean_eta_Quotient() << " " << c->Mean_eta_Fraction() << " " << c->Mean_roz_Quotient() << " " << c->Mean_roz_Fraction() <<  " "<< c->Sigma_z_Quotient() << " "<< c->Sigma_z_Fraction() << " "<< c->Sigma_phi_Quotient() << " " << c-> Sigma_phi_Fraction() << " " << c->Sigma_eta_Quotient() << " " << c->Sigma_eta_Fraction() << " " << c->Sigma_roz_Quotient() << " "<< c->Sigma_roz_Fraction() << " "<< c->FirstLayer() <<" "<< c->LastLayer() << " "<< c->ShowerLen() << " " << c->CoreShowerLen() << " "<< c->E_EM_over_E_Quotient() << " " << c->E_EM_over_E_Fraction() << " " << c->E_EM_core_over_E_EM_Quotient() << " "<< c->E_EM_core_over_E_EM_Fraction() << " " << c->E_H_early_over_E_Quotient() << " " << c->E_H_early_over_E_Fraction() << std::endl;
+      nTCs += c->n_tc();
+   }
+   std::cout << nTCs << std::endl;
+}
 
 void HGCalHistoClusteringImplSA::initializeTriggerCellDistGrid( HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const {
   for (unsigned int iX = 0; iX < nX; ++iX ) {
@@ -681,3 +803,5 @@ void HGCalHistoClusteringImplSA::runDistServers( const HGCalTriggerCellSAPtrColl
     }
   }
 }
+
+

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -378,7 +378,29 @@ void HGCalHistoClusteringImplSA::clusterizer( HGCalTriggerCellSAPtrCollection& t
       bool compareEPlus = (i<17) ? ( lastLatched[i]->energy() >= lastLatched[i+1]->energy() ) : false; // Magic numbers
 
       if ( lastLatched[i]->dataValid() ) {
-        if ( ( !lastLatched[i+1]->dataValid() || compareEPlus || deltaPlus ) && ( !lastLatched[i-1]->dataValid() || compareEMinus || deltaMinus ) ) {
+        // Similar out of bounds issue here
+        // if ( ( !lastLatched[i+1]->dataValid() || compareEPlus || deltaPlus ) && ( !lastLatched[i-1]->dataValid() || compareEMinus || deltaMinus ) ) {
+
+        bool accept = true;
+        if ( lastLatched.size() > i+1 ) {
+          if ( !lastLatched[i+1]->dataValid() || compareEPlus || deltaPlus ) {
+            accept = true;
+          }
+          else {
+            accept = false;
+          }
+        }
+
+        if ( i > 0 ) {
+          if ( !lastLatched[i-1]->dataValid() || compareEMinus || deltaMinus  ) {
+            accept = true;
+          }
+          else {
+            accept = false;
+          }
+        }
+
+        if ( accept ) {
           accepted[i] = latched[i];
           latched[i] = make_shared<CentroidHelper>();
           --seedCounter;

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -12,7 +12,7 @@ using namespace std;
 using namespace l1thgcfirmware;
 HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA( ClusterAlgoConfig& config ) : config_(config) {}
 
-void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags ) const {
+void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags, HGCalClusterSAPtrCollection& clusterSums ) const {
   cout << "Running the algorithm" << endl;
 
   HGCalTriggerCellSAPtrCollection triggerCellsIn = triggerCellInput( inputs );
@@ -43,8 +43,7 @@ void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& 
 
   // Cluster properties
   HGCalClusterSAPtrCollection protoClusters = triggerCellToCluster( clusteredTCs );
-  l1thgcfirmware::HGCalClusterSAPtrCollection clusterAccumulation;
-  l1thgcfirmware::HGCalClusterSAPtrCollection clusterSums;
+  HGCalClusterSAPtrCollection clusterAccumulation;
   clusterSum( protoClusters, readoutFlags, clusterAccumulation, clusterSums );
 
 }
@@ -528,8 +527,8 @@ HGCalClusterSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToCluster( HG
       continue;
     }
 
-    unsigned int s_TC_W = ( int( tc->energy() / 4 ) == 0 ) ? 1 : tc->energy() / 4;
-    unsigned int s_TC_Z = config_.depth( tc->layer() );
+    unsigned long int s_TC_W = ( int( tc->energy() / 4 ) == 0 ) ? 1 : tc->energy() / 4;
+    unsigned long int s_TC_Z = config_.depth( tc->layer() );
 
     unsigned int triggerLayer = config_.triggerLayer( tc->layer() );
     unsigned int s_E_EM = ( (  ( (unsigned long int) tc->energy() * config_.layerWeight_E_EM( triggerLayer ) ) + config_.correction() ) >> 18 );
@@ -563,7 +562,7 @@ HGCalClusterSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToCluster( HG
     cluster->set_wphi2( s_TC_W * tc->phi() * tc->phi() );
     cluster->set_wroz2( s_TC_W * tc->rOverZ() * tc->rOverZ() );
 
-    cluster->set_layerbits( cluster->layerbits() | ( 1 << ( 36 - triggerLayer ) ) ); // Magic numbers
+    cluster->set_layerbits( cluster->layerbits() | ( ( (unsigned long int) 1) << ( 36 - triggerLayer ) ) ); // Magic numbers
     cluster->set_sat_tc( cluster->e() == config_.saturation() || cluster->e_em() == config_.saturation() );
     cluster->set_shapeq(1);
 
@@ -574,7 +573,7 @@ HGCalClusterSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToCluster( HG
   // std::cout << "Protoclusters : " << protoClusters.size() << std::endl;
   // for ( const auto& pclus : protoClusters ) {
 
-  //     std::cout << pclus->clock() << " " << pclus->index() << " " << pclus->n_tc() << " " << pclus->e() << " " << pclus->e_em() << " " << pclus->e_em_core() << " " << pclus->e_h_early() << " " << pclus->w() << " " << pclus->n_tc_w() << " " << pclus->w2() << std::endl;
+  //     std::cout << pclus->clock() << " " << pclus->index() << " " << pclus->n_tc() << " " << pclus->e() << " " << pclus->e_em() << " " << pclus->e_em_core() << " " << pclus->e_h_early() << " " << pclus->w() << " " << pclus->n_tc_w() << " " << pclus->weta2() << " " << pclus->wphi2() << std::endl;
   // }
   return protoClusters;
 }

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -731,8 +731,9 @@ std::vector<int> HGCalHistoClusteringImplSA::showerLengthProperties(unsigned lon
 
 void HGCalHistoClusteringImplSA::clusterProperties(  HGCalClusterSAPtrCollection& clusterSums ) const {
    unsigned int nTCs = 0;
-   std::cout << "Cluster Prop" << std::endl;
+  //  std::cout << "Cluster Prop" << std::endl;
    for ( const auto& c : clusterSums ) {
+     if ( c->n_tc_w() == 0 ) continue;
       std::pair< unsigned int, unsigned int > sigmaEnergy = sigma_Energy( c->n_tc_w(), c->w2(), c->w() );
       c->set_Sigma_E_Quotient( sigmaEnergy.first );
       c->set_Sigma_E_Fraction( sigmaEnergy.second );
@@ -776,10 +777,10 @@ void HGCalHistoClusteringImplSA::clusterProperties(  HGCalClusterSAPtrCollection
       c->set_E_H_early_over_E_Fraction( E_H_early_over_E.second );
 
 
-      std::cout << c->clock() << " " << c->index() << " " << c->n_tc() << " " << c->e() << " " << c->e_em() << " " << c->e_em_core() << " " << c->e_h_early() << " N "<< c->Sigma_E_Quotient()<< " " <<c->Sigma_E_Fraction() << " " << c->Mean_z_Quotient() << " " << c->Mean_z_Fraction() << " " << c->Mean_phi_Quotient() << " "<< c->Mean_phi_Fraction() << " " << c->Mean_eta_Quotient() << " " << c->Mean_eta_Fraction() << " " << c->Mean_roz_Quotient() << " " << c->Mean_roz_Fraction() <<  " "<< c->Sigma_z_Quotient() << " "<< c->Sigma_z_Fraction() << " "<< c->Sigma_phi_Quotient() << " " << c-> Sigma_phi_Fraction() << " " << c->Sigma_eta_Quotient() << " " << c->Sigma_eta_Fraction() << " " << c->Sigma_roz_Quotient() << " "<< c->Sigma_roz_Fraction() << " "<< c->FirstLayer() <<" "<< c->LastLayer() << " "<< c->ShowerLen() << " " << c->CoreShowerLen() << " "<< c->E_EM_over_E_Quotient() << " " << c->E_EM_over_E_Fraction() << " " << c->E_EM_core_over_E_EM_Quotient() << " "<< c->E_EM_core_over_E_EM_Fraction() << " " << c->E_H_early_over_E_Quotient() << " " << c->E_H_early_over_E_Fraction() << std::endl;
+      // std::cout << c->clock() << " " << c->index() << " " << c->n_tc() << " " << c->e() << " " << c->e_em() << " " << c->e_em_core() << " " << c->e_h_early() << " N "<< c->Sigma_E_Quotient()<< " " <<c->Sigma_E_Fraction() << " " << c->Mean_z_Quotient() << " " << c->Mean_z_Fraction() << " " << c->Mean_phi_Quotient() << " "<< c->Mean_phi_Fraction() << " " << c->Mean_eta_Quotient() << " " << c->Mean_eta_Fraction() << " " << c->Mean_roz_Quotient() << " " << c->Mean_roz_Fraction() <<  " "<< c->Sigma_z_Quotient() << " "<< c->Sigma_z_Fraction() << " "<< c->Sigma_phi_Quotient() << " " << c-> Sigma_phi_Fraction() << " " << c->Sigma_eta_Quotient() << " " << c->Sigma_eta_Fraction() << " " << c->Sigma_roz_Quotient() << " "<< c->Sigma_roz_Fraction() << " "<< c->FirstLayer() <<" "<< c->LastLayer() << " "<< c->ShowerLen() << " " << c->CoreShowerLen() << " "<< c->E_EM_over_E_Quotient() << " " << c->E_EM_over_E_Fraction() << " " << c->E_EM_core_over_E_EM_Quotient() << " "<< c->E_EM_core_over_E_EM_Fraction() << " " << c->E_H_early_over_E_Quotient() << " " << c->E_H_early_over_E_Fraction() << std::endl;
       nTCs += c->n_tc();
    }
-   std::cout << nTCs << std::endl;
+  //  std::cout << nTCs << std::endl;
 }
 
 void HGCalHistoClusteringImplSA::initializeTriggerCellDistGrid( HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const {

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -14,7 +14,7 @@ using namespace l1thgcfirmware;
 HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA( ClusterAlgoConfig& config ) : config_(config) {}
 
 void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags, HGCalClusterSAPtrCollection& clusterSums ) const {
-  cout << "Running the algorithm" << endl;
+  config_.printConfiguration();
 
   HGCalTriggerCellSAPtrCollection triggerCellsIn = triggerCellInput( inputs );
 
@@ -180,7 +180,7 @@ HGCalHistogramCellSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToHisto
                                                tc->phi(),
                                                tc->rOverZ(),
                                                1,
-                                               int( ( tc->rOverZ() - 440 )/ 64 ) // Magic numbers 
+                                               int( ( tc->rOverZ() - config_.rOverZHistOffset() )/ config_.rOverZBinSize() ) // Magic numbers 
                                               );
     tc->setClock( hc->clock() );
     tc->setSortKey( hc->sortKey() );
@@ -445,7 +445,7 @@ void HGCalHistoClusteringImplSA::clusterizer( HGCalTriggerCellSAPtrCollection& t
               int dR = r1 - r2;
               int dPhi = tc->phi() - a->X();
               unsigned int dR2 = dR * dR;
-              unsigned int cosTerm = ( abs(dPhi) > 77 ) ? 2047 : config_.cosLUT( abs(dPhi) ); // Magic numbers
+              unsigned int cosTerm = ( abs(dPhi) > config_.nBinsCosLUT() ) ? 2047 : config_.cosLUT( abs(dPhi) ); // Magic numbers
               dR2 += int( r1 * r2 / pow(2,7) ) * cosTerm / pow(2,10); // Magic numbers
 
               tc->setClock( clock[iCol] + 1 );

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -1,0 +1,618 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistoClusteringImpl_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/DistServer.h"
+#include "L1Trigger/L1THGCal/interface/backend_emulator/CentroidHelper.h"
+
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+using namespace std;
+using namespace l1thgcfirmware;
+HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA( ClusterAlgoConfig& config ) : config_(config) {}
+
+void HGCalHistoClusteringImplSA::runAlgorithm(HGCalTriggerCellSAPtrCollections& inputs, HGCalTriggerCellSAPtrCollection& clusteredTCs, HGCalTriggerCellSAPtrCollection& unclusteredTCs, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlags ) const {
+  cout << "Running the algorithm" << endl;
+
+  HGCalTriggerCellSAPtrCollection triggerCellsIn = triggerCellInput( inputs );
+
+  // TC Distribution
+  triggerCellDistribution0( triggerCellsIn );
+  HGCalTriggerCellSAPtrCollections tcDistGrid1 = triggerCellDistribution1( triggerCellsIn );
+  HGCalTriggerCellSAPtrCollections tcDistGrid2 = triggerCellDistribution2( triggerCellsIn, tcDistGrid1 );
+  HGCalTriggerCellSAPtrCollections tcDistGrid3 = triggerCellDistribution3( triggerCellsIn, tcDistGrid2 );
+  triggerCellDistribution4( triggerCellsIn );
+  triggerCellDistribution5( triggerCellsIn, tcDistGrid3 );
+
+  // Histogram
+  HGCalHistogramCellSAPtrCollection histoCells = triggerCellToHistogramCell( triggerCellsIn );
+  HGCalHistogramCellSAPtrCollection histogram = makeHistogram( histoCells );
+
+  // Smearing
+  smearing1D( histogram );
+  areaNormalization( histogram );
+  smearing2D( histogram );
+
+  //Maxima finding
+  thresholdMaximaFinder( histogram );
+  calculateAveragePosition( histogram );
+
+  // Clustering
+  clusterizer( triggerCellsIn, histogram, clusteredTCs, unclusteredTCs, prioritizedMaxima, readoutFlags );
+  
+  // HGCalClusterSAPtrCollection clusters = triggerCellToCluster( clusteredTriggerCells );
+}
+
+HGCalTriggerCellSAPtrCollection HGCalHistoClusteringImplSA::triggerCellInput( HGCalTriggerCellSAPtrCollections& inputs ) const {
+
+  HGCalTriggerCellSAPtrCollection triggerCellsIn;
+  for (unsigned int iFrame = 0; iFrame < inputs.size(); ++iFrame ) {
+    for (unsigned int iInput = 0; iInput < inputs[iFrame].size(); ++iInput ) {
+      auto& tc = inputs[iFrame][iInput];
+      tc->setIndex(iInput);
+      tc->setClock(iFrame+1);
+      if ( tc->dataValid() ) {
+        triggerCellsIn.push_back(tc);
+      }
+    }
+  }
+  return triggerCellsIn;
+}
+
+void HGCalHistoClusteringImplSA::triggerCellDistribution0( HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const {
+  for ( auto& tc : triggerCellsIn ) {
+    unsigned int newIndex = tc->index() + int( tc->index() / 24 ); // Magic numbers
+    tc->setIndex( newIndex );
+  }
+}
+
+HGCalTriggerCellSAPtrCollections HGCalHistoClusteringImplSA::triggerCellDistribution1( HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const {
+
+  HGCalTriggerCellSAPtrCollections triggerCellDistributionGrid;
+  initializeTriggerCellDistGrid( triggerCellDistributionGrid, config_.cClocks(), config_.cInputs2() );
+
+  const unsigned int stepLatency = config_.getStepLatency( Dist1 );
+  for ( auto& tc : triggerCellsIn ) {
+    tc->addLatency( stepLatency );
+    unsigned int sector = int( tc->index() / 25 ); // Magic numbers
+    triggerCellDistributionGrid[tc->clock()-2][tc->index()] = tc; // Magic numbers
+    for ( int iSortKey = 5; iSortKey >= 0; --iSortKey ) { // Magic numbers
+      // Split each 60 degree sector into 6 phi region
+      // Sort key is index of small phi region
+      if ( int( tc->phi() % 1944 ) > int( 108 * iSortKey + 648 * sector ) ) { // Magic numbers
+        tc->setSortKey( iSortKey );
+        break;
+      }
+    }
+  }
+
+  return triggerCellDistributionGrid;
+}
+
+HGCalTriggerCellSAPtrCollections HGCalHistoClusteringImplSA::triggerCellDistribution2( HGCalTriggerCellSAPtrCollection& triggerCellsIn, HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const {
+
+  const unsigned int latency = config_.getLatencyUpToAndIncluding( Dist2 );
+
+  HGCalTriggerCellSAPtrCollection triggerCells;
+  HGCalTriggerCellSAPtrCollections triggerCellDistributionGrid;
+  initializeTriggerCellDistGrid( triggerCellDistributionGrid, config_.cClocks(), config_.cInt() );
+
+  runDistServers(inTriggerCellDistributionGrid,
+                  triggerCellDistributionGrid,
+                  triggerCells,
+                  latency,
+                  15, 5, 6, 4, true); // Magic numbers
+
+  triggerCellsIn = triggerCells;
+  return triggerCellDistributionGrid;
+}
+
+HGCalTriggerCellSAPtrCollections HGCalHistoClusteringImplSA::triggerCellDistribution3( HGCalTriggerCellSAPtrCollection& triggerCellsIn, HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const {
+  HGCalTriggerCellSAPtrCollection triggerCells;
+  HGCalTriggerCellSAPtrCollections triggerCellDistributionGrid;
+  initializeTriggerCellDistGrid( triggerCellDistributionGrid, config_.cClocks(), config_.cInt() );
+  for ( unsigned int iClock = 0; iClock < config_.cClocks(); ++iClock ) {
+    for ( unsigned int i = 0; i < 3; ++i ) { // Magic numbers
+      for ( unsigned int k = 0; k < 6; ++k ) { // Magic numbers
+        for ( unsigned int j = 0; j < 5; ++j ) { // Magic numbers
+          auto& tc = inTriggerCellDistributionGrid[iClock][ 30*i + 6*j + k ]; // Magic numbers
+          if ( tc->dataValid() ) {
+              tc->setIndex( (30*i) + (5*k) + j ); // Magic numbers
+              triggerCells.push_back( tc );
+              triggerCellDistributionGrid[iClock-2][tc->index()] = tc;
+          }
+        }
+      }
+    }
+  }
+  triggerCellsIn = triggerCells;
+
+  return triggerCellDistributionGrid;
+}
+
+void HGCalHistoClusteringImplSA::triggerCellDistribution4( HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const {
+  const unsigned int stepLatency = config_.getStepLatency( Dist4 );
+  for ( auto& lCell : triggerCellsIn ) {
+    lCell->addLatency( stepLatency );
+    unsigned int sector = int( lCell->index() / 5 ); // Magic numbers
+    for ( int iSortKey = 5; iSortKey >= 0; --iSortKey ) {  // Magic numbers
+      if ( int(lCell->phi() % 1944) > int( ( 18 * iSortKey ) + ( 108 * sector ) ) ) { // Magic numbers
+        lCell->setSortKey(iSortKey);
+        break;
+      }
+    }
+  }
+}
+
+void HGCalHistoClusteringImplSA::triggerCellDistribution5( HGCalTriggerCellSAPtrCollection& triggerCellsIn, HGCalTriggerCellSAPtrCollections& inTriggerCellDistributionGrid ) const {
+  const unsigned int latency = config_.getLatencyUpToAndIncluding( Dist5 );
+
+  HGCalTriggerCellSAPtrCollection triggerCells;
+  // Dummy distribution grid?  After writing the runDistServers function to avoid duplicating identical code from triggerCellDistribution2, I realised the second possible use case of runDistServers isn't completely identical i.e. the triggerCellDistributionGrid isn't used/set
+  HGCalTriggerCellSAPtrCollections triggerCellDistributionGrid;
+  initializeTriggerCellDistGrid( triggerCellDistributionGrid, 1, 1 );
+
+  runDistServers(inTriggerCellDistributionGrid,
+                  triggerCellDistributionGrid,
+                  triggerCells,
+                  latency,
+                  18, 5, 6, 4, false); // Magic numbers
+
+  triggerCellsIn = triggerCells;
+}
+
+HGCalHistogramCellSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToHistogramCell( HGCalTriggerCellSAPtrCollection& triggerCellsIn ) const {
+
+  const unsigned int latency = config_.getStepLatency( TcToHc );
+
+  HGCalHistogramCellSAPtrCollection histoCells;
+  for ( auto& tc : triggerCellsIn ) {
+    auto hc = make_shared<HGCalHistogramCell>( tc->clock() + latency,
+                                               tc->index(),
+                                               tc->energy(),
+                                               tc->phi(),
+                                               tc->rOverZ(),
+                                               1,
+                                               int( ( tc->rOverZ() - 440 )/ 64 ) // Magic numbers 
+                                              );
+    tc->setClock( hc->clock() );
+    tc->setSortKey( hc->sortKey() );
+    histoCells.push_back( hc );
+  }
+
+  return histoCells;
+}
+
+HGCalHistogramCellSAPtrCollection HGCalHistoClusteringImplSA::makeHistogram( HGCalHistogramCellSAPtrCollection histogramCells ) const {
+
+  HGCalHistogramCellSAPtrCollection histogram;
+  const unsigned int latency = config_.getLatencyUpToAndIncluding( Hist );
+  for ( unsigned int iRow = 0; iRow < config_.cRows(); ++iRow ) {
+    for ( unsigned int iColumn = 0; iColumn < config_.cColumns(); ++iColumn ) {
+
+      auto hc = make_shared<HGCalHistogramCell>( latency, iColumn, iRow );
+      histogram.push_back( hc );
+    }
+  }
+
+  for ( const auto& hc : histogramCells ) {
+    const unsigned int binIndex = config_.cColumns() * hc->sortKey() + hc->index() ;
+    *histogram.at( binIndex ) += *hc;
+  }
+
+  return histogram;
+
+}
+
+void HGCalHistoClusteringImplSA::smearing1D( HGCalHistogramCellSAPtrCollection& histogram ) const {
+
+  HGCalHistogramCellSACollection lHistogram;
+  for ( unsigned int iBin = 0; iBin < histogram.size(); ++iBin ) {
+    lHistogram.emplace_back( *histogram.at(iBin) );
+  }
+
+  const unsigned int stepLatency = config_.getStepLatency( Step::Smearing1D );
+  for ( unsigned int iBin = 0; iBin < lHistogram.size(); ++iBin ) {
+    auto& hc = histogram.at(iBin);
+    hc->addLatency( stepLatency );
+
+    const unsigned int col = hc->index();
+    const unsigned int row = hc->sortKey();
+    const unsigned int binIndex = config_.cColumns() * row + col;
+    unsigned int scale = 1;
+    int width = config_.kernelWidth( row );
+    unsigned int offset = 1;
+    while ( width > 0 ) {
+      shared_ptr<HGCalHistogramCell> l1 = make_shared<HGCalHistogramCell>(HGCalHistogramCell());
+      shared_ptr<HGCalHistogramCell> l2 = make_shared<HGCalHistogramCell>(HGCalHistogramCell());
+      shared_ptr<HGCalHistogramCell> r1 = make_shared<HGCalHistogramCell>(HGCalHistogramCell());
+      shared_ptr<HGCalHistogramCell> r2 = make_shared<HGCalHistogramCell>(HGCalHistogramCell());
+
+
+      if ( width >= 2 ) {
+        if ( int(col - offset - 1)  >= 0 ) {
+          l2 = make_shared<HGCalHistogramCell>(lHistogram[binIndex - offset - 1]/4); // Magic numbers (?)
+        }
+        if ( int(col + offset + 1) <= int(config_.cColumns()-1) ) {
+          r2 = make_shared<HGCalHistogramCell>(lHistogram[binIndex + offset + 1]/4); // Magic numbers (?)
+        }
+      }
+      
+      if ( int(col - offset)  >= 0 ) {
+        l1 = make_shared<HGCalHistogramCell>(lHistogram[binIndex - offset]/2); // Magic numbers (?)
+      }
+      if ( int(col + offset)  <= int(config_.cColumns()-1) ) {
+        r1 = make_shared<HGCalHistogramCell>(lHistogram[binIndex + offset]/2); // Magic numbers (?)
+      }
+      *hc += ( ( *l2 + *l1 ) / scale + ( *r2 + *r1 ) / scale );
+      scale *= 4; // Magic numbers
+      width -= 2; // Magic numbers
+      offset += 2; // Magic numbers
+    }
+  }
+}
+
+void HGCalHistoClusteringImplSA::areaNormalization( HGCalHistogramCellSAPtrCollection& histogram ) const {
+  const unsigned int stepLatency = config_.getStepLatency( NormArea );
+  for ( unsigned int iBin = 0; iBin < histogram.size(); ++iBin ) {
+    HGCalHistogramCell& hc = *histogram.at(iBin);
+    hc.addLatency( stepLatency );
+    hc *= config_.areaNormalization(hc.sortKey());
+  }
+}
+
+void HGCalHistoClusteringImplSA::smearing2D( HGCalHistogramCellSAPtrCollection& histogram ) const {
+  HGCalHistogramCellSACollection lHistogram;
+  for ( unsigned int iBin = 0; iBin < histogram.size(); ++iBin ) {
+    lHistogram.emplace_back( *histogram.at(iBin) );
+  }
+  const unsigned int stepLatency = config_.getStepLatency( Step::Smearing2D );
+  for ( unsigned int iBin = 0; iBin < lHistogram.size(); ++iBin ) {
+    auto& hc = histogram.at(iBin);
+    hc->addLatency( stepLatency );
+
+    const unsigned int col = hc->index();
+    const int row = hc->sortKey();
+    const unsigned int binIndex = config_.cColumns() * row + col;
+    if ( row - 1 >= 0 ) {
+      *hc += (lHistogram[binIndex - config_.cColumns()] / 2 ); // Magic numbers (?)
+    }
+    if ( row + 1 <= int(config_.cRows()-1) ) {
+      *hc += (lHistogram[binIndex + config_.cColumns()] / 2 ); // Magic numbers (?)
+    }
+  }
+}
+
+void HGCalHistoClusteringImplSA::thresholdMaximaFinder( HGCalHistogramCellSAPtrCollection& histogram ) const {
+  const unsigned int stepLatency = config_.getStepLatency( Maxima2D );
+  for ( auto& hc : histogram ) {
+    hc->addLatency( stepLatency );
+    if ( hc->S() <= config_.thresholdMaxima( hc->sortKey() ) ) {
+      hc->setS(0);
+      hc->setX(0);
+      hc->setY(0);
+      hc->setN(0);
+    }
+  }
+}
+
+void HGCalHistoClusteringImplSA::calculateAveragePosition( HGCalHistogramCellSAPtrCollection& histogram ) const {
+  const unsigned int stepLatency = config_.getStepLatency( CalcAverage );
+  for ( auto& hc : histogram ) {
+    hc->addLatency( stepLatency );
+    if ( hc->N() > 0 ) {
+      unsigned int inv_N = int( round(1.0 * 0x1FFFF / hc->N() ) ); // Magic numbers
+      hc->setX( ( hc->X() * inv_N ) >> 17 ); //Magic numbers
+      hc->setY( ( hc->Y() * inv_N ) >> 17 ); //Magic numbers
+    }
+  }
+}
+
+void HGCalHistoClusteringImplSA::clusterizer( HGCalTriggerCellSAPtrCollection& triggerCellsIn, HGCalHistogramCellSAPtrCollection& histogram, HGCalTriggerCellSAPtrCollection& clusteredTriggerCellsOut, HGCalTriggerCellSAPtrCollection& unclusteredTriggerCellsOut, CentroidHelperPtrCollection& prioritizedMaxima, CentroidHelperPtrCollection& readoutFlagsOut ) const {
+  
+  unsigned int seedCounter = 0;
+  vector< CentroidHelperPtrCollection > fifos( 18, CentroidHelperPtrCollection() ); // Magic numbers
+  vector<unsigned int> clock( config_.cColumns(), config_.clusterizerMagicTime() );
+  CentroidHelperPtrCollection latched( 18+1, make_shared<CentroidHelper>() ); // Magic numbers
+
+  HGCalTriggerCellSAPtrCollections clusteredTriggerCells( config_.cColumns(), HGCalTriggerCellSAPtrCollection() );
+  HGCalTriggerCellSAPtrCollections unclusteredTriggerCells( config_.cColumns(), HGCalTriggerCellSAPtrCollection() );
+  CentroidHelperPtrCollections readoutFlags( config_.cColumns(), CentroidHelperPtrCollection() );
+
+  HGCalTriggerCellSAPtrCollectionss triggerCellBuffers( config_.cColumns(), HGCalTriggerCellSAPtrCollections( config_.cRows(), HGCalTriggerCellSAPtrCollection() ) );
+  for (const auto& tc : triggerCellsIn ) {
+    triggerCellBuffers.at( tc->index() ).at( tc->sortKey() ).push_back( tc );
+  }
+
+  for ( unsigned int iRow = 0; iRow < config_.cRows(); ++iRow ) {
+    for ( unsigned int j = 0; j < 4; ++j ) { // Magic numbers
+      for ( unsigned int k = 0; k < 18; ++k ) { // Magic numbers
+        unsigned int col = 18 + (4*k) + j; // Magic numbers
+        const auto& cell = histogram.at( config_.cColumns() * iRow + col );
+        if ( cell->S() > 0 ) {
+          auto ch = make_shared<CentroidHelper>( cell->clock() + 1 + j,
+                                                4*k + j, // Magic numbers
+                                                cell->index(),
+                                                cell->sortKey(),
+                                                cell->S(),
+                                                cell->X(),
+                                                cell->Y(),
+                                                true
+                                                );
+          fifos[k].push_back( ch );
+          ++seedCounter;
+        }
+      }
+    }
+  }
+
+  while ( seedCounter > 0 ) {
+    for ( unsigned int i = 0; i < 18; ++i ) { // Magic numbers
+      if ( !latched[i]->dataValid() ) {
+        if ( fifos[i].size() > 0 ) {
+          latched[i] = fifos[i][0];
+          fifos[i].erase(fifos.at(i).begin());
+        }
+      }
+    }
+
+    CentroidHelperPtrCollection accepted( 20, make_shared<CentroidHelper>() ); // Magic numbers
+    CentroidHelperPtrCollection lastLatched( latched );
+
+    for ( unsigned int i = 0; i < 18; ++i ) { // Magic numbers
+      // Different implementation to python emulator
+      // For i=0, i-1=-1, which would give the last element of lastLatched in python, but is out of bounds in C++
+      // Similar for i=17
+      // Need to find out intended behaviour
+      bool deltaMinus = (i>0) ? ( lastLatched[i]->column() - lastLatched[i-1]->column() ) > 6 : false ; // Magic numbers
+      bool deltaPlus = (i<17) ? ( lastLatched[i+1]->column() - lastLatched[i]->column() ) > 6 : false ; // Magic numbers
+
+      bool compareEMinus = (i>0) ? ( lastLatched[i]->energy() > lastLatched[i-1]->energy() ) : false; // Magic numbers
+      bool compareEPlus = (i<17) ? ( lastLatched[i]->energy() >= lastLatched[i+1]->energy() ) : false; // Magic numbers
+
+      if ( lastLatched[i]->dataValid() ) {
+        if ( ( !lastLatched[i+1]->dataValid() || compareEPlus || deltaPlus ) && ( !lastLatched[i-1]->dataValid() || compareEMinus || deltaMinus ) ) {
+          accepted[i] = latched[i];
+          latched[i] = make_shared<CentroidHelper>();
+          --seedCounter;
+        }
+      }
+    }
+
+    CentroidHelperPtrCollection output( config_.cColumns(), make_shared<CentroidHelper>() );
+    for ( const auto& a : accepted ) {
+      if ( a->dataValid() ) {
+        for ( unsigned int iCol = a->column() - 3; iCol < a->column() + 4; ++iCol ) { // Magic numbers
+          clock[iCol] = clock[a->column()];
+          output[iCol] = a;
+          output[iCol]->setIndex( iCol );
+          output[iCol]->setClock( clock[iCol] );
+          prioritizedMaxima.push_back( output[iCol] );
+        }
+      }
+    }
+
+    for ( const auto& a : accepted ) {
+      if ( a->dataValid() ) {
+        unsigned int dR2Cut = 20000; // Magic numbers
+        unsigned int T=0; // Magic numbers
+
+        for ( unsigned int iCol = a->column() - 3; iCol < a->column() + 4; ++iCol ) { // Magic numbers
+          clock[ iCol ] += 8; // Magic numbers
+          for ( int k = -2; k < 3; ++k ) { // Magic numbers
+            int row = a->row() + k;
+            if ( row < 0 ) continue;
+
+            if ( triggerCellBuffers[iCol][row].size() == 0 ) {
+              clock[iCol] += 1 ;
+              continue;
+            }
+
+            for ( auto& tc : triggerCellBuffers[iCol][row] ) {
+              clock[iCol] += 1 ;
+
+              unsigned int r1 = tc->rOverZ();
+              unsigned int r2 = a->Y();
+              int dR = r1 - r2;
+              int dPhi = tc->phi() - a->X();
+              unsigned int dR2 = dR * dR;
+              unsigned int cosTerm = ( abs(dPhi) > 77 ) ? 2047 : config_.cosLUT( abs(dPhi) ); // Magic numbers
+              dR2 += int( r1 * r2 / pow(2,7) ) * cosTerm / pow(2,10); // Magic numbers
+
+              tc->setClock( clock[iCol] + 1 );
+              if ( clock[iCol] > T ) T = clock[iCol];
+
+              if ( dR2 < dR2Cut ) {
+                clusteredTriggerCells[iCol].push_back(tc);
+              }
+              else {
+                unclusteredTriggerCells[iCol].push_back(tc);
+              }
+            }
+          }
+
+          for ( const auto& tc : clusteredTriggerCells[iCol] ) {
+            auto tcMatch = std::find_if(triggerCellBuffers[iCol][tc->sortKey()].begin(), triggerCellBuffers[iCol][tc->sortKey()].end(), [&](const HGCalTriggerCellSAPtr tcToMatch) {
+              bool isMatch = tc->index() == tcToMatch->index() &&
+                             tc->rOverZ() == tcToMatch->rOverZ() &&
+                             tc->layer() == tcToMatch->layer() &&
+                             tc->energy() == tcToMatch->energy() &&
+                             tc->phi() == tcToMatch->phi() &&
+                             tc->sortKey() == tcToMatch->sortKey() &&
+                             tc->deltaR2() == tcToMatch->deltaR2() &&
+                             tc->dX() == tcToMatch->dX() &&
+                             tc->Y() == tcToMatch->Y() &&
+                             tc->frameValid() == tcToMatch->frameValid() &&
+                             tc->dataValid() == tcToMatch->dataValid() &&
+                             tc->clock() == tcToMatch->clock();
+              return isMatch;
+            });
+
+            if ( tcMatch != triggerCellBuffers[iCol][tc->sortKey()].end() ) {
+              triggerCellBuffers[iCol][tc->sortKey()].erase(tcMatch);
+            }
+          }
+        }
+
+        for ( unsigned int iCol = a->column() - 3; iCol < a->column() + 4; ++iCol ) { // Magic numbers
+          clock[iCol] = T+1;
+
+          CentroidHelperPtr readoutFlag = make_shared<CentroidHelper>(T-2, iCol, true);
+          if ( readoutFlag->clock() == 448 ) { // Magic numbers
+            readoutFlag->setClock( readoutFlag->clock() + 1 );
+          }
+
+          readoutFlags[iCol].push_back( readoutFlag );
+        }
+      }
+    }
+  }
+
+  for ( unsigned int i = 0; i <1000; ++i ) { // Magic numbers
+    for ( unsigned int iCol = 0; iCol < config_.cColumns(); ++iCol ) {
+      for ( const auto& clustered : clusteredTriggerCells[iCol] ) {
+        if ( clustered->clock() == config_.clusterizerMagicTime() + i ) {
+          clusteredTriggerCellsOut.push_back( clustered );
+        }
+      }
+
+      for ( const auto& unclustered : unclusteredTriggerCells[iCol] ) {
+        if ( unclustered->clock() == config_.clusterizerMagicTime() + i ) {
+          unclusteredTriggerCellsOut.push_back( unclustered );
+        }
+      }
+
+      for ( const auto& readoutFlag : readoutFlags[iCol] ) {
+        if ( readoutFlag->clock() == config_.clusterizerMagicTime() + i ) {
+          readoutFlagsOut.push_back( readoutFlag );
+        }
+      }
+    }
+  }
+
+  std::cout << "Output from Clusterizer" << std::endl;
+  std::cout << "Number of clustered TCs : " << clusteredTriggerCellsOut.size() << std::endl;
+  // for ( const auto& tc : clusteredTriggerCellsOut ) {
+  //   std::cout << tc->clock() << " " << tc->index() << " " << tc->rOverZ() << " " << tc->layer() << " " << tc->energy() << " " << tc->phi() << " " << tc->sortKey() << " " << tc->deltaR2() << " " << tc->dX() << " " << tc->Y() << " " << tc->dataValid() << std::endl;
+  // }
+  std::cout << "Number of unclustered TCs : " << unclusteredTriggerCellsOut.size() << std::endl;
+  std::cout << "Number of readoutFlags : " << readoutFlagsOut.size() << std::endl;
+  // for ( const auto& f : readoutFlagsOut ) {
+  //   std::cout << f->clock() << " " << f->index() << " " << f->column() << " " << f->row() << " " << f->energy() << " " << f->X() << " " << f->Y() << " " << f->dataValid() << std::endl;
+  // }
+}
+
+HGCalClusterSAPtrCollection HGCalHistoClusteringImplSA::triggerCellToCluster( HGCalTriggerCellSAPtrCollection& clusteredTriggerCells ) const {
+
+  const unsigned int stepLatency = config_.getStepLatency( TriggerCellToCluster );
+
+  HGCalClusterSAPtrCollection protoClusters;
+
+  for ( const auto& tc : clusteredTriggerCells ) {
+
+    auto cluster = make_shared<HGCalCluster>( tc->clock() + stepLatency,
+                                              tc->index(),
+                                              true, true
+                                            );
+
+    // Cluster from single TC
+    // Does this ever happen?
+    if ( tc->deltaR2() >= 25000 ) { // Magic numbers
+      protoClusters.push_back( cluster );
+      continue;
+    }
+
+    unsigned int s_TC_W = ( int( tc->energy() / 4 ) == 0 ) ? 1 : tc->energy() / 4;
+    unsigned int s_TC_Z = config_.depth( tc->layer() );
+
+    unsigned int triggerLayer = config_.triggerLayer( tc->layer() );
+
+    unsigned int s_E_EM = ( ( tc->energy() * config_.layerWeight_E_EM( triggerLayer ) + config_.correction() ) >> 18 );
+    if ( s_E_EM > config_.saturation() ) s_E_EM = config_.saturation();
+
+    unsigned int s_E_EM_core = ( ( tc->energy() * config_.layerWeight_E_EM_core( triggerLayer ) + config_.correction() ) >> 18 );
+    if ( s_E_EM_core > config_.saturation() ) s_E_EM_core = config_.saturation();
+
+    // Alternative constructor perhaps?
+    cluster->set_n_tc( 1 ); // Magic numbers
+    cluster->set_n_tc_w( 1 ); // Magic numbers
+    
+    cluster->set_e( ( config_.layerWeight_E( triggerLayer ) == 1 ) ? tc->energy() : 0  );
+    cluster->set_e_h_early( ( config_.layerWeight_E_H_early( triggerLayer ) == 1 ) ? tc->energy() : 0  );
+
+    cluster->set_e_em( s_E_EM );
+    cluster->set_e_em_core( s_E_EM_core );
+
+    cluster->set_w( s_TC_W );
+    cluster->set_w2( s_TC_W * s_TC_W );
+
+    cluster->set_wz( s_TC_W * s_TC_Z );
+    cluster->set_weta( 0 );
+    cluster->set_wphi( s_TC_W * tc->phi() );
+    cluster->set_wroz( s_TC_W * tc->rOverZ() );
+
+    cluster->set_wz2( s_TC_W * s_TC_Z * s_TC_Z );
+    cluster->set_weta2( 0 );
+    cluster->set_wphi2( s_TC_W * tc->phi() * tc->phi() );
+    cluster->set_wroz2( s_TC_W * tc->rOverZ() * tc->rOverZ() );
+
+    cluster->set_layerbits( cluster->layerbits() | ( 1 << ( 36 - triggerLayer ) ) ); // Magic numbers
+    cluster->set_sat_tc( cluster->e() == config_.saturation() || cluster->e_em() == config_.saturation() );
+    cluster->set_shapeq(1);
+
+    protoClusters.push_back( cluster );
+  }
+
+  // std::cout << "Output from triggerCellToCluster" << std::endl;
+  // std::cout << "Protoclusters : " << protoClusters.size() << std::endl;
+  // for ( const auto& pclus : protoClusters ) {
+  //     std::cout << pclus->clock() << " " << pclus->index() << " " << pclus->n_tc() << " " << pclus->e() << " " << pclus->e_h_early() << " " << pclus->e_em() << " " << pclus->e_em_core() << " " << pclus->wz2() << std::endl;
+  // }
+  return protoClusters;
+}
+
+
+void HGCalHistoClusteringImplSA::initializeTriggerCellDistGrid( HGCalTriggerCellSAPtrCollections& grid, unsigned int nX, unsigned int nY ) const {
+  for (unsigned int iX = 0; iX < nX; ++iX ) {
+    HGCalTriggerCellSAPtrCollection temp;
+    for (unsigned int iY = 0; iY < nY; ++iY ) {
+      temp.emplace_back(make_shared<HGCalTriggerCell>());
+    }
+    grid.push_back(temp);
+  }
+}
+
+void HGCalHistoClusteringImplSA::runDistServers( const HGCalTriggerCellSAPtrCollections& gridIn,
+                      HGCalTriggerCellSAPtrCollections& gridOut,
+                      HGCalTriggerCellSAPtrCollection& tcsOut,
+                      unsigned int latency,
+                      unsigned int nDistServers,
+                      unsigned int nInputs,
+                      unsigned int nOutputs,
+                      unsigned int nInterleave,
+                      bool setOutputGrid ) const {
+  vector< DistServer > distServers(nDistServers, DistServer(nInputs, nOutputs, nInterleave));
+
+  for ( unsigned int iClock = 0; iClock < config_.cClocks(); ++iClock ) {
+    for ( unsigned int iDistServer = 0; iDistServer < nDistServers; ++iDistServer ) {
+      auto first = gridIn[iClock].cbegin() + nInputs*iDistServer;
+      auto last = gridIn[iClock].cbegin() + nInputs*(iDistServer+1);
+      HGCalTriggerCellSAPtrCollection inCells(first, last);
+      HGCalTriggerCellSAPtrCollection lCells = distServers[iDistServer].clock(inCells);
+
+      for ( unsigned int iOutput = 0; iOutput<lCells.size(); ++iOutput ) {
+        auto& tc = lCells[iOutput];
+        if ( tc->dataValid() ){
+          tc->setIndex(nOutputs*iDistServer+iOutput);
+          tc->setClock(iClock+latency);
+
+          tcsOut.push_back(tc);
+          if ( setOutputGrid ) {
+            gridOut[iClock][tc->index()] = tc;
+          }
+        }
+      }
+    }
+  }
+}

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistoClusteringImpl_SA.cc
@@ -385,7 +385,7 @@ void HGCalHistoClusteringImplSA::clusterizer( HGCalTriggerCellSAPtrCollection& t
       if ( a->dataValid() ) {
         for ( unsigned int iCol = a->column() - 3; iCol < a->column() + 4; ++iCol ) { // Magic numbers
           clock[iCol] = clock[a->column()];
-          output[iCol] = a;
+          output[iCol] = make_shared<CentroidHelper>(*a);
           output[iCol]->setIndex( iCol );
           output[iCol]->setClock( clock[iCol] );
           prioritizedMaxima.push_back( output[iCol] );

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistogramCell_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalHistogramCell_SA.cc
@@ -1,0 +1,37 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalHistogramCell_SA.h"
+
+using namespace l1thgcfirmware;
+
+const HGCalHistogramCell& HGCalHistogramCell::operator+=(const HGCalHistogramCell& hc) {
+  S_ += hc.S();
+  X_ += hc.X();
+  Y_ += hc.Y();
+  N_ += hc.N();
+
+  return *this;
+}
+
+const HGCalHistogramCell HGCalHistogramCell::operator/(const unsigned int factor) const {
+  
+  HGCalHistogramCell hc(*this);
+
+  hc.S_ /= factor;
+  hc.X_ = 0;
+  hc.Y_ = 0;
+  hc.N_ = 0;
+  return hc;
+}
+
+const HGCalHistogramCell HGCalHistogramCell::operator+(const HGCalHistogramCell& hc) const {
+  
+  HGCalHistogramCell sum(*this);
+  sum += hc;
+  return sum;
+}
+
+const HGCalHistogramCell& HGCalHistogramCell::operator*=(const unsigned int factor) {
+  S_ = int( 1.0*S_ * factor / 262144 ); // Magic numbers
+
+  return *this;
+}
+

--- a/L1Trigger/L1THGCal/src/backend_emulator/HGCalTriggerCell_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend_emulator/HGCalTriggerCell_SA.cc
@@ -1,0 +1,14 @@
+#include "L1Trigger/L1THGCal/interface/backend_emulator/HGCalTriggerCell_SA.h"
+
+using namespace l1thgcfirmware;
+
+bool HGCalTriggerCell::operator==(const HGCalTriggerCell& rhs) const {
+  bool isEqual = ( this->index() == rhs.index() );
+  return isEqual;
+}
+
+bool HGCalTriggerCell::operator==(const std::shared_ptr<HGCalTriggerCell>& rhs) const {
+  bool isEqual = ( this->index() == rhs->index() );
+  return isEqual;
+}
+


### PR DESCRIPTION
This is a draft PR for including an emulation of the stage 2 clustering.

I have put the implementation of the algorithm under `L1THGCal/interface/backend_emulator` and `L1THGCal/src/backend_emulator`.  This is what we have been referring to as the C++ conversion of the python emulator that Andy uses to develop the firmware, and I had been developing standalone to CMSSW.

I modified the existing processor (`plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc`) and wrapper (`plugins/backend/HGCalHistoClusteringWrapper.cc`) to run the new emulation.  The distribution of the input trigger cells on the input links is currently an approximation of what's being assumed by the current stage 2 firmware, where I have combined and sorted in r/z the trigger cells from all stage 1 FPGAs within a 60 degree sector:

https://github.com/EmyrClement/cmssw/blob/S2ClusteringEmulatorIntegration/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc#L124-L130

Is it already possible to take the order of the trigger cells in r/z from the stage 1 emulation in CMSSW?

The outputs from the emulation are not yet converted back to CMSSW objects, as I am not sure how best to do this such that the cluster properties step has all the information it needs e.g. we may need to add extra variables to the CMSSW objects (e.g. a clock timestamp), and perhaps a new CMSSW class to store the additional output from the clustering step (readout flags and prioritized maxima):

https://github.com/EmyrClement/cmssw/blob/S2ClusteringEmulatorIntegration/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc#L124-L130

I have checked that the python and C++ emulators both give the same output on a few events when running standalone, and that the C++ emulation gives the same output when ran standalone and integrated into CMSSW, but only on one FPGA in one event.

Two other minor points:

- Constants are currently defined in the constructor of the configuration class, rather than in a python configuration.  There are also many hardcoded constants/numbers throughout the python emulation, which I also left as hardcoded in the C++ emulation for now (and tried to label them all with a comment)
- The algorithm implementation corresponds to the "new" firmware that was presented by Andy recently, however what I have here is not completely up to date with the python emulation.


