### PR TITLE
Switch default seeding without area normalization

### DIFF
--- a/L1Trigger/L1THGCal/python/customHistoSeeding.py
+++ b/L1Trigger/L1THGCal/python/customHistoSeeding.py
@@ -102,6 +102,14 @@ def custom_3dclustering_XYHistoMax(process,
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
     return process
 
+
+def custom_3dclustering_seedArea(process,
+                                   seed_threshold=cms.double(8.5)):
+    parameters_c3d = histoMax_C3d_seeding_params.clone(seeds_norm_by_area = True,
+                                                        threshold_histo_multicluster = seed_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
+    return process
+
 def custom_3dclustering_seedNoArea(process,
                                    seed_threshold=cms.double(20)):
     parameters_c3d = histoMax_C3d_seeding_params.clone(seeds_norm_by_area = False,

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -79,13 +79,13 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                binSumsHisto=binSums,
                                kROverZMin=cms.double(0.076),
                                kROverZMax=cms.double(0.58),
-                               threshold_histo_multicluster=cms.double(10.),
+                               threshold_histo_multicluster=cms.double(20.),
                                neighbour_weights=neighbour_weights_1stOrder,
                                seed_position=cms.string("TCWeighted"),#BinCentre, TCWeighted
                                seeding_space=cms.string("RPhi"),# RPhi, XY
                                seed_smoothing_ecal=seed_smoothing_ecal,
                                seed_smoothing_hcal=seed_smoothing_hcal,
-                               seeds_norm_by_area=cms.bool(True)
+                               seeds_norm_by_area=cms.bool(False)
                               )
 
 histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
@@ -102,14 +102,6 @@ histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
 histoMax_C3d_sorting_truncation_params = cms.PSet(AlgoName = cms.string('HGCalSortingTruncationWrapper'),
                                                   maxTCs=cms.uint32(80),
                                )
-
-# >= V9 samples have a different definition of the dEdx calibrations. To account for it
-# we rescale the thresholds of the clustering seeds
-# (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
-# for more details)
-phase2_hgcalV10.toModify(histoMax_C3d_seeding_params,
-                        threshold_histo_multicluster=8.5,  # MipT
-                        )
 
 
 histoMaxVariableDR_C3d_params = histoMax_C3d_clustering_params.clone(


### PR DESCRIPTION
Switch to seeding without area normalization (see #468) as default.
Performance study on jets can be found [here](https://indico.cern.ch/event/1061177/#30-performance-studies-for-alg).
Performance study on electrons can be found  [here](https://indico.cern.ch/event/1075714/#3-study-of-seeding-normalizati)