### PR TITLE
Switch default trigger geometry to Imp3

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -66,7 +66,7 @@ public:
 private:
   // HSc trigger cell grouping
   unsigned hSc_triggercell_size_ = 2;
-  unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
+  // unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
   //  unsigned hSc_wafers_per_module_ = 3;
   static constexpr unsigned hSc_num_panels_per_sector_ = 12;
   static constexpr unsigned hSc_tcs_per_module_phi_ = 4;
@@ -127,12 +127,7 @@ private:
 HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf)
     : HGCalTriggerGeometryBase(conf),
       hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
-      hSc_module_size_(conf.getParameter<unsigned>("ScintillatorModuleSize")),
       jsonMappingFile_(conf.getParameter<edm::FileInPath>("JsonMappingFile")) {
-  //hSc_wafers_per_module_ = std::round(hSc_module_size_ * hSc_module_size_ / float(ntc_per_wafer_));
-  //  if (ntc_per_wafer_ * hSc_wafers_per_module_ < hSc_module_size_ * hSc_module_size_) {
-  //    hSc_wafers_per_module_++;
-  //  }
   std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedLayers");
   std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_layers_, disconnected_layers_.end()));
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -66,8 +66,6 @@ public:
 private:
   // HSc trigger cell grouping
   unsigned hSc_triggercell_size_ = 2;
-  // unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
-  //  unsigned hSc_wafers_per_module_ = 3;
   static constexpr unsigned hSc_num_panels_per_sector_ = 12;
   static constexpr unsigned hSc_tcs_per_module_phi_ = 4;
   static constexpr unsigned hSc_front_layers_split_ = 12;

--- a/L1Trigger/L1THGCal/plugins/geometries/README.md
+++ b/L1Trigger/L1THGCal/plugins/geometries/README.md
@@ -2,12 +2,14 @@ Trigger geometries provide the following interfaces:
 * Mapping between HGCAL sensor cells, trigger cells, modules, lpGBTs and backend FPGAs
 
 The available HGCAL trigger geometries are the following:
-* `HGCalTriggerGeometryV9Imp3`
+* `HGCalTriggerGeometryV9Imp3` (DEFAULT)
   - Compatible with the HGCAL geometries >= V9
   - All links mapping are available (elinks, lpGBT, BE links)
   - Backend FPGA mappings are available
   - Links and FPGA mappings are defined in external JSON files
-* `HGCalTriggerGeometryV9Imp2` (DEFAULT)
+  - Mapping configs are available for 72 and 120 input links per Stage 1 FPGA.
+  - These mappings correspond to a PU-driven distribution of elinks; there is no configuration corresponding to signal-driven elink distribution at the moment.
+* `HGCalTriggerGeometryV9Imp2`
   - Compatible with the HGCAL geometries >= V9
-  - No links mapping. Only the number of elinks per module/ECON-T is available
+  - No links mapping. Only the number of elinks per module/ECON-T is available. Both PU-driven and signal-driven elink distributions can be used.
   - Backend FPGA mappings are not available

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -1,28 +1,34 @@
 import FWCore.ParameterSet.Config as cms
 
+def custom_geometry_V11_Imp3(process, stage1links=120):
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp3')
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
+    if stage1links==120:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
+    elif stage1links==72:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_72links_v2.json")
+    else:
+        raise RuntimeError('{} Stage 1 input links is not supported. Supported options are 72 or 120 links'.format(stage1links))
+    return process
 
-def custom_geometry_decentralized_V11(process, links='signaldriven',implementation=1):
+def custom_geometry_V11_Imp2(process, links='signaldriven'):
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
     if links=='signaldriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_signaldriven_0.txt'
     elif links=='pudriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_march20_0.txt'
     else:
         raise RuntimeError('Unknown links mapping "{}". Options are "signaldriven" or "pudriven".'.format(links))
-    if implementation==1:
-        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
-    elif implementation==2:
-        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp3')
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorModuleSize = cms.uint32(6)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_V11_decentralized_march20_2.txt")
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TLinksMapping = cms.FileInPath(links_mapping)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorLinksPerModule = cms.uint32(2)
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
     return process
 
 
-def custom_geometry_decentralized_V10(process, links='signaldriven'):
+def custom_geometry_V10(process, links='signaldriven'):
     if links=='signaldriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_decentralized_signaldriven_0.txt'
     elif links=='pudriven':

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -20,10 +20,10 @@ phase2_hfnose.toReplaceWith(
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V10, custom_geometry_decentralized_V11
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
-modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_decentralized_V10)
-modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_decentralized_V11)
+modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_V10)
+modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_V11_Imp3)
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,


### PR DESCRIPTION
- Clean geometry class `V9Imp3`
- Update customization functions
- Switch default trigger geometry to `V9Imp3`